### PR TITLE
Simplify Convenience Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Follow the [activation instructions](https://cloud.google.com/datastore/docs/act
 See the [gcloud-ruby Datastore API documentation](http://googlecloudplatform.github.io/gcloud-ruby/docs/master/Gcloud/Storage.html) to learn how to interact with the Cloud Datastore using this library.
 
 ```ruby
-dataset = Gcloud::Datastore.dataset "my-todo-project-id",
-                                    "/path/to/keyfile.json"
+dataset = Gcloud.datastore "my-todo-project-id",
+                           "/path/to/keyfile.json"
 
 # Create a new task to demo datastore
 demo_task = Gcloud::Datastore::Entity.new
@@ -73,8 +73,8 @@ completed_tasks = dataset.run query
 See the [gcloud-ruby Storage API documentation](http://googlecloudplatform.github.io/gcloud-ruby/docs/master/Gcloud/Storage.html) to learn how to connect to Cloud Storage using this library.
 
 ```ruby
-storage = Gcloud::Storage.project "my-todo-project-id",
-                                  "/path/to/keyfile.json"
+storage = Gcloud.storage "my-todo-project-id",
+                         "/path/to/keyfile.json"
 
 bucket = storage.find_bucket "task-attachments"
 

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -20,59 +20,63 @@ require "gcloud/datastore/credentials"
 
 module Gcloud
   ##
+  # Create a new Gcloud::Datastore::Dataset.
+  #
+  #   entity = Gcloud::Datastore::Entity.new
+  #   entity.key = Gcloud::Datastore::Key.new "Task"
+  #   entity["description"] = "Get started with Google Cloud"
+  #   entity["completed"] = false
+  #
+  #   dataset = Gcloud.datastore "my-todo-project",
+  #                              "/path/to/keyfile.json"
+  #   dataset.save entity
+  #
+  # @param dataset_id [String] the dataset identifier for the Datastore
+  # you are connecting to.
+  # @param keyfile [String] the path to the keyfile you downloaded from
+  # Google Cloud. The file must readable.
+  # @return [Gcloud::Datastore::Dataset] new dataset.
+  #
+  # See Gcloud::Datastore::Dataset
+  def self.datastore project = ENV["DATASTORE_PROJECT"],
+                     keyfile = ENV["DATASTORE_KEYFILE"]
+    credentials = Gcloud::Datastore::Credentials.new keyfile
+    Gcloud::Datastore::Dataset.new project, credentials
+  end
+
+  ##
+  # Special dataset for connecting to a Local Development Server.
+  #
+  #   dataset = Gcloud.datastore "my-todo-project",
+  #                              "/path/to/keyfile.json"
+  #   entity = dataset.find "Task", "start"
+  #
+  #   devserver = Gcloud.devserver "my-todo-project"
+  #   devserver.save entity
+  #
+  # The URL of the devserver should be set in the DATASTORE_HOST
+  # environment variable.
+  #
+  # See https://cloud.google.com/datastore/docs/tools/devserver
+  def self.devserver project = ENV["DEVSERVER_PROJECT"],
+                     host    = ENV["DEVSERVER_HOST"]
+    credentials = Gcloud::Datastore::Credentials::Empty.new
+    devserver = Gcloud::Datastore::Dataset.new project, credentials
+    devserver.connection.http_host = (host || "http://localhost:8080")
+    devserver
+  end
+
+  ##
   # Google Cloud Datastore
   #
-  #   dataset = Gcloud::Datastore.dataset "my-todo-project",
-  #                                       "/path/to/keyfile.json"
+  #   dataset = Gcloud.datastore "my-todo-project",
+  #                              "/path/to/keyfile.json"
   #   entity = dataset.find "Task", "start"
   #   entity["completed"] = true
   #   dataset.save entity
   #
+  #
+  # See Gcloud::Datastore::Dataset
   module Datastore
-    ##
-    # Create a new Dataset.
-    #
-    #   entity = Gcloud::Datastore::Entity.new
-    #   entity.key = Gcloud::Datastore::Key.new "Task"
-    #   entity["description"] = "Get started with Google Cloud"
-    #   entity["completed"] = false
-    #
-    #   dataset = Gcloud::Datastore.dataset "my-todo-project",
-    #                                       "/path/to/keyfile.json"
-    #   dataset.save entity
-    #
-    # @param dataset_id [String] the dataset identifier for the Datastore
-    # you are connecting to.
-    # @param keyfile [String] the path to the keyfile you downloaded from
-    # Google Cloud. The file must readable.
-    # @return [Gcloud::Datastore::Connection] new connection
-    #
-    def self.dataset project = ENV["DATASTORE_PROJECT"],
-                     keyfile = ENV["DATASTORE_KEYFILE"]
-      credentials = Gcloud::Datastore::Credentials.new keyfile
-      Gcloud::Datastore::Dataset.new project, credentials
-    end
-
-    ##
-    # Special dataset for connecting to a Local Development Server.
-    #
-    #   dataset = Gcloud::Datastore.dataset "my-todo-project",
-    #                                       "/path/to/keyfile.json"
-    #   entity = dataset.find "Task", "start"
-    #
-    #   devserver = Gcloud::Datastore.devserver "my-todo-project"
-    #   devserver.save entity
-    #
-    # The URL of the devserver should be set in the DATASTORE_HOST
-    # environment variable.
-    #
-    # See https://cloud.google.com/datastore/docs/tools/devserver
-    def self.devserver project = ENV["DEVSERVER_PROJECT"],
-                       host    = ENV["DEVSERVER_HOST"]
-      credentials = Gcloud::Datastore::Credentials::Empty.new
-      devserver = Gcloud::Datastore::Dataset.new project, credentials
-      devserver.connection.http_host = (host || "http://localhost:8080")
-      devserver
-    end
   end
 end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -18,6 +18,8 @@ require "gcloud/datastore/dataset"
 require "gcloud/datastore/transaction"
 require "gcloud/datastore/credentials"
 
+##
+# Google Cloud Datastore
 module Gcloud
   ##
   # Create a new Gcloud::Datastore::Dataset.

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -30,22 +30,22 @@ module Gcloud
     # Google Datastore. Gcloud::Datastore::Entity objects are created,
     # read, updated, and deleted by Gcloud::Datastore::Dataset.
     #
-    #   dataset = Gcloud::Datastore.dataset "my-todo-project",
-    #                                       "/path/to/keyfile.json"
+    #   dataset = Gcloud.datastore "my-todo-project",
+    #                              "/path/to/keyfile.json"
     #
     #   query = Gcloud::Datastore::Query.new.kind("Task").
     #     where("completed", "=", true)
     #
     #   tasks = dataset.run query
     #
-    # See Gcloud::Datastore.dataset
+    # See Gcloud.datastore
     class Dataset
       attr_accessor :connection #:nodoc:
 
       ##
       # Creates a new Dataset instance.
       #
-      # See Gcloud::Datastore.dataset
+      # See Gcloud.datastore
       def initialize project, credentials #:nodoc:
         @connection = Connection.new project, credentials
       end
@@ -59,7 +59,7 @@ module Gcloud
       ##
       # Generate IDs for a Key before creating an entity.
       #
-      #   dataset = Gcloud::Datastore.dataset
+      #   dataset = Gcloud.datastore
       #   empty_key = Gcloud::Datastore::Key.new "Task"
       #   task_keys = dataset.allocate_ids empty_key, 5
       def allocate_ids incomplete_key, count = 1
@@ -77,7 +77,7 @@ module Gcloud
       ##
       # Persist entities to the Datastore.
       #
-      #   dataset = Gcloud::Datastore.dataset
+      #   dataset = Gcloud.datastore
       #   dataset.save task1, task2
       def save *entities
         mutation = Proto.new_mutation
@@ -91,11 +91,11 @@ module Gcloud
       # Retrieve an entity by providing key information.
       # Either a Key object or kind and id/name can be provided.
       #
-      #   dataset = Gcloud::Datastore.dataset
+      #   dataset = Gcloud.datastore
       #   key = Gcloud::Datastore::Key.new "Task", 123456
       #   task = dataset.find key
       #
-      #   dataset = Gcloud::Datastore.dataset
+      #   dataset = Gcloud.datastore
       #   task = dataset.find "Task", 123456
       def find key_or_kind, id_or_name = nil
         key = key_or_kind
@@ -107,7 +107,7 @@ module Gcloud
       ##
       # Retrieve the entities for the provided keys.
       #
-      #   dataset = Gcloud::Datastore.dataset
+      #   dataset = Gcloud.datastore
       #   key1 = Gcloud::Datastore::Key.new "Task", 123456
       #   key2 = Gcloud::Datastore::Key.new "Task", 987654
       #   tasks = dataset.find_all key1, key2
@@ -127,7 +127,7 @@ module Gcloud
       # Remove entities from the Datastore.
       # Accepts Entity and Key objects.
       #
-      #   dataset = Gcloud::Datastore.dataset
+      #   dataset = Gcloud.datastore
       #   dataset.delete task1, task2
       def delete *entities_or_keys
         keys = entities_or_keys.map do |e_or_k|

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -17,34 +17,36 @@ require "gcloud/storage/project"
 
 module Gcloud
   ##
-  # Google Cloud Storage
+  # Create a new Storage project.
   #
-  #   storage = Gcloud::Storage.project "my-todo-project",
-  #                                     "/path/to/keyfile.json"
+  #   storage = Gcloud.storage "my-todo-project",
+  #                            "/path/to/keyfile.json"
   #   bucket = storage.find_bucket "my-bucket"
   #   file = bucket.find_file "path/to/my-file.ext"
-  module Storage
-    ##
-    # Create a new Storage project.
-    #
-    #   storage = Gcloud::Storage.project "my-todo-project",
-    #                                     "/path/to/keyfile.json"
-    #   bucket = storage.find_bucket "my-bucket"
-    #   file = bucket.find_file "path/to/my-file.ext"
-    #
-    # @param project [String] the project identifier for the Storage
-    # account you are connecting to.
-    # @param keyfile [String] the path to the keyfile you downloaded from
-    # Google Cloud. The file must readable.
-    # @return [Gcloud::Storage::Connection] new connection
-    #
-    # See Gcloud::Storage::Project
-    def self.project project = ENV["STORAGE_PROJECT"],
-                     keyfile = ENV["STORAGE_KEYFILE"]
-      credentials = Gcloud::Storage::Credentials.new keyfile
-      Gcloud::Storage::Project.new project, credentials
-    end
+  #
+  # @param project [String] the project identifier for the Storage
+  # account you are connecting to.
+  # @param keyfile [String] the path to the keyfile you downloaded from
+  # Google Cloud. The file must readable.
+  # @return [Gcloud::Storage::Project] storage project.
+  #
+  # See Gcloud::Storage::Project
+  def self.storage project = ENV["STORAGE_PROJECT"],
+                   keyfile = ENV["STORAGE_KEYFILE"]
+    credentials = Gcloud::Storage::Credentials.new keyfile
+    Gcloud::Storage::Project.new project, credentials
+  end
 
+  ##
+  # Google Cloud Storage
+  #
+  #   storage = Gcloud.storage "my-todo-project",
+  #                            "/path/to/keyfile.json"
+  #   bucket = storage.find_bucket "my-bucket"
+  #   file = bucket.find_file "path/to/my-file.ext"
+  #
+  # See Gcloud::Storage::Project
+  module Storage
     ##
     # Retrieve resumable threshold.
     # If uploads are larger in size than this value then

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -15,6 +15,8 @@
 require "gcloud"
 require "gcloud/storage/project"
 
+##
+# Google Cloud Storage
 module Gcloud
   ##
   # Create a new Storage project.

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -102,7 +102,7 @@ module Gcloud
       ##
       # Retrieves a list of files matching the criteria.
       #
-      #   storage = Gcloud::Storage.project
+      #   storage = Gcloud.storage
       #   bucket = storage.find_bucket "my-bucket"
       #   files = bucket.files
       #   files.each do |file|
@@ -123,7 +123,7 @@ module Gcloud
       ##
       # Retrieves a file matching the path.
       #
-      #   storage = Gcloud::Storage.project
+      #   storage = Gcloud.storage
       #   bucket = storage.find_bucket "my-bucket"
       #   file = bucket.find_file "path/to/my-file.ext"
       #   puts file.name
@@ -143,13 +143,13 @@ module Gcloud
       # Create a new Gcloud::Storeage::File object by providing a
       # File object to upload and the path to store it with.
       #
-      #   storage = Gcloud::Storage.project
+      #   storage = Gcloud.storage
       #   bucket = storage.find_bucket "my-bucket"
       #   bucket.create_file "path/to/local.file.ext"
       #
       # Additionally, a destination path can be specified.
       #
-      #   storage = Gcloud::Storage.project
+      #   storage = Gcloud.storage
       #   bucket = storage.find_bucket "my-bucket"
       #   bucket.create_file "path/to/local.file.ext",
       #                      "destination/path/file.ext"

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -27,12 +27,12 @@ module Gcloud
     # Google Storage. Gcloud::Storage::Bucket objects are created,
     # read, updated, and deleted by Gcloud::Storage::Project.
     #
-    #   storage = Gcloud::Storage.project "my-todo-project",
-    #                                     "/path/to/keyfile.json"
+    #   storage = Gcloud.storage "my-todo-project",
+    #                            "/path/to/keyfile.json"
     #   bucket = storage.find_bucket "my-bucket"
     #   file = bucket.find_file "path/to/my-file.ext"
     #
-    # See Gcloud::Storage.project
+    # See Gcloud.storage
     class Project
       ##
       # The Connection object.
@@ -41,7 +41,7 @@ module Gcloud
       ##
       # Creates a new Project instance.
       #
-      # See Gcloud::Storage.project
+      # See Gcloud.storage
       def initialize project, credentials #:nodoc:
         @connection = Connection.new project, credentials
       end
@@ -55,7 +55,7 @@ module Gcloud
       ##
       # Retrieves a list of buckets for the given project.
       #
-      #   storage = Gcloud::Storage.project
+      #   storage = Gcloud.storage
       #   buckets = storage.buckets
       #   buckets.each do |bucket|
       #     puts bucket.name
@@ -74,7 +74,7 @@ module Gcloud
       ##
       # Retrieves bucket by name.
       #
-      #   storage = Gcloud::Storage.project
+      #   storage = Gcloud.storage
       #   bucket = storage.find_bucket "my-bucket"
       #   puts bucket.name
       #

--- a/regression/datastore_helper.rb
+++ b/regression/datastore_helper.rb
@@ -22,9 +22,9 @@ module Regression
     # Setup project based on available ENV variables
     def setup
       if ENV["DEVSERVER_PROJECT"]
-        @dataset = Gcloud::Datastore.devserver
+        @dataset = Gcloud.devserver
       else
-        @dataset = Gcloud::Datastore.dataset
+        @dataset = Gcloud.datastore
       end
 
       refute_nil @dataset, "You do not have an active dataset to run the tests."

--- a/regression/storage_helper.rb
+++ b/regression/storage_helper.rb
@@ -45,7 +45,7 @@ module Regression
     ##
     # Setup project based on available ENV variables
     def setup
-      @storage = Gcloud::Storage.project
+      @storage = Gcloud.storage
 
       refute_nil @storage, "You do not have an active storage to run the tests."
 


### PR DESCRIPTION
Move the convenience methods to the top-level Gcloud namespace. This reduces the typing needed to get started. 