### PR TITLE
Reduce number of API backoffs in regression tests

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -139,6 +139,27 @@ namespace :test do
       Dir.glob("regression/storage/**/test*.rb").each { |file| require_relative "../#{file}"}
     end
 
+    namespace :storage do
+      desc "Removes *ALL* buckets and files. Use with caution."
+      task :cleanup do |t, args|
+        project = args[:project]
+        project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["STORAGE_TEST_PROJECT"]
+        keyfile = args[:keyfile]
+        keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["STORAGE_TEST_KEYFILE"]
+        if project.nil? || keyfile.nil?
+          fail "You must provide a project and keyfile. e.g. rake test:regression:storage:cleanup[test123, /path/to/keyfile.json] or STORAGE_TEST_PROJECT=test123 STORAGE_TEST_KEYFILE=/path/to/keyfile.json rake test:regression:storage:cleanup"
+        end
+        # always overwrite when running tests
+        ENV["STORAGE_PROJECT"] = project
+        ENV["STORAGE_KEYFILE"] = keyfile
+
+        $LOAD_PATH.unshift "lib"
+        require "gcloud/storage"
+        puts "Cleaning up existing buckets and files"
+        Gcloud.storage.buckets.each { |b| b.files.map(&:delete); b.delete }
+      end
+    end
+
   end
 
 end

--- a/regression/storage_helper.rb
+++ b/regression/storage_helper.rb
@@ -25,6 +25,7 @@ Faraday.default_adapter = :httpclient
 require "gcloud/backoff"
 
 Gcloud::Backoff.retries = 10
+Gcloud::Backoff.backoff = ->(retries) { puts "Backoff #{retries}"; sleep retries.to_i }
 
 # Create shared storage object so we don't create new for each test
 $storage = Gcloud.storage

--- a/test/gcloud/storage/test_backoff.rb
+++ b/test/gcloud/storage/test_backoff.rb
@@ -103,13 +103,8 @@ describe "Gcloud Storage Backoff", :mock_storage do
   def assert_backoff_sleep *args
     mock = Minitest::Mock.new
     args.each { |intv| mock.expect :sleep, nil, [intv] }
-    backoff = Gcloud::Backoff.new retries: 5
-    backoff.instance_variable_set :@sleep_mock, mock
-    def backoff.sleep num
-      if num > 0
-        @sleep_mock.sleep num
-      end
-    end
+    callback = ->(retries) { mock.sleep retries }
+    backoff = Gcloud::Backoff.new retries: 5, backoff: callback
 
     Gcloud::Backoff.stub :new, backoff do
       yield


### PR DESCRIPTION
The regression tests will sometimes fail due to the number of API calls to create and delete buckets. This normally happens when CI runs the regressions for all the Ruby versions at once, since they all share the same Google Cloud account credentials.

Simplify things a bit by creating the buckets just once, and removing the buckets after all the tests are run using `Minitest.after_run`.

This PR also makes it obvious that an incremental backoff has occurred during the regression test by printing it to the output.