### PR TITLE
Remove Gcloud.devserver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,14 @@ $ export STORAGE_TEST_KEYFILE=/path/to/other/keyfile.json
 $ rake test:regression
 ```
 
+### Local Datastore Devserver
+
+You can run the Datstore regression tests against a devserver running locally. To switch to the devserver set the `DATASTORE_HOST` environment variable with the location of the local devserver.
+
+``` sh
+$ DATASTORE_HOST=http://127.0.0.1:8080 rake test:regression:datastore
+```
+
 ## Coding Style
 
 Please follow the established coding style in the library. The style is is largely based on [The Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) with a few exceptions based on seattle-style:

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -51,28 +51,6 @@ module Gcloud
   end
 
   ##
-  # Special dataset for connecting to a Local Development Server.
-  #
-  #   dataset = Gcloud.datastore "my-todo-project",
-  #                              "/path/to/keyfile.json"
-  #   entity = dataset.find "Task", "start"
-  #
-  #   devserver = Gcloud.devserver "my-todo-project"
-  #   devserver.save entity
-  #
-  # The URL of the devserver should be set in the DATASTORE_HOST
-  # environment variable.
-  #
-  # See https://cloud.google.com/datastore/docs/tools/devserver
-  def self.devserver project = ENV["DEVSERVER_PROJECT"],
-                     host    = ENV["DEVSERVER_HOST"]
-    credentials = Gcloud::Datastore::Credentials::Empty.new
-    devserver = Gcloud::Datastore::Dataset.new project, credentials
-    devserver.connection.http_host = (host || "http://localhost:8080")
-    devserver
-  end
-
-  ##
   # Google Cloud Datastore
   #
   #   dataset = Gcloud.datastore "my-todo-project",

--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -36,15 +36,6 @@ module Gcloud
         end
         request
       end
-
-      ##
-      # Represent the empty credentials, useful for connecting
-      # to a local devserver.
-      class Empty #:nodoc:
-        def sign_http_request request
-          request
-        end
-      end
     end
   end
 end

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -25,7 +25,6 @@ namespace :test do
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake test:regression[test123, /path/to/keyfile.json] or GCLOUD_TEST_PROJECT=test123 GCLOUD_TEST_KEYFILE=/path/to/keyfile.json rake test:regression"
     end
-    ENV["DEVSERVER_PROJECT"] = nil # clear in case it is also set
     # always overwrite when running tests
     ENV["DATASTORE_PROJECT"] = project
     ENV["DATASTORE_KEYFILE"] = keyfile
@@ -49,7 +48,6 @@ namespace :test do
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake test:regression[test123, /path/to/keyfile.json] or GCLOUD_TEST_PROJECT=test123 GCLOUD_TEST_KEYFILE=/path/to/keyfile.json rake test:regression"
     end
-    ENV["DEVSERVER_PROJECT"] = nil # clear in case it is also set
     # always overwrite when running tests
     ENV["DATASTORE_PROJECT"] = project
     ENV["DATASTORE_KEYFILE"] = keyfile
@@ -74,7 +72,6 @@ namespace :test do
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake test:regression[test123, /path/to/keyfile.json] or GCLOUD_TEST_PROJECT=test123 GCLOUD_TEST_KEYFILE=/path/to/keyfile.json rake test:regression"
     end
-    ENV["DEVSERVER_PROJECT"] = nil # clear in case it is also set
     # always overwrite when running tests
     ENV["DATASTORE_PROJECT"] = project
     ENV["DATASTORE_KEYFILE"] = keyfile
@@ -96,27 +93,9 @@ namespace :test do
       if project.nil? || keyfile.nil?
         fail "You must provide a project and keyfile. e.g. rake test:regression:datastore[test123, /path/to/keyfile.json] or DATASTORE_TEST_PROJECT=test123 DATASTORE_TEST_KEYFILE=/path/to/keyfile.json rake test:regression:datastore"
       end
-      ENV["DEVSERVER_PROJECT"] = nil # clear in case it is also set
       # always overwrite when running tests
       ENV["DATASTORE_PROJECT"] = project
       ENV["DATASTORE_KEYFILE"] = keyfile
-
-      $LOAD_PATH.unshift "lib", "test", "regression"
-      Dir.glob("regression/datastore/**/test*.rb").each { |file| require_relative "../#{file}"}
-    end
-
-    desc "Runs the datastore regression tests against a locally runnning devserver."
-    task :devserver, :project, :host do |t, args|
-      project = args[:project]
-      project ||= ENV["DEVSERVER_PROJECT"]
-      host = args[:host]
-      host ||= ENV["DEVSERVER_HOST"]
-      host ||= "http://localhost:8080"
-      if project.nil?
-        fail "You must provide a project. e.g. rake test:regression:devserver[test123] or DEVSERVER_PROJECT=test123 rake test:regression:devserver"
-      end
-      ENV["DEVSERVER_PROJECT"] = project
-      ENV["DEVSERVER_HOST"]    = host
 
       $LOAD_PATH.unshift "lib", "test", "regression"
       Dir.glob("regression/datastore/**/test*.rb").each { |file| require_relative "../#{file}"}

--- a/regression/datastore_helper.rb
+++ b/regression/datastore_helper.rb
@@ -21,11 +21,7 @@ module Regression
     ##
     # Setup project based on available ENV variables
     def setup
-      if ENV["DEVSERVER_PROJECT"]
-        @dataset = Gcloud.devserver
-      else
-        @dataset = Gcloud.datastore
-      end
+      @dataset = Gcloud.datastore
 
       refute_nil @dataset, "You do not have an active dataset to run the tests."
 

--- a/test/gcloud/datastore/test_connection.rb
+++ b/test/gcloud/datastore/test_connection.rb
@@ -17,7 +17,7 @@ require "gcloud/datastore"
 
 describe Gcloud::Datastore::Connection do
   let(:project)     { "my-todo-project" }
-  let(:credentials) { Gcloud::Datastore::Credentials::Empty.new }
+  let(:credentials) { OpenStruct.new }
   let(:connection)  { Gcloud::Datastore::Connection.new project, credentials }
   let(:http_mock)   { Minitest::Mock.new }
   let(:mocks)       { [] }

--- a/test/gcloud/datastore/test_dataset.rb
+++ b/test/gcloud/datastore/test_dataset.rb
@@ -17,7 +17,7 @@ require "gcloud/datastore"
 
 describe Gcloud::Datastore::Dataset do
   let(:project)     { "my-todo-project" }
-  let(:credentials) { Gcloud::Datastore::Credentials::Empty.new }
+  let(:credentials) { OpenStruct.new }
   let(:dataset)     { Gcloud::Datastore::Dataset.new project, credentials }
   let(:allocate_ids_response) do
     Gcloud::Datastore::Proto::AllocateIdsResponse.new.tap do |response|

--- a/test/gcloud/datastore/test_entity.rb
+++ b/test/gcloud/datastore/test_entity.rb
@@ -127,9 +127,9 @@ describe Gcloud::Datastore::Entity do
 
   it "raises when setting an unsupported property type" do
     error = assert_raises Gcloud::Datastore::PropertyError do
-      entity["thing"] = Gcloud::Datastore::Credentials::Empty.new
+      entity["thing"] = OpenStruct.new
     end
-    error.message.must_equal "A property of type Gcloud::Datastore::Credentials::Empty is not supported."
+    error.message.must_equal "A property of type OpenStruct is not supported."
   end
 
   it "raises when setting a key when persisted" do

--- a/test/gcloud/datastore/test_transaction.rb
+++ b/test/gcloud/datastore/test_transaction.rb
@@ -17,7 +17,7 @@ require "gcloud/datastore"
 
 describe Gcloud::Datastore::Transaction do
   let(:project)     { "my-todo-project" }
-  let(:credentials) { Gcloud::Datastore::Credentials::Empty.new }
+  let(:credentials) { OpenStruct.new }
   let(:connection)  do
     mock = Minitest::Mock.new
     mock.expect :begin_transaction, begin_transaction_response


### PR DESCRIPTION
Remove convenience method and env vars for local devserver support.
The only way to specify a devserver is through DATASTORE_HOST.
Update CONTRIBUTING guide with demonstration of using DATASTORE_HOST.