### PR TITLE
Allow JSON in Environment Variables

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,71 @@
+# Authentication
+
+## Creating a Service Account
+
+Gcloud aims to make authentication as simple as possible. Google Cloud requires a **Project ID** and **Service Account Credentials** to connect to the APIs. To create a service account:
+
+1. Visit the [Google Developers Console](https://console.developers.google.com/project).
+2. Create a new project or click on an existing project.
+3. Navigate to **APIs & auth** > **APIs section** and turn on the following APIs (you may need to enable billing in order to use these services):
+  * Google Cloud Datastore API
+  * Google Cloud Storage
+  * Google Cloud Storage JSON API
+4. Navigate to **APIs & auth** > **Credentials** and then:
+  * If you want to use a new service account, click on **Create new Client ID** and select **Service account**. After the account is created, you will be prompted to download the JSON key file that the library uses to authorize your requests.
+  * If you want to generate a new key for an existing service account, click on **Generate new JSON key** and download the JSON key file.
+
+You will use the **Project ID** and **JSON file** to connect to services with gcloud.
+
+## Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Compute Engine
+
+While running on Google Compute Engine no extra work is needed. The **Project ID** and **Credentials** and are discovered automatically. Code should be written as if already authenticated.
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables that Datastore checks for project ID:
+
+1. DATASTORE_PROJECT
+2. GOOGLE_CLOUD_PROJECT
+
+Here are the environment variables that Datastore checks for credentials:
+
+1. DATASTORE_KEYFILE - Path to JSON file
+2. GOOGLE_CLOUD_KEYFILE - Path to JSON file
+3. DATASTORE_KEYFILE_JSON - JSON contents
+4. GOOGLE_CLOUD_KEYFILE_JSON - JSON contents
+
+### Cloud SDK
+
+This option allows for an easy way to authenticate during development. If credentials are not provided in code or in environment variables, then Cloud SDK credentials are discovered.
+
+To configure your system for this, simply:
+
+1. [Download and install the Cloud SDK](https://cloud.google.com/sdk)
+2. Authenticate using OAuth2 `$ gcloud auth login`
+3. Write code as if already authenticated.
+
+**NOTE:** This is _not_ recommended for running in production. The Cloud SDK should only be used during development.
+
+## Troubleshooting
+
+If you're having trouble authenticating open a [Github Issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/new?title=Authentication+question) to get help.  Also consider searching or asking [questions](http://stackoverflow.com/questions/tagged/gcloud-ruby) on [StackOverflow](http://stackoverflow.com).

--- a/README.md
+++ b/README.md
@@ -23,21 +23,11 @@ If you need support for other Google APIs, check out the [Google API Ruby Client
 $ gem install gcloud
 ```
 
-### Authorization
+### Authentication
 
-You need a Google Developers service account to use the Google Cloud services. To create a service account:
+Gcloud uses Service Account credentials to connect to Google Cloud services. When running on Compute Engine the credentials will be discovered automatically. When running on other environments the Service Account credentials can be specified by providing the path to the JSON file, or the JSON itself, in environment variables. Additionally, Cloud SDK credentials can also be discovered automatically, but this is only recommended during development.
 
-1. Visit the [Google Developers Console](https://console.developers.google.com/project).
-2. Create a new project or click on an existing project.
-3. Navigate to **APIs & auth** > **APIs section** and turn on the following APIs (you may need to enable billing in order to use these services):
-  * Google Cloud Datastore API
-  * Google Cloud Storage
-  * Google Cloud Storage JSON API
-4. Navigate to **APIs & auth** > **Credentials** and then:
-  * If you want to use a new service account, click on **Create new Client ID** and select **Service account**. After the account is created, you will be prompted to download the JSON key file that the library uses to authorize your requests.
-  * If you want to generate a new key for an existing service account, click on **Generate new JSON key** and download the JSON key file.
-
-You will use the **Project ID** and **JSON file** to connect to services with gcloud.
+Instructions and configuration options are covered in the [Authentication guide](AUTHENTICATION.md). The examples in Quick Start will demonstrate providing the **Project ID** and **Credentials JSON file path** in code.
 
 ### Datastore
 

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -58,25 +58,26 @@ module Gcloud
     ##
     # Returns the default credentials.
     #
-    def self.default
+    def self.default options = {}
       env  = ->(v) { ENV[v] }
       json = ->(v) { JSON.parse ENV[v] rescue nil unless ENV[v].nil? }
       path = ->(p) { ::File.file? p }
 
       # First try to find keyfile file from environment variables.
       self::PATH_ENV_VARS.map(&env).reject(&:nil?).select(&path).each do |file|
-        return new file
+        return new file, options
       end
       # Second try to find keyfile json from environment variables.
       self::JSON_ENV_VARS.map(&json).reject(&:nil?).each do |hash|
-        return new hash
+        return new hash, options
       end
       # Third try to find keyfile file from known file paths.
       self::DEFAULT_PATHS.select(&path).each do |file|
-        return new file
+        return new file, options
       end
       # Finally get instantiated client from Google::Auth.
-      client = Google::Auth.get_application_default self::SCOPE
+      scope = options[:scope] || options["scope"] || self::SCOPE
+      client = Google::Auth.get_application_default scope
       new client
     end
 

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -26,7 +26,9 @@ module Gcloud
     TOKEN_CREDENTIAL_URI = "https://accounts.google.com/o/oauth2/token"
     AUDIENCE = "https://accounts.google.com/o/oauth2/token"
     SCOPE = []
-    ENV_VARS = ["GOOGLE_CLOUD_KEYFILE"]
+    PATH_ENV_VARS = ["GOOGLE_CLOUD_KEYFILE"]
+    JSON_ENV_VARS = ["GOOGLE_CLOUD_KEYFILE_JSON"]
+    DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
 
     attr_accessor :client
 
@@ -38,57 +40,68 @@ module Gcloud
                    :scope, :issuer, :signing_key
 
     def initialize keyfile, options = {}
+      verify_keyfile_provided! keyfile
       if keyfile.is_a? Signet::OAuth2::Client
         @client = keyfile
-      else
+      elsif keyfile.is_a? Hash
         @client = init_client keyfile, options
+      else
+        verify_keyfile_exists! keyfile
+        @client = init_client JSON.parse(::File.read(keyfile)), options
       end
       @client.fetch_access_token!
     end
+
+    # rubocop:disable all
+    # Disabled rubocop because this is intentionally complex.
 
     ##
     # Returns the default credentials.
     #
     def self.default
-      self::ENV_VARS.each do |env_var|
-        keyfile = ENV[env_var].to_s
-        return new keyfile if ::File.file? keyfile
+      env  = ->(v) { ENV[v] }
+      json = ->(v) { JSON.parse ENV[v] rescue nil unless ENV[v].nil? }
+      path = ->(p) { ::File.file? p }
+
+      # First try to find keyfile file from environment variables.
+      self::PATH_ENV_VARS.map(&env).reject(&:nil?).select(&path).each do |file|
+        return new file
       end
-      return new sdk_default_creds if ::File.file? sdk_default_creds
+      # Second try to find keyfile json from environment variables.
+      self::JSON_ENV_VARS.map(&json).reject(&:nil?).each do |hash|
+        return new hash
+      end
+      # Third try to find keyfile file from known file paths.
+      self::DEFAULT_PATHS.select(&path).each do |file|
+        return new file
+      end
+      # Finally get instantiated client from Google::Auth.
       client = Google::Auth.get_application_default self::SCOPE
       new client
     end
 
-    ##
-    # The filepath of the default application credentials used by
-    # the gcloud SDK.
-    #
-    # This file is created when running <tt>gcloud auth login</tt>
-    def self.sdk_default_creds #:nodoc:
-      # This method will likely be moved once we gain better
-      # support for running in a GCE environment.
-      sdk_creds = "~/.config/gcloud/application_default_credentials.json"
-      File.expand_path sdk_creds
-    end
+    # rubocop:enable all
 
     protected
 
     ##
-    # Initializes the Signet client.
-    def init_client keyfile, options
-      verify_keyfile! keyfile
-      client_opts = client_options keyfile, options
-      Signet::OAuth2::Client.new client_opts
+    # Verify that the keyfile argument is provided.
+    def verify_keyfile_provided! keyfile
+      fail "You must provide a keyfile to connect with." if keyfile.nil?
+    end
+
+    ##
+    # Verify that the keyfile argument is a file.
+    def verify_keyfile_exists! keyfile
+      exists = ::File.file? keyfile
+      fail "The keyfile '#{keyfile}' is not a valid file." unless exists
     end
 
     ##
     # Initializes the Signet client.
-    def verify_keyfile! keyfile
-      if keyfile.nil?
-        fail "You must provide a keyfile to connect with."
-      elsif !::File.file?(keyfile)
-        fail "The keyfile '#{keyfile}' is not a valid file."
-      end
+    def init_client keyfile, options
+      client_opts = client_options keyfile, options
+      Signet::OAuth2::Client.new client_opts
     end
 
     ##
@@ -111,7 +124,7 @@ module Gcloud
       # Constructor options override default options
       options = default_options.merge options
       # Keyfile options override everything
-      options = options.merge JSON.parse(::File.read(keyfile))
+      options = options.merge keyfile
 
       # client options for initializing signet client
       { token_credential_uri: options["token_credential_uri"],

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -40,8 +40,8 @@ module Gcloud
   # @return [Gcloud::Datastore::Dataset] new dataset.
   #
   # See Gcloud::Datastore::Dataset
-  def self.datastore project = ENV["DATASTORE_PROJECT"],
-                     keyfile = nil
+  def self.datastore project = nil, keyfile = nil
+    project ||= Gcloud::Datastore::Dataset.default_project
     if keyfile.nil?
       credentials = Gcloud::Datastore::Credentials.default
     else

--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -25,7 +25,8 @@ module Gcloud
     class Credentials < Gcloud::Credentials #:nodoc:
       SCOPE = ["https://www.googleapis.com/auth/datastore",
                "https://www.googleapis.com/auth/userinfo.email"]
-      ENV_VARS = ["DATASTORE_KEYFILE"]
+      PATH_ENV_VARS = %w(DATASTORE_KEYFILE GOOGLE_CLOUD_KEYFILE)
+      JSON_ENV_VARS = %w(DATASTORE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON)
 
       ##
       # Sign Oauth2 API calls.

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -57,6 +57,12 @@ module Gcloud
       end
 
       ##
+      # Default project.
+      def self.default_project #:nodoc:
+        ENV["DATASTORE_PROJECT"] || ENV["GOOGLE_CLOUD_PROJECT"]
+      end
+
+      ##
       # Generate IDs for a Key before creating an entity.
       #
       #   dataset = Gcloud.datastore

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -32,8 +32,8 @@ module Gcloud
   # @param keyfile [String] the path to the keyfile you downloaded from
   # Google Cloud. The file must readable.
   # @return [Gcloud::Pubsub::Project] the project instance.
-  def self.pubsub project = ENV["PUBSUB_PROJECT"],
-                  keyfile = nil
+  def self.pubsub project = nil, keyfile = nil
+    project ||= Gcloud::Pubsub::Project.default_project
     if keyfile.nil?
       credentials = Gcloud::Pubsub::Credentials.default
     else

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -33,8 +33,12 @@ module Gcloud
   # Google Cloud. The file must readable.
   # @return [Gcloud::Pubsub::Project] the project instance.
   def self.pubsub project = ENV["PUBSUB_PROJECT"],
-                  keyfile = ENV["PUBSUB_KEYFILE"]
-    credentials = Gcloud::Pubsub::Credentials.new keyfile
+                  keyfile = nil
+    if keyfile.nil?
+      credentials = Gcloud::Pubsub::Credentials.default
+    else
+      credentials = Gcloud::Pubsub::Credentials.new keyfile
+    end
     Gcloud::Pubsub::Project.new project, credentials
   end
 

--- a/lib/gcloud/pubsub/credentials.rb
+++ b/lib/gcloud/pubsub/credentials.rb
@@ -22,6 +22,8 @@ module Gcloud
     class Credentials < Gcloud::Credentials #:nodoc:
       SCOPE = ["https://www.googleapis.com/auth/pubsub",
                "https://www.googleapis.com/auth/cloud-platform"]
+      PATH_ENV_VARS = %w(PUBSUB_KEYFILE GOOGLE_CLOUD_KEYFILE)
+      JSON_ENV_VARS = %w(PUBSUB_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON)
     end
   end
 end

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -40,6 +40,12 @@ module Gcloud
       end
 
       ##
+      # Default project.
+      def self.default_project #:nodoc:
+        ENV["PUBSUB_PROJECT"] || ENV["GOOGLE_CLOUD_PROJECT"]
+      end
+
+      ##
       # Retrieves topic by name.
       def topic topic_name
         ensure_connection!

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -33,8 +33,8 @@ module Gcloud
   # @return [Gcloud::Storage::Project] storage project.
   #
   # See Gcloud::Storage::Project
-  def self.storage project = ENV["STORAGE_PROJECT"],
-                   keyfile = nil
+  def self.storage project = nil, keyfile = nil
+    project ||= Gcloud::Storage::Project.default_project
     if keyfile.nil?
       credentials = Gcloud::Storage::Credentials.default
     else

--- a/lib/gcloud/storage/credentials.rb
+++ b/lib/gcloud/storage/credentials.rb
@@ -20,7 +20,8 @@ module Gcloud
     # Represents the Oauth2 signing logic for Storage.
     class Credentials < Gcloud::Credentials #:nodoc:
       SCOPE = ["https://www.googleapis.com/auth/devstorage.full_control"]
-      ENV_VARS = ["STORAGE_KEYFILE"]
+      PATH_ENV_VARS = %w(STORAGE_KEYFILE GOOGLE_CLOUD_KEYFILE)
+      JSON_ENV_VARS = %w(STORAGE_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON)
     end
   end
 end

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -53,6 +53,12 @@ module Gcloud
       end
 
       ##
+      # Default project.
+      def self.default_project #:nodoc:
+        ENV["STORAGE_PROJECT"] || ENV["GOOGLE_CLOUD_PROJECT"]
+      end
+
+      ##
       # Retrieves a list of buckets for the given project.
       #
       #   storage = Gcloud.storage


### PR DESCRIPTION
This change allows the keyfile JSON contents to be accessed from environment variables. It allows for configuration without writing the file to disk. This is useful when using pre-packaged docker containers and other deployment scenarios.

Currently Gcloud only supports the project identifier and keyfile path in environment variables. The path must point to an actual file.

```ruby
require "gcloud/datastore"

ENV["DATASTORE_PROJECT"] = "project-identifier"
ENV["DATASTORE_KEYFILE"] = "/path/to/keyfile.json"

@datastore = Gcloud.datastore
@entity = @datastore.find "Task", 123
```

This change allows for the JSON to be in the environment variable instead of being read from a file.

```ruby
require "gcloud/datastore"

ENV["DATASTORE_PROJECT"] = "project-identifier"
ENV["DATASTORE_KEYFILE_JSON"] = "{\"private_key_id\": \"...\", \"private_key\": \"...\", \"client_email\": \"...\", \"client_id\": \"...\", \"type\": \"...\"}"

@datastore = Gcloud.datastore
@entity = @datastore.find "Task", 123
```

Addresses #109