### PR TITLE
Add Incremental Backoff

### DIFF
--- a/lib/gcloud/backoff.rb
+++ b/lib/gcloud/backoff.rb
@@ -1,0 +1,105 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gcloud
+  ##
+  # Backoff allows users to control how Google API calls are retried.
+  # If an API call fails the response will be checked to see if the
+  # call can be retried. If the response matches the criteria, then it
+  # will be retried with an incremental backoff. This means that an
+  # increasing delay will be added between each retried call. The first
+  # retry will be delayed one second, the second retry will be delayed
+  # two seconds, and so on.
+  #
+  #   require "gcloud/backoff"
+  #
+  #   Gcloud::Backoff.retries = 5 # Set a maximum of five retries per call
+  class Backoff
+    class << self
+      ##
+      # The number of times a retriable API call should be retried.
+      #
+      # The default value is 3.
+      attr_accessor :retries
+
+      ##
+      # The HTTP Status Codes that should be retried.
+      #
+      # The default values are 500 and 503.
+      attr_accessor :http_codes
+
+      ##
+      # The Google API error reasons that should be retried.
+      #
+      # The default values are rateLimitExceeded and
+      # userRateLimitExceeded.
+      attr_accessor :reasons
+    end
+    # Set the default values
+    self.retries = 3
+    self.http_codes = [500, 503]
+    self.reasons = %w(rateLimitExceeded userRateLimitExceeded)
+
+    ##
+    # Creates a new Backoff object to catch common errors when calling
+    # the Google API and handle the error by retrying the call.
+    #
+    #   Gcloud::Backoff.new(options).execute do
+    #     client.execute api_method: service.things.insert,
+    #                    parameters: { thing: @thing },
+    #                    body_object: { name: thing_name }
+    #   end
+    def initialize options = {} #:nodoc:
+      @max_retries  = (options[:retries]    || Backoff.retries).to_i
+      @http_codes   = (options[:http_codes] || Backoff.http_codes).to_a
+      @reasons      = (options[:reasons]    || Backoff.reasons).to_a
+    end
+
+    def execute #:nodoc:
+      current_retries = 0
+      loop do
+        sleep current_retries # Incremental backoff
+        result = yield # Expecting Google::APIClient::Result
+        return result if result.success?
+        break result unless retry? result, current_retries
+        current_retries += 1
+      end
+    end
+
+    protected
+
+    def retry? result, current_retries #:nodoc:
+      if current_retries < @max_retries
+        return true if retry_http_code? result
+        return true if retry_error_reason? result
+      end
+      false
+    end
+
+    def retry_http_code? result #:nodoc:
+      @http_codes.include? result.response.status
+    end
+
+    def retry_error_reason? result #:nodoc:
+      if result.data &&
+         result.data["error"] &&
+         result.data["error"]["errors"]
+        Array(result.data["error"]["errors"]).each do |error|
+          return true if error["reason"] && @reasons.include?(error["reason"])
+        end
+      end
+      false
+    end
+  end
+end

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -75,9 +75,17 @@ module Gcloud
       ##
       # Permenently deletes the bucket.
       # The bucket must be empty.
-      def delete
+      #
+      #   bucket.delete
+      #
+      # The API call to delete the bucket may be retried under certain
+      # conditions. See Gcloud::Backoff to control this behavior, or
+      # specify the wanted behavior in the call:
+      #
+      #   bucket.delete retries: 5
+      def delete options = {}
         ensure_connection!
-        resp = connection.delete_bucket name
+        resp = connection.delete_bucket name, options
         if resp.success?
           true
         else

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -66,8 +66,16 @@ module Gcloud
 
       ##
       # Creates a new bucket.
-      def create_bucket bucket_name
-        resp = connection.insert_bucket bucket_name
+      #
+      #   bucket = project.create_bucket "my-bucket"
+      #
+      # The API call to create the bucket may be retried under certain
+      # conditions. See Gcloud::Backoff to control this behavior, or
+      # specify the wanted behavior in the call:
+      #
+      #   bucket = project.create_bucket "my-bucket", retries: 5
+      def create_bucket bucket_name, options = {}
+        resp = connection.insert_bucket bucket_name, options
         if resp.success?
           Bucket.from_gapi resp.data, connection
         else

--- a/regression/storage/test_storage.rb
+++ b/regression/storage/test_storage.rb
@@ -32,17 +32,8 @@ describe "Storage", :storage do
   end
 
   before do
-     # always create the bucket
-     # use incremental back off
-     max_tries = 3
-     tries = 0
-    begin
-      sleep tries
-      bucket
-    rescue Gcloud::Storage::ApiError
-      tries += 1
-      retry if tries <= max_tries
-    end
+    # always create the bucket
+    bucket
   end
 
   after do
@@ -117,18 +108,18 @@ describe "Storage", :storage do
       end
     end
 
-    # it "should write metadata" do
-    #   skip
+    it "should write metadata" do
+      skip
 
-    #   meta = { content_type: "x-image/x-png",
-    #            title: "Logo Image" }
-    #   uploaded = bucket.create_file files[:logo][:path],
-    #                                 "CloudLogo",
-    #                                 meta
+      meta = { content_type: "x-image/x-png",
+               title: "Logo Image" }
+      uploaded = bucket.create_file files[:logo][:path],
+                                    "CloudLogo",
+                                    meta
 
-    #   uploaded.content_type.must_equal meta[:content_type]
-    #   uploaded.meta["title"].must_equal meta[:title]
-    # end
+      uploaded.content_type.must_equal meta[:content_type]
+      uploaded.meta["title"].must_equal meta[:title]
+    end
 
     it "should copy an existing file" do
       uploaded = bucket.create_file files[:logo][:path], "CloudLogo"
@@ -160,16 +151,16 @@ describe "Storage", :storage do
       assert_equal filenames.size, files.size
     end
 
-    # it "should paginate the list" do
-    #   skip
+    it "should paginate the list" do
+      skip
 
-    #   limit = filenames.size - 1
-    #   files = bucket.files limit: limit
-    #   files.size.must_equal limit
+      limit = filenames.size - 1
+      files = bucket.files limit: limit
+      files.size.must_equal limit
 
-    #   files = bucket.files limit: limit, offset: limit
-    #   files.size.must_equal 1
-    # end
+      files = bucket.files limit: limit, offset: limit
+      files.size.must_equal 1
+    end
   end
 
   describe "sign urls" do
@@ -180,27 +171,27 @@ describe "Storage", :storage do
       end
     end
 
-    # it "should create a signed read url" do
-    #   skip
+    it "should create a signed read url" do
+      skip
 
-    #   five_min_from_now = Time.now + 5 * 60
-    #   url = file.signed_url action: "read",
-    #                         expires: five_min_from_now
+      five_min_from_now = Time.now + 5 * 60
+      url = file.signed_url action: "read",
+                            expires: five_min_from_now
 
-    #   read_contents = Net::HTTP.get URI(url)
-    #   assert_equal local_file.read, read_contents
-    # end
+      read_contents = Net::HTTP.get URI(url)
+      assert_equal local_file.read, read_contents
+    end
 
-    # it "should create a signed delete url" do
-    #   skip
+    it "should create a signed delete url" do
+      skip
 
-    #   url = file.signed_url action: "delete",
-    #                         expires: five_min_from_now
+      url = file.signed_url action: "delete",
+                            expires: five_min_from_now
 
-    #   http = Net::HTTP.new URI(url)
-    #   resp = http.delete uri.path
+      http = Net::HTTP.new URI(url)
+      resp = http.delete uri.path
 
-    #   assert_equal 404, resp.code
-    # end
+      assert_equal 404, resp.code
+    end
   end
 end

--- a/regression/storage_helper.rb
+++ b/regression/storage_helper.rb
@@ -21,6 +21,11 @@ require "gcloud/storage"
 # and https://github.com/google/google-api-ruby-client/issues/106
 Faraday.default_adapter = :httpclient
 
+# Increase the number of retries because we run so many tests in parallel
+require "gcloud/backoff"
+
+Gcloud::Backoff.retries = 10
+
 ##
 # Test class for running against a Storage instance.
 # Ensures that there is an active connection for the tests to use.

--- a/test/gcloud/storage/test_backoff.rb
+++ b/test/gcloud/storage/test_backoff.rb
@@ -1,0 +1,86 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe "Gcloud Storage Backoff", :mock_storage do
+  # Create a bucket object with the project's mocked connection object
+  let(:bucket) { Gcloud::Storage::Bucket.from_gapi random_bucket_hash,
+                                                   storage.connection }
+
+  it "creates a bucket even when rate limited" do
+    new_bucket_name = "new-bucket-#{Time.now.to_i}"
+
+    mock_connection.post "/storage/v1/b?project=#{project}" do |env|
+      JSON.parse(env.body)["name"].must_equal new_bucket_name
+      [429, {"Content-Type"=>"application/json"},
+       rate_limit_exceeded_json]
+    end
+    mock_connection.post "/storage/v1/b?project=#{project}" do |env|
+      JSON.parse(env.body)["name"].must_equal new_bucket_name
+      [429, {"Content-Type"=>"application/json"},
+       rate_limit_exceeded_json]
+    end
+    mock_connection.post "/storage/v1/b?project=#{project}" do |env|
+      JSON.parse(env.body)["name"].must_equal new_bucket_name
+      [200, {"Content-Type"=>"application/json"},
+       create_bucket_json]
+    end
+
+    # Should be delayed ~3 seconds
+    assert_execution_time 3 do
+      storage.create_bucket new_bucket_name
+    end
+  end
+
+  it "deletes a bucket even when rate limited" do
+    mock_connection.delete "/storage/v1/b/#{bucket.name}" do |env|
+      [429, {"Content-Type"=>"application/json"},
+       rate_limit_exceeded_json]
+    end
+    mock_connection.delete "/storage/v1/b/#{bucket.name}" do |env|
+      [429, {"Content-Type"=>"application/json"},
+       rate_limit_exceeded_json]
+    end
+    mock_connection.delete "/storage/v1/b/#{bucket.name}" do |env|
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    # Should be delayed ~3 seconds
+    assert_execution_time 3 do
+      bucket.delete
+    end
+  end
+
+  def assert_execution_time seconds, delta = 0.1
+    begin_time = Time.now
+    yield
+    finish_time = Time.now
+    assert_in_delta seconds, (finish_time - begin_time), delta
+  end
+
+  def create_bucket_json
+    random_bucket_hash.to_json
+  end
+
+  def rate_limit_exceeded_json
+    { "error" => { "errors" => [{ "domain" => "usageLimits",
+                                  "reason" => "rateLimitExceeded",
+                                  "message" => "The project exceeded the rate limit for creating and deleting buckets."}], "code"=>429, "message"=>"The project exceeded the rate limit for creating and deleting buckets."
+                                }
+    }.to_json
+  end
+end


### PR DESCRIPTION
Add incremental backoff to the Gcloud API. Behavior can be changed with the following:

```ruby
require "cloud/backoff"

Gcloud::Backoff.retries #=> 3
Gcloud::Backoff.http_codes #=> [500, 503]
Gcloud::Backoff.reasons #=> ["rateLimitExceeded", "userRateLimitExceeded"]
Gcloud::Backoff.retries = 5
```

The backoff behavior can also be set on individual calls:

```ruby
storage = Gcloud::Storage.project "my-todo-project",
                                  "/path/to/keyfile.json"
bucket = storage.create_bucket "my-bucket", retries: 5
```