### PR TITLE
Rename QueryResults cursor to end_cursor

### DIFF
--- a/lib/gcloud/datastore/dataset/query_results.rb
+++ b/lib/gcloud/datastore/dataset/query_results.rb
@@ -30,15 +30,16 @@ module Gcloud
       #
       #   entities = dataset.run query
       #   entities.size #=> 3
-      #   entities.cursor #=> "c3VwZXJhd2Vzb21lIQ"
+      #   entities.end_cursor #=> "c3VwZXJhd2Vzb21lIQ"
       #   names = entities.map { |e| e.name }
       #   names.size #=> 3
       #   names.cursor #=> NoMethodError
       #
       class QueryResults < DelegateClass(::Array)
         ##
-        # The cursor of the QueryResults.
-        attr_reader :cursor
+        # The end_cursor of the QueryResults.
+        attr_reader :end_cursor
+        alias_method :cursor, :end_cursor
 
         ##
         # The state of the query after the current batch.
@@ -76,9 +77,9 @@ module Gcloud
 
         ##
         # Create a new QueryResults with an array of values.
-        def initialize arr = [], cursor = nil, more_results = nil
+        def initialize arr = [], end_cursor = nil, more_results = nil
           super arr
-          @cursor = cursor
+          @end_cursor = end_cursor
           @more_results = more_results
         end
       end

--- a/test/gcloud/datastore/test_dataset.rb
+++ b/test/gcloud/datastore/test_dataset.rb
@@ -268,6 +268,7 @@ describe Gcloud::Datastore::Dataset do
       entity.must_be_kind_of Gcloud::Datastore::Entity
     end
     entities.cursor.must_equal query_cursor
+    entities.end_cursor.must_equal query_cursor
     entities.more_results.must_be :nil?
     refute entities.not_finished?
     refute entities.more_after_limit?


### PR DESCRIPTION
Request from the Datastore team.

[Closes #119]