### PR TITLE
Update GoogleAuth

### DIFF
--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -15,6 +15,7 @@
 require "json"
 require "signet/oauth_2/client"
 require "forwardable"
+require "googleauth"
 
 module Gcloud
   ##
@@ -37,19 +38,12 @@ module Gcloud
                    :scope, :issuer, :signing_key
 
     def initialize keyfile, options = {}
-      if keyfile.nil?
-        fail "You must provide a keyfile to connect with."
-      elsif !::File.file?(keyfile)
-        fail "The keyfile '#{keyfile}' is not a valid file."
+      if keyfile.is_a? Signet::OAuth2::Client
+        @client = keyfile
+      else
+        @client = init_client keyfile, options
       end
-
-      # Turn keys to strings
-      options = stringify_hash_keys options
-      # Constructor options override default options
-      options = default_options.merge options
-      # Keyfile options override everything
-      options = options.merge JSON.parse(::File.read(keyfile))
-      init_signet_client! options
+      @client.fetch_access_token!
     end
 
     ##
@@ -61,7 +55,8 @@ module Gcloud
         return new keyfile if ::File.file? keyfile
       end
       return new sdk_default_creds if ::File.file? sdk_default_creds
-      nil
+      client = Google::Auth.get_application_default self::SCOPE
+      new client
     end
 
     ##
@@ -79,6 +74,24 @@ module Gcloud
     protected
 
     ##
+    # Initializes the Signet client.
+    def init_client keyfile, options
+      verify_keyfile! keyfile
+      client_opts = client_options keyfile, options
+      Signet::OAuth2::Client.new client_opts
+    end
+
+    ##
+    # Initializes the Signet client.
+    def verify_keyfile! keyfile
+      if keyfile.nil?
+        fail "You must provide a keyfile to connect with."
+      elsif !::File.file?(keyfile)
+        fail "The keyfile '#{keyfile}' is not a valid file."
+      end
+    end
+
+    ##
     # returns a new Hash with string keys instead of symbol keys.
     def stringify_hash_keys hash
       Hash[hash.map { |(k, v)| [k.to_s, v] }]
@@ -92,19 +105,20 @@ module Gcloud
         "scope"                => self.class::SCOPE }
     end
 
-    ##
-    # Initializes the Signet client.
-    def init_signet_client! options
-      client_opts = {
-        token_credential_uri: options["token_credential_uri"],
+    def client_options keyfile, options
+      # Turn keys to strings
+      options = stringify_hash_keys options
+      # Constructor options override default options
+      options = default_options.merge options
+      # Keyfile options override everything
+      options = options.merge JSON.parse(::File.read(keyfile))
+
+      # client options for initializing signet client
+      { token_credential_uri: options["token_credential_uri"],
         audience: options["audience"],
         scope: options["scope"],
         issuer: options["client_email"],
-        signing_key: OpenSSL::PKey::RSA.new(options["private_key"])
-      }
-
-      @client = Signet::OAuth2::Client.new client_opts
-      @client.fetch_access_token!
+        signing_key: OpenSSL::PKey::RSA.new(options["private_key"]) }
     end
   end
 end

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -25,6 +25,7 @@ module Gcloud
     TOKEN_CREDENTIAL_URI = "https://accounts.google.com/o/oauth2/token"
     AUDIENCE = "https://accounts.google.com/o/oauth2/token"
     SCOPE = []
+    ENV_VARS = ["GOOGLE_CLOUD_KEYFILE"]
 
     attr_accessor :client
 
@@ -36,7 +37,6 @@ module Gcloud
                    :scope, :issuer, :signing_key
 
     def initialize keyfile, options = {}
-      keyfile ||= sdk_default_creds
       if keyfile.nil?
         fail "You must provide a keyfile to connect with."
       elsif !::File.file?(keyfile)
@@ -50,6 +50,18 @@ module Gcloud
       # Keyfile options override everything
       options = options.merge JSON.parse(::File.read(keyfile))
       init_signet_client! options
+    end
+
+    ##
+    # Returns the default credentials.
+    #
+    def self.default
+      self::ENV_VARS.each do |env_var|
+        keyfile = ENV[env_var].to_s
+        return new keyfile if ::File.file? keyfile
+      end
+      return new sdk_default_creds if ::File.file? sdk_default_creds
+      nil
     end
 
     ##

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -39,7 +39,7 @@ module Gcloud
       keyfile ||= sdk_default_creds
       if keyfile.nil?
         fail "You must provide a keyfile to connect with."
-      elsif !::File.exist?(keyfile)
+      elsif !::File.file?(keyfile)
         fail "The keyfile '#{keyfile}' is not a valid file."
       end
 

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -36,6 +36,7 @@ module Gcloud
                    :scope, :issuer, :signing_key
 
     def initialize keyfile, options = {}
+      keyfile ||= sdk_default_creds
       if keyfile.nil?
         fail "You must provide a keyfile to connect with."
       elsif !::File.exist?(keyfile)
@@ -49,6 +50,18 @@ module Gcloud
       # Keyfile options override everything
       options = options.merge JSON.parse(::File.read(keyfile))
       init_signet_client! options
+    end
+
+    ##
+    # The filepath of the default application credentials used by
+    # the gcloud SDK.
+    #
+    # This file is created when running <tt>gcloud auth login</tt>
+    def self.sdk_default_creds #:nodoc:
+      # This method will likely be moved once we gain better
+      # support for running in a GCE environment.
+      sdk_creds = "~/.config/gcloud/application_default_credentials.json"
+      File.expand_path sdk_creds
     end
 
     protected

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -41,8 +41,12 @@ module Gcloud
   #
   # See Gcloud::Datastore::Dataset
   def self.datastore project = ENV["DATASTORE_PROJECT"],
-                     keyfile = ENV["DATASTORE_KEYFILE"]
-    credentials = Gcloud::Datastore::Credentials.new keyfile
+                     keyfile = nil
+    if keyfile.nil?
+      credentials = Gcloud::Datastore::Credentials.default
+    else
+      credentials = Gcloud::Datastore::Credentials.new keyfile
+    end
     Gcloud::Datastore::Dataset.new project, credentials
   end
 

--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -25,6 +25,7 @@ module Gcloud
     class Credentials < Gcloud::Credentials #:nodoc:
       SCOPE = ["https://www.googleapis.com/auth/datastore",
                "https://www.googleapis.com/auth/userinfo.email"]
+      ENV_VARS = ["DATASTORE_KEYFILE"]
 
       ##
       # Sign Oauth2 API calls.

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -34,8 +34,12 @@ module Gcloud
   #
   # See Gcloud::Storage::Project
   def self.storage project = ENV["STORAGE_PROJECT"],
-                   keyfile = ENV["STORAGE_KEYFILE"]
-    credentials = Gcloud::Storage::Credentials.new keyfile
+                   keyfile = nil
+    if keyfile.nil?
+      credentials = Gcloud::Storage::Credentials.default
+    else
+      credentials = Gcloud::Storage::Credentials.new keyfile
+    end
     Gcloud::Storage::Project.new project, credentials
   end
 

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -169,7 +169,7 @@ module Gcloud
         ensure_connection!
         # TODO: Raise if file doesn't exist
         # ensure_file_exists!
-        fail unless ::File.exist? file
+        fail unless ::File.file? file
 
         options[:acl] = File::Acl.predefined_rule_for options[:acl]
 

--- a/lib/gcloud/storage/credentials.rb
+++ b/lib/gcloud/storage/credentials.rb
@@ -20,6 +20,7 @@ module Gcloud
     # Represents the Oauth2 signing logic for Storage.
     class Credentials < Gcloud::Credentials #:nodoc:
       SCOPE = ["https://www.googleapis.com/auth/devstorage.full_control"]
+      ENV_VARS = ["STORAGE_KEYFILE"]
     end
   end
 end

--- a/test/gcloud/datastore/test_credentials.rb
+++ b/test/gcloud/datastore/test_credentials.rb
@@ -26,7 +26,7 @@ describe Gcloud::Datastore::Credentials do
     client_mock = Minitest::Mock.new
     client_mock.expect :fetch_access_token!, true
     Signet::OAuth2::Client.stub :new, client_mock do
-      File.stub :exist?, true do
+      File.stub :file?, true do
         File.stub :read, keyfile_json do
           credz = Gcloud::Datastore::Credentials.new "fake.json"
         end


### PR DESCRIPTION
Add support for the Cloud SDK's credential application file as well as Google Compute Engine.

[Resolves #102]