### PR TITLE
Add Properties object

### DIFF
--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -1,0 +1,102 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gcloud
+  module Datastore
+    ##
+    # Properties
+    class Properties
+      def initialize properties = {}
+        @hash = {}
+        properties.each do |key, value|
+          key   = ensure_key_type key
+          value = ensure_value_type value
+          @hash[key] = value
+        end
+      end
+
+      def [] key
+        key = ensure_key_type key
+        @hash[key]
+      end
+      alias_method :read, :[]
+
+      def []= key, value
+        key   = ensure_key_type key
+        value = ensure_value_type value
+        @hash[key] = value
+      end
+      alias_method :write, :[]=
+
+      def exist? key
+        key = ensure_key_type key
+        @hash.key? key
+      end
+
+      def fetch key, &_block
+        key = ensure_key_type key
+        @hash[key] = yield unless exist? key
+        @hash[key]
+      end
+
+      def each &block
+        @hash.each(&block)
+      end
+
+      def delete key, &block
+        key = ensure_key_type key
+        @hash.delete key, &block
+      end
+
+      def to_h
+        @hash.dup
+      end
+      alias_method :to_hash, :to_h
+
+      protected
+
+      ##
+      # Ensures the key is the proper type,
+      # otherwise a PropertyError is raised.
+      def ensure_key_type key
+        return key.to_str if key.respond_to? :to_str
+        fail "Property key #{key} must be a String."
+      end
+
+      # rubocop:disable all
+      # Disabled rubocop because this needs to match Proto.to_proto_value
+
+      ##
+      # Ensures the value is a type that can be persisted,
+      # otherwise a PropertyError is raised.
+      def ensure_value_type value
+        if Time                      === value ||
+           Gcloud::Datastore::Key    === value ||
+           Gcloud::Datastore::Entity === value ||
+           TrueClass                 === value ||
+           FalseClass                === value ||
+           Float                     === value ||
+           Integer                   === value ||
+           String                    === value ||
+           Array                     === value
+          return value
+        elsif defined?(BigDecimal) && BigDecimal === value
+          return value
+        end
+        fail PropertyError, "A property of type #{value.class} is not supported."
+      end
+      # rubocop:enable all
+    end
+  end
+end

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -82,6 +82,23 @@ module Gcloud
         v
       end
 
+      def self.from_proto_properties proto_properties
+        hash_properties = {}
+        Array(proto_properties).each do |p|
+          hash_properties[p.name] = Proto.from_proto_value p.value
+        end
+        hash_properties
+      end
+
+      def self.to_proto_properties hash_properties
+        hash_properties.map do |name, value|
+          Proto::Property.new.tap do |p|
+            p.name = name.to_s
+            p.value = Proto.to_proto_value value
+          end
+        end
+      end
+
       def self.microseconds_from_time time
         (time.utc.to_f * 1000000).to_i
       end

--- a/regression/datastore/test_datastore.rb
+++ b/regression/datastore/test_datastore.rb
@@ -59,10 +59,10 @@ describe "Datastore", :datastore do
       dataset.save post
 
       refresh = dataset.find post.key
-      refresh.key.kind.must_equal post.key.kind
-      refresh.key.id.must_equal   post.key.id
-      refresh.key.name.must_equal post.key.name
-      refresh.properties.must_equal post.properties
+      refresh.key.kind.must_equal        post.key.kind
+      refresh.key.id.must_equal          post.key.id
+      refresh.key.name.must_equal        post.key.name
+      refresh.properties.to_h.must_equal post.properties.to_h
 
       dataset.delete post
       refresh = dataset.find post.key
@@ -74,10 +74,10 @@ describe "Datastore", :datastore do
       dataset.save post
 
       refresh = dataset.find post.key
-      refresh.key.kind.must_equal post.key.kind
-      refresh.key.id.must_equal   post.key.id
-      refresh.key.name.must_equal post.key.name
-      refresh.properties.must_equal post.properties
+      refresh.key.kind.must_equal        post.key.kind
+      refresh.key.id.must_equal          post.key.id
+      refresh.key.name.must_equal        post.key.name
+      refresh.properties.to_h.must_equal post.properties.to_h
 
       dataset.delete post.key
       refresh = dataset.find post.key
@@ -89,10 +89,10 @@ describe "Datastore", :datastore do
       dataset.save post
 
       refresh = dataset.find post.key
-      refresh.key.kind.must_equal post.key.kind
-      refresh.key.id.must_equal   post.key.id
-      refresh.key.name.must_equal post.key.name
-      refresh.properties.must_equal post.properties
+      refresh.key.kind.must_equal        post.key.kind
+      refresh.key.id.must_equal          post.key.id
+      refresh.key.name.must_equal        post.key.name
+      refresh.properties.to_h.must_equal post.properties.to_h
 
       dataset.delete post
       refresh = dataset.find post.key
@@ -109,10 +109,10 @@ describe "Datastore", :datastore do
       post.key.id.wont_be :nil?
 
       refresh = dataset.find "Post", post.key.id
-      refresh.key.kind.must_equal post.key.kind
-      refresh.key.id.must_equal   post.key.id
-      refresh.key.name.must_equal post.key.name
-      refresh.properties.must_equal post.properties
+      refresh.key.kind.must_equal        post.key.kind
+      refresh.key.id.must_equal          post.key.id
+      refresh.key.name.must_equal        post.key.name
+      refresh.properties.to_h.must_equal post.properties.to_h
 
       dataset.delete post
       refresh = dataset.find post.key
@@ -368,9 +368,9 @@ describe "Datastore", :datastore do
         select("name", "family")
       entities = dataset.run query
       entities.each do |entity|
-        entity.properties.count.must_equal 2
-        entity.properties.assoc("name").wont_be :nil?
-        entity.properties.assoc("family").wont_be :nil?
+        entity.properties.to_h.keys.count.must_equal 2
+        entity.properties["name"].wont_be :nil?
+        entity.properties["family"].wont_be :nil?
       end
     end
 
@@ -452,10 +452,10 @@ describe "Datastore", :datastore do
 
       entity = dataset.find obj.key
       entity.wont_be :nil?
-      entity.key.kind.must_equal   obj.key.kind
-      entity.key.id.must_equal     obj.key.id
-      entity.key.name.must_equal   obj.key.name
-      entity.properties.must_equal obj.properties
+      entity.key.kind.must_equal        obj.key.kind
+      entity.key.id.must_equal          obj.key.id
+      entity.key.name.must_equal        obj.key.name
+      entity.properties.to_h.must_equal obj.properties.to_h
       dataset.delete entity
     end
 
@@ -475,10 +475,10 @@ describe "Datastore", :datastore do
 
       entity = dataset.find obj.key
       entity.wont_be :nil?
-      entity.key.kind.must_equal   obj.key.kind
-      entity.key.id.must_equal     obj.key.id
-      entity.key.name.must_equal   obj.key.name
-      entity.properties.must_equal obj.properties
+      entity.key.kind.must_equal        obj.key.kind
+      entity.key.id.must_equal          obj.key.id
+      entity.key.name.must_equal        obj.key.name
+      entity.properties.to_h.must_equal obj.properties.to_h
       dataset.delete entity
     end
   end

--- a/test/gcloud/datastore/proto/test_value.rb
+++ b/test/gcloud/datastore/proto/test_value.rb
@@ -166,9 +166,6 @@ describe "Proto Value methods" do
     raw = Gcloud::Datastore::Proto.from_proto_value value
     assert_kind_of Gcloud::Datastore::Key, raw
     refute_kind_of Gcloud::Datastore::Proto::Key, raw
-    # We don't have equality on key yet,
-    # so let's make sure the proto values are equal.
-    # (they are actually the same object, so this works...)
     raw.to_proto.must_equal key.to_proto
   end
 
@@ -196,10 +193,12 @@ describe "Proto Value methods" do
     raw = Gcloud::Datastore::Proto.from_proto_value value
     assert_kind_of Gcloud::Datastore::Entity, raw
     refute_kind_of Gcloud::Datastore::Proto::Entity, raw
-    # We don't have equality on entity yet,
-    # so let's make sure the proto values are equal.
-    # (they are actually the same object, so this works...)
-    raw.to_proto.must_equal entity.to_proto
+    # Fix up the indexed values so they can match
+    raw_proto = raw.to_proto
+    raw_proto.property.first.value.indexed = true
+    entity_proto = entity.to_proto
+    entity_proto.property.first.value.indexed = true
+    raw_proto.must_equal entity_proto
   end
 
   it "encodes Array" do

--- a/test/gcloud/datastore/test_entity.rb
+++ b/test/gcloud/datastore/test_entity.rb
@@ -28,8 +28,8 @@ describe Gcloud::Datastore::Entity do
   it "creates instances with .new" do
     # Calling entity here creates by calling new
     entity.wont_be :nil?
-    entity.properties.must_include ["name", "User McUser"]
-    entity.properties.must_include ["email", "user@example.net"]
+    entity.properties["name"].must_equal "User McUser"
+    entity.properties["email"].must_equal "user@example.net"
   end
 
   it "returns a correct protocol buffer object" do
@@ -65,8 +65,8 @@ describe Gcloud::Datastore::Entity do
     entity_from_proto.key.kind.must_equal "User"
     entity_from_proto.key.id.must_equal 123456
     entity_from_proto.key.name.must_be :nil?
-    entity_from_proto.properties.must_include ["name", "User McNumber"]
-    entity_from_proto.properties.must_include ["email", "number@example.net"]
+    entity_from_proto.properties["name"].must_equal "User McNumber"
+    entity_from_proto.properties["email"].must_equal "number@example.net"
   end
 
   it "can store other entities as properties" do


### PR DESCRIPTION
Properties allows for properties to be removed from an entity,
not simply setting the value to NULL.
Properties is a hash-like data structure that does several things for us.
It ensures that only strings are stored as keys, although it allows
symbols to be used for getting and setting values.

Fixes #61