### PR TITLE
Create top-level Gcloud object

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -17,10 +17,10 @@ Follow the [activation instructions](https://cloud.google.com/datastore/docs/act
 See the [gcloud-ruby Datastore API documentation](rdoc-ref:Gcloud::Datastore) to learn how to interact with the Cloud Datastore using this library.
 
 ```ruby
-require "gcloud/datastore"
+require "gcloud"
 
-dataset = Gcloud.datastore "my-todo-project-id",
-                           "/path/to/keyfile.json"
+gcloud = Gcloud.new
+dataset = gcloud.datastore
 
 # Create a new task to demo datastore
 demo_task = Gcloud::Datastore::Entity.new
@@ -44,9 +44,10 @@ completed_tasks = dataset.run query
 See the [gcloud-ruby Pub/Sub API documentation](rdoc-ref:Gcloud::Pubsub) to learn how to connect to Cloud Pub/Sub using this library.
 
 ```ruby
-require "gcloud/pubsub"
+require "gcloud"
 
-pubsub = Gcloud.pubsub
+gcloud = Gcloud.new
+pubsub = gcloud.pubsub
 
 # Retrieve a topic
 topic = pubsub.topic "my-topic"
@@ -68,10 +69,10 @@ msgs = sub.pull
 See the [gcloud-ruby Storage API documentation](rdoc-ref:Gcloud::Storage) to learn how to connect to Cloud Storage using this library.
 
 ```ruby
-require "gcloud/storage"
+require "gcloud"
 
-storage = Gcloud.storage "my-todo-project-id",
-                         "/path/to/keyfile.json"
+gcloud = Gcloud.new
+storage = gcloud.storage
 
 bucket = storage.bucket "task-attachments"
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ dataset.save demo_task
 # Run a query for all completed tasks
 query = Gcloud::Datastore::Query.new.kind("Task").
   where("completed", "=", true)
-completed_tasks = datastore.run query
+completed_tasks = dataset.run query
 ```
 
 ### Pub/Sub

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ require "gcloud"
 
 gcloud = Gcloud.new "my-todo-project-id",
                     "/path/to/keyfile.json"
-datastore = gcloud.datastore
+dataset = gcloud.datastore
 
 # Create a new task to demo datastore
 demo_task = Gcloud::Datastore::Entity.new
@@ -54,7 +54,7 @@ demo_task[:description] = "Demonstrate Datastore functionality"
 demo_task[:completed] = false
 
 # Save the new task
-datastore.save demo_task
+dataset.save demo_task
 
 # Run a query for all completed tasks
 query = Gcloud::Datastore::Query.new.kind("Task").

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Instructions and configuration options are covered in the [Authentication guide]
 #### Preview
 
 ```ruby
-require "gcloud/datastore"
+require "gcloud"
 
-dataset = Gcloud.datastore "my-todo-project-id",
-                           "/path/to/keyfile.json"
+gcloud = Gcloud.new "my-todo-project-id",
+                    "/path/to/keyfile.json"
+datastore = gcloud.datastore
 
 # Create a new task to demo datastore
 demo_task = Gcloud::Datastore::Entity.new
@@ -53,12 +54,12 @@ demo_task[:description] = "Demonstrate Datastore functionality"
 demo_task[:completed] = false
 
 # Save the new task
-dataset.save demo_task
+datastore.save demo_task
 
 # Run a query for all completed tasks
 query = Gcloud::Datastore::Query.new.kind("Task").
   where("completed", "=", true)
-completed_tasks = dataset.run query
+completed_tasks = datastore.run query
 ```
 
 ### Pub/Sub
@@ -69,9 +70,11 @@ completed_tasks = dataset.run query
 #### Preview
 
 ```ruby
-require "gcloud/pubsub"
+require "gcloud"
 
-pubsub = Gcloud.pubsub
+gcloud = Gcloud.new "my-todo-project-id",
+                    "/path/to/keyfile.json"
+pubsub = gcloud.pubsub
 
 # Retrieve a topic
 topic = pubsub.topic "my-topic"
@@ -94,10 +97,11 @@ msgs = sub.pull
 #### Preview
 
 ```ruby
-require "gcloud/storage"
+require "gcloud"
 
-storage = Gcloud.storage "my-todo-project-id",
-                         "/path/to/keyfile.json"
+gcloud = Gcloud.new "my-todo-project-id",
+                    "/path/to/keyfile.json"
+storage = gcloud.storage
 
 bucket = storage.bucket "task-attachments"
 

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -51,10 +51,10 @@ module Gcloud
   #
   #   require "gcloud"
   #
-  #   gcloud    = Gcloud.new
-  #   datastore = gcloud.datastore
-  #   pubsub    = gcloud.pubsub
-  #   storage   = gcloud.storage
+  #   gcloud  = Gcloud.new
+  #   dataset = gcloud.datastore
+  #   pubsub  = gcloud.pubsub
+  #   storage = gcloud.storage
   #
   def self.new project = nil, keyfile = nil
     gcloud = Object.new
@@ -78,15 +78,15 @@ module Gcloud
   #
   #   require "gcloud"
   #
-  #   gcloud    = Gcloud.new
-  #   datastore = gcloud.datastore
+  #   gcloud  = Gcloud.new
+  #   dataset = gcloud.datastore
   #
   #   entity = Gcloud::Datastore::Entity.new
   #   entity.key = Gcloud::Datastore::Key.new "Task"
   #   entity["description"] = "Get started with Google Cloud"
   #   entity["completed"] = false
   #
-  #   datastore.save entity
+  #   dataset.save entity
   #
   def datastore
     require "gcloud/datastore"

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -32,6 +32,112 @@ require "gcloud/version"
 #
 module Gcloud
   ##
+  # Creates a new object for connecting to Google Cloud.
+  #
+  # === Parameters
+  #
+  # +project+::
+  #   Project identifier for the Pub/Sub service you are connecting to.
+  #   (+String+)
+  # +keyfile+::
+  #   Keyfile downloaded from Google Cloud. If file path the file must be
+  #   readable. (+String+ or +Hash+)
+  #
+  # === Returns
+  #
+  # Gcloud
+  #
+  # === Example
+  #
+  #   require "gcloud"
+  #
+  #   gcloud    = Gcloud.new
+  #   datastore = gcloud.datastore
+  #   pubsub    = gcloud.pubsub
+  #   storage   = gcloud.storage
+  #
+  def self.new project = nil, keyfile = nil
+    gcloud = Object.new
+    gcloud.instance_eval do
+      @project = project
+      @keyfile = keyfile
+    end
+    gcloud.extend Gcloud
+    gcloud
+  end
+
+  ##
+  # Creates a new object for connecting to the Datastore service.
+  # Each call creates a new connection.
+  #
+  # === Returns
+  #
+  # Gcloud::Datastore::Dataset
+  #
+  # === Example
+  #
+  #   require "gcloud"
+  #
+  #   gcloud    = Gcloud.new
+  #   datastore = gcloud.datastore
+  #
+  #   entity = Gcloud::Datastore::Entity.new
+  #   entity.key = Gcloud::Datastore::Key.new "Task"
+  #   entity["description"] = "Get started with Google Cloud"
+  #   entity["completed"] = false
+  #
+  #   datastore.save entity
+  #
+  def datastore
+    require "gcloud/datastore"
+    Gcloud.datastore @project, @keyfile
+  end
+
+  ##
+  # Creates a new object for connecting to the Storage service.
+  # Each call creates a new connection.
+  #
+  # === Returns
+  #
+  # Gcloud::Storage::Project
+  #
+  # === Example
+  #
+  #   require "gcloud"
+  #
+  #   gcloud  = Gcloud.new
+  #   storage = gcloud.storage
+  #   bucket = storage.bucket "my-bucket"
+  #   file = bucket.file "path/to/my-file.ext"
+  #
+  def storage
+    require "gcloud/storage"
+    Gcloud.storage @project, @keyfile
+  end
+
+  ##
+  # Creates a new object for connecting to the Pub/Sub service.
+  # Each call creates a new connection.
+  #
+  # === Returns
+  #
+  # Gcloud::Pubsub::Project
+  #
+  # === Example
+  #
+  #   require "gcloud"
+  #
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
+  #   topic = pubsub.topic "my-topic"
+  #   topic.publish "task completed"
+  #
+  def pubsub
+    require "gcloud/pubsub"
+    Gcloud.pubsub @project, @keyfile
+  end
+
+  ##
   # Base Gcloud exception class.
   class Error < StandardError
   end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -71,15 +71,16 @@ module Gcloud
   # make the most of using Datastore.
   #
   # Gcloud's goal is to provide a API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud.datastore. You can provide
+  # Rubyists. Authentication is handled by Gcloud#datastore. You can provide
   # the project and credential information to connect to the Datastore service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you.
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore "my-todo-project",
-  #                              "/path/to/keyfile.json"
+  #   gcloud = Gcloud.new "my-todo-project",
+  #                       "/path/to/keyfile.json"
+  #   dataset = gcloud.datastore
   #   entity = dataset.find "Task", "start"
   #   entity["completed"] = true
   #   dataset.save entity
@@ -100,16 +101,18 @@ module Gcloud
   # <tt>name</tt> value. A single record can be retrieved by calling
   # Gcloud::Datastore::Dataset#find and passing the parts of the key:
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   entity = dataset.find "Task", "start"
   #
   # Optionally, Gcloud::Datastore::Dataset#find can be given a Key object:
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   key = Gcloud::Datastore::Key.new "Task", 12345
   #   entity = dataset.find key
   #
@@ -120,9 +123,10 @@ module Gcloud
   # Multiple records can be found that match criteria.
   # (See Gcloud::Datastore::Query#where)
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   query = Gcloud::Datastore::Query.new
   #   query.kind("List").
   #     where("active", "=", true)
@@ -130,9 +134,10 @@ module Gcloud
   #
   # Records can also be ordered. (See Gcloud::Datastore::Query#order)
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   query = Gcloud::Datastore::Query.new
   #   query.kind("List").
   #     where("active", "=", true).
@@ -142,9 +147,10 @@ module Gcloud
   # The number of records returned can be specified.
   # (See Gcloud::Datastore::Query#limit)
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   query = Gcloud::Datastore::Query.new
   #   query.kind("List").
   #     where("active", "=", true).
@@ -155,9 +161,10 @@ module Gcloud
   # Records' Key structures can also be queried.
   # (See Gcloud::Datastore::Query#ancestor)
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #
   #   list = dataset.find "List", "todos"
   #   query = Gcloud::Datastore::Query.new
@@ -173,9 +180,10 @@ module Gcloud
   # to return them all. The returned records will have a <tt>cursor</tt> if
   # there are more available.
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #
   #   list = dataset.find "List", "todos"
   #   query = Gcloud::Datastore::Query.new
@@ -204,9 +212,10 @@ module Gcloud
   # The entity must have a Key to be saved. If the Key is incomplete then
   # it will be completed when saved.
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   entity = Gcloud::Datastore::Entity.new
   #   entity.key = Gcloud::Datastore::Key.new "User"
   #   entity["name"] = "Heidi Henderson"
@@ -221,9 +230,10 @@ module Gcloud
   # String, Integer, Date, Time, and even other Entity or Key objects. Changes
   # to the Entity's properties are persisted by calling Dataset#save.
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   entity = datastore.find "User", "heidi"
   #   # Read the status property
   #   entity["status"] #=> "inactive"
@@ -237,9 +247,10 @@ module Gcloud
   # Entities can be removed from Datastore by calling Dataset#delete and passing
   # the Entity object or the entity's Key object.
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #   entity = datastore.find "User", "heidi"
   #   dataset.delete entity
   #
@@ -249,9 +260,10 @@ module Gcloud
   # within the Dataset#transaction block are run within the transaction scope,
   # and will be automatically committed when the block completes.
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #
   #   key = Gcloud::Datastore::Key.new "User", "heidi"
   #
@@ -269,9 +281,10 @@ module Gcloud
   # Alternatively, if no block is given the transaction object is returned
   # allowing you to commit or rollback manually.
   #
-  #   require "gcloud/datastore"
+  #   require "gcloud"
   #
-  #   dataset = Gcloud.datastore
+  #   gcloud = Gcloud.new
+  #   dataset = gcloud.datastore
   #
   #   key = Gcloud::Datastore::Key.new "User", "heidi"
   #

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -234,7 +234,7 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   entity = datastore.find "User", "heidi"
+  #   entity = dataset.find "User", "heidi"
   #   # Read the status property
   #   entity["status"] #=> "inactive"
   #   # Write the status property
@@ -251,7 +251,7 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   entity = datastore.find "User", "heidi"
+  #   entity = dataset.find "User", "heidi"
   #   dataset.delete entity
   #
   # == Transactions

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -33,23 +33,24 @@ module Gcloud
     # Google Datastore. Gcloud::Datastore::Entity objects are created,
     # read, updated, and deleted by Gcloud::Datastore::Dataset.
     #
-    #   require "gcloud/datastore"
+    #   require "gcloud"
     #
-    #   dataset = Gcloud.datastore
+    #   gcloud = Gcloud.new
+    #   dataset = gcloud.datastore
     #
     #   query = Gcloud::Datastore::Query.new.kind("Task").
     #     where("completed", "=", true)
     #
     #   tasks = dataset.run query
     #
-    # See Gcloud.datastore
+    # See Gcloud#datastore
     class Dataset
       attr_accessor :connection #:nodoc:
 
       ##
       # Creates a new Dataset instance.
       #
-      # See Gcloud.datastore
+      # See Gcloud#datastore
       def initialize project, credentials #:nodoc:
         @connection = Connection.new project, credentials
       end
@@ -59,11 +60,12 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore "my-todo-project",
-      #                              "/path/to/keyfile.json"
+      #   gcloud = Gcloud.new "my-todo-project",
+      #                       "/path/to/keyfile.json"
       #
+      #   dataset = gcloud.datastore
       #   dataset.project #=> "my-todo-project"
       #
       def project
@@ -179,7 +181,8 @@ module Gcloud
       #
       # === Example
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   key1 = Gcloud::Datastore::Key.new "Task", 123456
       #   key2 = Gcloud::Datastore::Key.new "Task", 987654
       #   tasks = dataset.find_all key1, key2
@@ -207,7 +210,8 @@ module Gcloud
       #
       # === Example
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   dataset.delete entity1, entity2
       #
       def delete *entities_or_keys
@@ -255,9 +259,10 @@ module Gcloud
       #
       # Runs the given block in a database transaction:
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #
       #   key = Gcloud::Datastore::Key.new "User", "heidi"
       #
@@ -274,9 +279,10 @@ module Gcloud
       #
       # Alternatively, if no block is given a Transaction object is returned:
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #
       #   key = Gcloud::Datastore::Key.new "User", "heidi"
       #

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -62,7 +62,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = datastore.find "User", "heidi"
+      #   user = dataset.find "User", "heidi"
       #   user["name"] #=> "Heidi Henderson"
       #
       # Or with a symbol name:
@@ -71,7 +71,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = datastore.find "User", "heidi"
+      #   user = dataset.find "User", "heidi"
       #   user[:name] #=> "Heidi Henderson"
       #
       def [] prop_name
@@ -96,7 +96,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = datastore.find "User", "heidi"
+      #   user = dataset.find "User", "heidi"
       #   user["name"] = "Heidi H. Henderson"
       #
       # Or with a symbol name:
@@ -105,7 +105,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = datastore.find "User", "heidi"
+      #   user = dataset.find "User", "heidi"
       #   user[:name] = "Heidi H. Henderson"
       #
       def []= prop_name, prop_value

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -58,17 +58,19 @@ module Gcloud
       #
       # Properties can be retrieved with a string name:
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   user = datastore.find "User", "heidi"
       #   user["name"] #=> "Heidi Henderson"
       #
       # Or with a symbol name:
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   user = datastore.find "User", "heidi"
       #   user[:name] #=> "Heidi Henderson"
       #
@@ -90,17 +92,19 @@ module Gcloud
       #
       # Properties can be set with a string name:
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   user = datastore.find "User", "heidi"
       #   user["name"] = "Heidi H. Henderson"
       #
       # Or with a symbol name:
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   user = datastore.find "User", "heidi"
       #   user[:name] = "Heidi H. Henderson"
       #
@@ -149,9 +153,10 @@ module Gcloud
       #
       # The Key can be set before the entity is saved.
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   entity = Gcloud::Datastore::Entity.new
       #   entity.key = Gcloud::Datastore::Key.new "User"
       #   dataset.save entity
@@ -159,9 +164,10 @@ module Gcloud
       # Once the entity is saved, the key is frozen and immutable.
       # Trying to set a key when immutable will raise a +RuntimeError+.
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #   entity = dataset.find "User", "heidi"
       #   entity.persisted? #=> true
       #   entity.key = Gcloud::Datastore::Key.new "User" #=> RuntimeError
@@ -178,9 +184,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #
       #   new_entity = Gcloud::Datastore::Entity.new
       #   new_entity.persisted? #=> false

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -51,11 +51,12 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore "my-todo-project",
-      #                              "/path/to/keyfile.json"
+      #   gcloud = Gcloud.new "my-todo-project",
+      #                       "/path/to/keyfile.json"
       #
+      #   dataset = gcloud.datastore
       #   entity = dataset.find "User", "heidi"
       #   entity.key.dataset_id #=> "my-todo-project"
       #
@@ -70,11 +71,12 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore "my-todo-project",
-      #                              "/path/to/keyfile.json"
+      #   gcloud = Gcloud.new "my-todo-project",
+      #                       "/path/to/keyfile.json"
       #
+      #   dataset = gcloud.datastore
       #   entity = dataset.find "User", "heidi"
       #   entity.key.namespace #=> "ns~todo-project"
       #
@@ -188,9 +190,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/datastore"
+      #   require "gcloud"
       #
-      #   dataset = Gcloud.datastore
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
       #
       #   user = dataset.find "User", "heidi"
       #   query = Gcloud::Datastore::Query.new

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -66,14 +66,15 @@ module Gcloud
   # applications.
   #
   # Gcloud's goal is to provide a API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud.pubsub. You can provide the
+  # Rubyists. Authentication is handled by Gcloud#pubsub. You can provide the
   # project and credential information to connect to the Pub/Sub service, or if
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
@@ -86,36 +87,40 @@ module Gcloud
   # A Topic is a named resource to which messages are sent by publishers.
   # A Topic is found by its name. (See Project#topic)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #   topic = pubsub.topic "my-topic"
   #
   # == Creating a Topic
   #
   # A Topic is created from a Project. (See Project#create_topic)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #   topic = pubsub.create_topic "my-topic"
   #
   # == Publishing Messages
   #
   # Messages are published to a topic. (See Topic#publish)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   topic = pubsub.topic "my-topic"
   #   msg = topic.publish "new-message"
   #
   # Messages can also be published with attributes:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   topic = pubsub.topic "my-topic"
   #   msg = topic.publish "new-message",
@@ -124,9 +129,10 @@ module Gcloud
   #
   # Multiple messages can be published at the same time by passing a block:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   topic = pubsub.topic "my-topic"
   #   msgs = topic.publish do |batch|
@@ -141,9 +147,10 @@ module Gcloud
   # a single, specific Topic, to be delivered to the subscribing application.
   # A Subscription is found by its name. (See Topic#subscription)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   topic = pubsub.topic "my-topic"
   #   subscription = topic.subscription "my-topic-subscription"
@@ -153,9 +160,10 @@ module Gcloud
   #
   # A Subscription is created from a Topic. (See Topic#subscribe)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   topic = pubsub.topic "my-topic"
   #   sub = topic.subscribe "my-topic-sub"
@@ -164,9 +172,10 @@ module Gcloud
   # The subscription can be created that specifies the number of seconds to
   # wait to be acknowledged as well as an endpoint URL to push the messages to:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   topic = pubsub.topic "my-topic"
   #   sub = topic.subscribe "my-topic-sub",
@@ -176,14 +185,15 @@ module Gcloud
   # == Working Across Projects
   #
   # All calls to the Pub/Sub service use the same project and credentials
-  # provided to the Gcloud.pubsub method. However, it is common to reference
+  # provided to the Gcloud#pubsub method. However, it is common to reference
   # topics or subscriptions in other projects, which can be achieved by using
   # the +project+ option. The main credentials must have permissions to the
   # topics and subscriptions in other projects.
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub # my-project-id
+  #   gcloud = Gcloud.new # my-project-id
+  #   pubsub = gcloud.pubsub
   #
   #   # Get a topic in the current project
   #   my_topic = pubsub.topic "my-topic"
@@ -195,9 +205,10 @@ module Gcloud
   # It is possible to create a subscription in the current project that pulls
   # from a topic in another project:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub # my-project-id
+  #   gcloud = Gcloud.new # my-project-id
+  #   pubsub = gcloud.pubsub
   #
   #   # Get a topic in another project
   #   topic = pubsub.topic "other-topic", project: "other-project-id"
@@ -211,18 +222,20 @@ module Gcloud
   #
   # Messages are pulled from a Subscription. (See Subscription#pull)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   msgs = sub.pull
   #
   # A maximum number of messages returned can also be specified:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub", max: 10
   #   msgs = sub.pull
@@ -230,9 +243,10 @@ module Gcloud
   # The request for messages can also block until messages are available.
   # (See Subscription#wait_for_messages)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   msgs = sub.wait_for_messages
@@ -246,9 +260,10 @@ module Gcloud
   # ReceivedMessages can be acknowledged one at a time:
   # (See ReceivedMessage#acknowledge!)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   sub.pull.each { |msg| msg.acknowledge! }
@@ -256,9 +271,10 @@ module Gcloud
   # Or, multiple messages can be acknowledged in a single API call:
   # (See Subscription#acknowledge)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   received_messages = sub.pull
@@ -271,9 +287,10 @@ module Gcloud
   # more time is needed. This will allow more time to process the message before
   # the message is marked for redelivery. (See ReceivedMessage#delay!)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   received_message = sub.pull.first
@@ -285,9 +302,10 @@ module Gcloud
   #
   # The message can also be made available for immediate redelivery:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   received_message = sub.pull.first
@@ -300,9 +318,10 @@ module Gcloud
   # Multiple messages can be delayed or made available for immediate redelivery:
   # (See Subscription#delay)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   received_messages = sub.pull
@@ -314,9 +333,10 @@ module Gcloud
   # infinitely blocking loop to process messages as they are received. (See
   # Subscription#listen)
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   sub.listen do |msg|
@@ -326,9 +346,10 @@ module Gcloud
   # Messages are retrieved in batches for efficiency. The number of messages
   # pulled per batch can be limited with the +max+ option:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   sub.listen max: 20 do |msg|
@@ -339,9 +360,10 @@ module Gcloud
   # messages can be automatically acknowledged as they are pulled with the
   # +autoack+ option:
   #
-  #   require "gcloud/pubsub"
+  #   require "gcloud"
   #
-  #   pubsub = Gcloud.pubsub
+  #   gcloud = Gcloud.new
+  #   pubsub = gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   sub.listen autoack: true do |msg|

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -27,9 +27,10 @@ module Gcloud
     # which contains a Message object. Each ReceivedMessage object can be
     # acknowledged and/or delayed.
     #
-    #   require "gcloud/pubsub"
+    #   require "gcloud"
     #
-    #   pubsub = Gcloud.pubsub
+    #   gcloud = Gcloud.new
+    #   pubsub = gcloud.pubsub
     #
     #   # Publish a message
     #   topic = pubsub.topic "my-topic"

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -30,14 +30,15 @@ module Gcloud
     # Message is a combination of data and attributes that a publisher sends to
     # a topic and is eventually delivered to subscribers.
     #
-    #   require "gcloud/pubsub"
+    #   require "gcloud"
     #
-    #   pubsub = Gcloud.pubsub
+    #   gcloud = Gcloud.new
+    #   pubsub = gcloud.pubsub
     #
     #   topic = pubsub.topic "my-topic"
     #   topic.publish "task completed"
     #
-    # See Gcloud.pubsub
+    # See Gcloud#pubsub
     class Project
       ##
       # The Connection object.
@@ -53,10 +54,11 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub "my-todo-project",
-      #                          "/path/to/keyfile.json"
+      #   gcloud = Gcloud.new "my-todo-project",
+      #                       "/path/to/keyfile.json"
+      #   pubsub = gcloud.pubsub
       #
       #   pubsub.project #=> "my-todo-project"
       #
@@ -86,9 +88,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #   topic = pubsub.get_topic "my-topic"
       #
       def get_topic topic_name
@@ -128,33 +131,37 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "existing-topic"
       #   msg = topic.publish "This is the first API call to Pub/Sub."
       #
       # By default the topic will be created in Pub/Sub when needed.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic"
       #   msg = topic.publish "This will create the topic in Pub/Sub."
       #
       # Setting the +autocomplete+ flag to false will not create the topic.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic"
       #   msg = topic.publish "This raises." #=> Gcloud::Pubsub::NotFoundError
       #
       # A topic in a different project can be created using the +project+ flag.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "another-topic", project: "another-project"
       #
       def topic topic_name, options = {}
@@ -177,9 +184,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #   topic = pubsub.create_topic "my-topic"
       #
       def create_topic topic_name
@@ -214,9 +222,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topics = pubsub.topics
       #   topics.each do |topic|
@@ -226,9 +235,10 @@ module Gcloud
       # If you have a significant number of topics, you may need to paginate
       # through them: (See Topic::List#token)
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   all_topics = []
       #   tmp_topics = pubsub.topics
@@ -271,9 +281,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   subscription = pubsub.get_subscription "my-topic-subscription"
       #   puts subscription.name
@@ -301,9 +312,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   subscription = pubsub.get_subscription "my-topic-subscription"
       #   puts subscription.name
@@ -342,9 +354,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   subscriptions = pubsub.subscriptions
       #   subscriptions.each do |subscription|
@@ -354,9 +367,10 @@ module Gcloud
       # If you have a significant number of subscriptions, you may need to
       # paginate through them: (See Subscription::List#token)
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   all_subs = []
       #   tmp_subs = pubsub.subscriptions

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -23,9 +23,10 @@ module Gcloud
     #
     # Represents a Pub/Sub Message that can be acknowledged or delayed.
     #
-    #   require "gcloud/pubsub"
+    #   require "gcloud"
     #
-    #   pubsub = Gcloud.pubsub
+    #   gcloud = Gcloud.new
+    #   pubsub = gcloud.pubsub
     #
     #   sub = pubsub.subscription "my-topic-sub"
     #   received_message = sub.pull.first
@@ -88,9 +89,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   received_message = sub.pull.first
@@ -122,9 +124,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   received_message = sub.pull.first

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -25,9 +25,10 @@ module Gcloud
     # A named resource representing the stream of messages from a single,
     # specific topic, to be delivered to the subscribing application.
     #
-    #   require "gcloud/pubsub"
+    #   require "gcloud"
     #
-    #   pubsub = Gcloud.pubsub
+    #   gcloud = Gcloud.new
+    #   pubsub = gcloud.pubsub
     #
     #   sub = pubsub.subscription "my-topic-sub"
     #   msgs = sub.pull
@@ -79,9 +80,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.topic.name #=> "projects/my-project/topics/my-topic"
@@ -126,9 +128,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.exists? #=> true
@@ -150,9 +153,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.get_subscription "my-topic-sub"
       #   sub.lazy? #=> false
@@ -171,9 +175,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.delete
@@ -220,18 +225,20 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.pull.each { |msg| msg.acknowledge! }
       #
       # A maximum number of messages returned can also be specified:
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub", max: 10
       #   sub.pull.each { |msg| msg.acknowledge! }
@@ -239,9 +246,10 @@ module Gcloud
       # The call can block until messages are available by setting the
       # +:immediate+ option to +false+:
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   msgs = sub.pull immediate: false
@@ -289,9 +297,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   msgs = sub.wait_for_messages
@@ -323,9 +332,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.listen do |msg|
@@ -335,9 +345,10 @@ module Gcloud
       # The number of messages pulled per batch can be set with the +max+
       # option:
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.listen max: 20 do |msg|
@@ -347,9 +358,10 @@ module Gcloud
       # Messages can be automatically acknowledged as they are pulled with the
       # +autoack+ option:
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.listen autoack: true do |msg|
@@ -384,9 +396,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   messages = sub.pull
@@ -425,9 +438,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   messages = sub.pull
@@ -474,9 +488,10 @@ module Gcloud
       # By default, the policy values are memoized to reduce the number of API
       # calls to the Pub/Sub service.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   subscription = pubsub.subscription "my-subscription"
       #   puts subscription.policy["bindings"]
@@ -485,9 +500,10 @@ module Gcloud
       # To retrieve the latest policy from the Pub/Sub service, use the +force+
       # flag.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   subscription = pubsub.subscription "my-subscription"
       #   policy = subscription.policy force: true
@@ -521,9 +537,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   viewer_policy = {
       #     "bindings" => [{

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -25,9 +25,10 @@ module Gcloud
     #
     # A named resource to which messages are published.
     #
-    #   require "gcloud/pubsub"
+    #   require "gcloud"
     #
-    #   pubsub = Gcloud.pubsub
+    #   gcloud = Gcloud.new
+    #   pubsub = gcloud.pubsub
     #
     #   topic = pubsub.topic "my-topic"
     #   topic.publish "task completed"
@@ -81,9 +82,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   topic.delete
@@ -124,9 +126,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   sub = topic.subscribe "my-topic-sub"
@@ -134,9 +137,10 @@ module Gcloud
       #
       # The name is optional, and will be generated if not given.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   sub = topic.subscribe "my-topic-sub"
@@ -145,9 +149,10 @@ module Gcloud
       # The subscription can be created that waits two minutes for
       # acknowledgement and pushed all messages to an endpoint
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   sub = topic.subscribe "my-topic-sub",
@@ -186,9 +191,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   subscription = topic.subscription "my-topic-subscription"
@@ -217,9 +223,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   subscription = topic.get_subscription "my-topic-subscription"
@@ -256,9 +263,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   subscription = topic.subscriptions
@@ -269,9 +277,10 @@ module Gcloud
       # If you have a significant number of subscriptions, you may need to
       # paginate through them: (See Subscription::List#token)
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   all_subs = []
@@ -315,18 +324,20 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   msg = topic.publish "new-message"
       #
       # Additionally, a message can be published with attributes:
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   msg = topic.publish "new-message",
@@ -335,9 +346,10 @@ module Gcloud
       #
       # Multiple messages can be published at the same time by passing a block:
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   msgs = topic.publish do |batch|
@@ -387,9 +399,10 @@ module Gcloud
       # By default, the policy values are memoized to reduce the number of API
       # calls to the Pub/Sub service.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   puts topic.policy["bindings"]
@@ -398,9 +411,10 @@ module Gcloud
       # To retrieve the latest policy from the Pub/Sub service, use the +force+
       # flag.
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   policy = topic.policy force: true
@@ -434,9 +448,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   viewer_policy = {
       #     "bindings" => [{
@@ -463,9 +478,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   topic.exists? #=> true
@@ -484,9 +500,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   topic.lazy? #=> false
@@ -501,9 +518,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/pubsub"
+      #   require "gcloud"
       #
-      #   pubsub = Gcloud.pubsub
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
       #   topic.autocreate? #=> true

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -65,15 +65,16 @@ module Gcloud
   # infrastructure to perform data operations in a cost effective manner.
   #
   # Gcloud's goal is to provide a API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud.storage. You can provide the
+  # Rubyists. Authentication is handled by Gcloud#storage. You can provide the
   # project and credential information to connect to the Storage service, or if
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage "my-todo-project",
-  #                            "/path/to/keyfile.json"
+  #   gcloud = Gcloud.new "my-todo-project",
+  #                       "/path/to/keyfile.json"
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
@@ -92,26 +93,29 @@ module Gcloud
   # and control access to your data. Each bucket has a unique name, which is how
   # they are retrieved: (See Project#bucket)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #
   # You can also retrieve all buckets on a project: (See Project#buckets)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   all_buckets = storage.buckets
   #
   # If you have a significant number of buckets, you may need to paginate
   # through them: (See Bucket::List#token)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   all_buckets = []
   #   tmp_buckets = storage.buckets
@@ -130,9 +134,10 @@ module Gcloud
   # A unique name is all that is needed to create a new bucket:
   # (See Project#create_bucket)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.create_bucket "my-todo-app-attachments"
   #
@@ -146,27 +151,30 @@ module Gcloud
   # Files are retrieved by their name, which is the path of the file in the
   # bucket: (See Bucket#file)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.file "avatars/heidi/400x400.png"
   #
   # You can also retrieve all files in a bucket: (See Bucket#files)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   all_files = bucket.files
   #
   # Or you can retrieve all files in a specified path:
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   avatar_files = bucket.files prefix: "avatars/"
@@ -174,9 +182,10 @@ module Gcloud
   # If you have a significant number of files, you may need to paginate through
   # them: (See File::List#token)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #
@@ -198,9 +207,10 @@ module Gcloud
   # file system, and the name/path that the file should be stored in the bucket.
   # (See Bucket#create_file)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
@@ -210,9 +220,10 @@ module Gcloud
   #
   # Files can be downloaded to the local file system. (See File#download)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.file "avatars/heidi/400x400.png"
@@ -224,9 +235,10 @@ module Gcloud
   # period of time. This URL uses a cryptographic signature
   # of your credentials to access the file. (See File#signed_url)
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.file "avatars/heidi/400x400.png"
@@ -245,9 +257,10 @@ module Gcloud
   # Access to a bucket can be granted to a user by appending +"user-"+ to the
   # email address:
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #
@@ -257,9 +270,10 @@ module Gcloud
   # Access to a bucket can be granted to a group by appending +"group-"+ to the
   # email address:
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #
@@ -268,9 +282,10 @@ module Gcloud
   #
   # Access to a bucket can also be granted to a predefined list of permissions:
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #
@@ -285,9 +300,10 @@ module Gcloud
   # Access to a file can be granted to a user by appending +"user-"+ to the
   # email address:
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.file "avatars/heidi/400x400.png"
@@ -298,9 +314,10 @@ module Gcloud
   # Access to a file can be granted to a group by appending +"group-"+ to the
   # email address:
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.file "avatars/heidi/400x400.png"
@@ -310,9 +327,10 @@ module Gcloud
   #
   # Access to a file can also be granted to a predefined list of permissions:
   #
-  #   require "gcloud/storage"
+  #   require "gcloud"
   #
-  #   storage = Gcloud.storage
+  #   gcloud = Gcloud.new
+  #   storage = gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.file "avatars/heidi/400x400.png"

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -24,9 +24,10 @@ module Gcloud
     #
     # Represents a Storage bucket. Belongs to a Project and has many Files.
     #
-    #   require "gcloud/storage"
+    #   require "gcloud"
     #
-    #   storage = Gcloud.storage
+    #   gcloud = Gcloud.new
+    #   storage = gcloud.storage
     #
     #   bucket = storage.bucket "my-bucket"
     #   file = bucket.file "path/to/my-file.ext"
@@ -107,9 +108,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #   bucket.delete
@@ -118,9 +120,10 @@ module Gcloud
       # conditions. See Gcloud::Backoff to control this behavior, or
       # specify the wanted behavior in the call:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #   bucket.delete retries: 5
@@ -167,9 +170,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #   files = bucket.files
@@ -180,9 +184,10 @@ module Gcloud
       # If you have a significant number of files, you may need to paginate
       # through them: (See File::List#token)
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -223,9 +228,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -279,9 +285,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -289,9 +296,10 @@ module Gcloud
       #
       # Additionally, a destination path can be specified.
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -304,9 +312,10 @@ module Gcloud
       # by 265KB then it will be lowered to the nearest acceptible
       # value.
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -346,9 +355,10 @@ module Gcloud
       # Access to a bucket can be granted to a user by appending +"user-"+ to
       # the email address:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #
@@ -358,9 +368,10 @@ module Gcloud
       # Access to a bucket can be granted to a group by appending +"group-"+ to
       # the email address:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #
@@ -370,9 +381,10 @@ module Gcloud
       # Access to a bucket can also be granted to a predefined list of
       # permissions:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #
@@ -398,9 +410,10 @@ module Gcloud
       # Access to a bucket's files can be granted to a user by appending
       # +"user-"+ to the email address:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #
@@ -410,9 +423,10 @@ module Gcloud
       # Access to a bucket's files can be granted to a group by appending
       # +"group-"+ to the email address:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #
@@ -422,9 +436,10 @@ module Gcloud
       # Access to a bucket's files can also be granted to a predefined list of
       # permissions:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -21,9 +21,10 @@ module Gcloud
       #
       # Represents a Bucket's Access Control List.
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -61,9 +62,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -86,9 +88,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -108,9 +111,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -130,9 +134,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -166,9 +171,10 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -178,9 +184,10 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -220,9 +227,10 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -232,9 +240,10 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -274,9 +283,10 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -286,9 +296,10 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -325,9 +336,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -357,9 +369,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -379,9 +392,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -397,9 +411,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -416,9 +431,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -435,9 +451,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -469,9 +486,10 @@ module Gcloud
       #
       # Represents a Bucket's Default Access Control List.
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -510,9 +528,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -535,9 +554,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -557,9 +577,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -579,9 +600,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -615,9 +637,10 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -627,9 +650,10 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -669,9 +693,10 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -681,9 +706,10 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -723,9 +749,10 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -735,9 +762,10 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -775,9 +803,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -807,9 +836,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -829,9 +859,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -848,9 +879,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -867,9 +899,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -885,9 +918,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -904,9 +938,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -24,9 +24,10 @@ module Gcloud
     #
     # Represents the File/Object that belong to a Bucket.
     #
-    #   require "gcloud/storage"
+    #   require "gcloud"
     #
-    #   storage = Gcloud.storage
+    #   gcloud = Gcloud.new
+    #   storage = gcloud.storage
     #
     #   bucket = storage.bucket "my-bucket"
     #
@@ -155,9 +156,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -167,9 +169,10 @@ module Gcloud
       # The download is verified by calculating the MD5 digest.
       # The CRC32c digest can be used by passing :crc32c.
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -178,9 +181,10 @@ module Gcloud
       #
       # Both the MD5 and CRC32c digest can be used by passing :all.
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -189,9 +193,10 @@ module Gcloud
       #
       # The download verification can be disabled by passing :none
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -250,9 +255,10 @@ module Gcloud
       #
       # The file can also be copied to a new path in the current bucket:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -261,9 +267,10 @@ module Gcloud
       #
       # The file can also be copied to a different bucket:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -294,9 +301,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -354,9 +362,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.file "avatars/heidi/400x400.png"
@@ -364,9 +373,10 @@ module Gcloud
       #
       # Any of the option parameters may be specified:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.file "avatars/heidi/400x400.png"
@@ -411,9 +421,10 @@ module Gcloud
       # Access to a file can be granted to a user by appending +"user-"+ to the
       # email address:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.file "avatars/heidi/400x400.png"
@@ -424,9 +435,10 @@ module Gcloud
       # Access to a file can be granted to a group by appending +"group-"+ to
       # the email address:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.file "avatars/heidi/400x400.png"
@@ -437,9 +449,10 @@ module Gcloud
       # Access to a file can also be granted to a predefined list of
       # permissions:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.file "avatars/heidi/400x400.png"

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -21,9 +21,10 @@ module Gcloud
       #
       # Represents a File's Access Control List.
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #
@@ -64,9 +65,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -90,9 +92,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -113,9 +116,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -136,9 +140,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -179,9 +184,10 @@ module Gcloud
         # Access to a file can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -192,9 +198,10 @@ module Gcloud
         # Access to a file can be granted to a group by appending +"group-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -242,9 +249,10 @@ module Gcloud
         # Access to a file can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -255,9 +263,10 @@ module Gcloud
         # Access to a file can be granted to a group by appending +"group-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -305,9 +314,10 @@ module Gcloud
         # Access to a file can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -318,9 +328,10 @@ module Gcloud
         # Access to a file can be granted to a group by appending +"group-"+ to
         # the email address:
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -365,9 +376,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -398,9 +410,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -421,9 +434,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -441,9 +455,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -461,9 +476,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -480,9 +496,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #
@@ -500,9 +517,10 @@ module Gcloud
         #
         # === Example
         #
-        #   require "gcloud/storage"
+        #   require "gcloud"
         #
-        #   storage = Gcloud.storage
+        #   gcloud = Gcloud.new
+        #   storage = gcloud.storage
         #
         #   bucket = storage.bucket "my-bucket"
         #

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -33,14 +33,15 @@ module Gcloud
     # Google Storage. Gcloud::Storage::Bucket objects are created,
     # read, updated, and deleted by Gcloud::Storage::Project.
     #
-    #   require "gcloud/storage"
+    #   require "gcloud"
     #
-    #   storage = Gcloud.storage
+    #   gcloud = Gcloud.new
+    #   storage = gcloud.storage
     #
     #   bucket = storage.bucket "my-bucket"
     #   file = bucket.file "path/to/my-file.ext"
     #
-    # See Gcloud.storage
+    # See Gcloud#storage
     class Project
       ##
       # The Connection object.
@@ -49,7 +50,7 @@ module Gcloud
       ##
       # Creates a new Project instance.
       #
-      # See Gcloud.storage
+      # See Gcloud#storage
       def initialize project, credentials #:nodoc:
         @connection = Connection.new project, credentials
       end
@@ -59,10 +60,11 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage "my-todo-project",
-      #                            "/path/to/keyfile.json"
+      #   gcloud = Gcloud.new "my-todo-project",
+      #                       "/path/to/keyfile.json"
+      #   storage = gcloud.storage
       #
       #   storage.project #=> "my-todo-project"
       #
@@ -98,9 +100,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   buckets = storage.buckets
       #   buckets.each do |bucket|
@@ -110,18 +113,20 @@ module Gcloud
       # You can also retrieve all buckets whose names begin with a prefix using
       # the +:prefix+ option:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   user_buckets = storage.buckets prefix: "user-"
       #
       # If you have a significant number of buckets, you may need to paginate
       # through them: (See Bucket::List#token)
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   all_buckets = []
       #   tmp_buckets = storage.buckets
@@ -159,9 +164,10 @@ module Gcloud
       #
       # === Example
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.bucket "my-bucket"
       #   puts bucket.name
@@ -196,9 +202,10 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.create_bucket "my-bucket"
       #
@@ -206,9 +213,10 @@ module Gcloud
       # conditions. See Gcloud::Backoff to control this behavior, or
       # specify the wanted behavior in the call with the +:retries:+ option:
       #
-      #   require "gcloud/storage"
+      #   require "gcloud"
       #
-      #   storage = Gcloud.storage
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
       #
       #   bucket = storage.create_bucket "my-bucket", retries: 5
       #

--- a/rakelib/console.rake
+++ b/rakelib/console.rake
@@ -21,7 +21,7 @@ task :console do
   $:.unshift lib unless $:.include?(lib)
 
   require "gcloud"
-  require "gcloud/datastore"
+  def gcloud; @gcloud ||= Gcloud.new; end
 
   ARGV.clear
   IRB.start

--- a/test/gcloud/test_gcloud.rb
+++ b/test/gcloud/test_gcloud.rb
@@ -1,0 +1,68 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "gcloud/datastore"
+require "gcloud/storage"
+require "gcloud/pubsub"
+
+describe Gcloud do
+  it "calls out to Gcloud.datastore" do
+    gcloud = Gcloud.new
+    Gcloud.stub :datastore, "datastore-project-object" do
+      dataset = gcloud.datastore
+      dataset.must_equal "datastore-project-object"
+    end
+  end
+
+  it "passes project and keyfile to Gcloud.datastore" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    Gcloud.stub :datastore, "datastore-project-object", ["project-id", "keyfile-path"] do
+      dataset = gcloud.datastore
+      dataset.must_equal "datastore-project-object"
+    end
+  end
+
+  it "calls out to Gcloud.storage" do
+    gcloud = Gcloud.new
+    Gcloud.stub :storage, "storage-project-object" do
+      dataset = gcloud.storage
+      dataset.must_equal "storage-project-object"
+    end
+  end
+
+  it "passes project and keyfile to Gcloud.storage" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    Gcloud.stub :storage, "storage-project-object", ["project-id", "keyfile-path"] do
+      dataset = gcloud.storage
+      dataset.must_equal "storage-project-object"
+    end
+  end
+
+  it "calls out to Gcloud.pubsub" do
+    gcloud = Gcloud.new
+    Gcloud.stub :pubsub, "pubsub-project-object" do
+      dataset = gcloud.pubsub
+      dataset.must_equal "pubsub-project-object"
+    end
+  end
+
+  it "passes project and keyfile to Gcloud.pubsub" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    Gcloud.stub :pubsub, "pubsub-project-object", ["project-id", "keyfile-path"] do
+      dataset = gcloud.pubsub
+      dataset.must_equal "pubsub-project-object"
+    end
+  end
+end

--- a/test/gcloud/test_version.rb
+++ b/test/gcloud/test_version.rb
@@ -1,7 +1,20 @@
-require "helper"
-require "gcloud"
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-describe Gcloud do
+require "helper"
+
+describe Gcloud, :version do
   it "has a version" do
     Gcloud::VERSION.wont_be :nil?
   end


### PR DESCRIPTION
Allows us to create a top level gcloud object instead of creating service objects on the modules/namespace. The top-level gcloud instance object creates service objects using the shared credentials.

Before:

```ruby
require "gcloud/datastore"
require "gcloud/storage"

datastore = Gcloud.datastore
entity = datastore.find "Task", 1234

storage = Gcloud.storage
bucket = storage.bucket "my-todos-bucket"
```

After:

```ruby
require "gcloud"

gcloud = Gcloud.new

datastore = gcloud.datastore
entity = datastore.find "Task", 1234

storage = gcloud.storage
bucket = storage.bucket "my-todos-bucket"
```
For now the various namespaces and requires still exist. This change is additive and optional.

Thoughts?

[refs #137]