### PR TITLE
Save file with binary mode

### DIFF
--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -140,7 +140,7 @@ module Gcloud
         ensure_connection!
         resp = connection.download_file bucket, name
         if resp.success?
-          ::File.open path, "w+" do |f|
+          ::File.open path, "wb+" do |f|
             f.write resp.body
           end
           verify_file! ::File.new(path), options


### PR DESCRIPTION
When using Google Cloud Storage, File#download opens local file with [non-binary mode](https://github.com/GoogleCloudPlatform/gcloud-ruby/blob/master/lib/gcloud/storage/file.rb#L143).
I tried downloading sample image from the bucket and it raised an encoding conversion error.

This simply adds binary switch to ensure that binary files stored on GCS can also be downloaded.