### PR TITLE
Add Storage aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ require 'gcloud/storage'
 storage = Gcloud.storage "my-todo-project-id",
                          "/path/to/keyfile.json"
 
-bucket = storage.find_bucket "task-attachments"
+bucket = storage.bucket "task-attachments"
 
 file = bucket.find_file "path/to/my-file.ext"
 
@@ -79,7 +79,7 @@ file = bucket.find_file "path/to/my-file.ext"
 file.download "/tasks/attachments/#{file.name}"
 
 # Copy the file to a backup bucket
-backup = storage.find_bucket "task-attachment-backups"
+backup = storage.bucket "task-attachment-backups"
 file.copy backup, file.name
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ storage = Gcloud.storage "my-todo-project-id",
 
 bucket = storage.bucket "task-attachments"
 
-file = bucket.find_file "path/to/my-file.ext"
+file = bucket.file "path/to/my-file.ext"
 
 # Download the file to the local file system
 file.download "/tasks/attachments/#{file.name}"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -124,7 +124,7 @@ storage = Gcloud.storage "my-todo-project-id",
 
 bucket = storage.bucket "task-attachments"
 
-file = bucket.find_file "path/to/my-file.ext"
+file = bucket.file "path/to/my-file.ext"
 
 # Download the file to the local file system
 file.download "/tasks/attachments/#{file.name}"

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -122,7 +122,7 @@ require 'gcloud/storage'
 storage = Gcloud.storage "my-todo-project-id",
                          "/path/to/keyfile.json"
 
-bucket = storage.find_bucket "task-attachments"
+bucket = storage.bucket "task-attachments"
 
 file = bucket.find_file "path/to/my-file.ext"
 
@@ -130,6 +130,6 @@ file = bucket.find_file "path/to/my-file.ext"
 file.download "/tasks/attachments/#{file.name}"
 
 # Copy the file to a backup bucket
-backup = storage.find_bucket "task-attachment-backups"
+backup = storage.bucket "task-attachment-backups"
 file.copy backup, file.name
 ```

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -44,7 +44,7 @@ module Gcloud
   #                            "/path/to/keyfile.json"
   #
   #   bucket = storage.bucket "my-bucket"
-  #   file = bucket.find_file "path/to/my-file.ext"
+  #   file = bucket.file "path/to/my-file.ext"
   #
   def self.storage project = nil, keyfile = nil
     project ||= Gcloud::Storage::Project.default_project
@@ -76,7 +76,7 @@ module Gcloud
   #                            "/path/to/keyfile.json"
   #
   #   bucket = storage.bucket "my-bucket"
-  #   file = bucket.find_file "path/to/my-file.ext"
+  #   file = bucket.file "path/to/my-file.ext"
   #
   # To learn more about Datastore, read the
   # {Google Cloud Storage Overview
@@ -141,14 +141,14 @@ module Gcloud
   # no limit on the number of objects that you can create in a bucket.
   #
   # Files are retrieved by their name, which is the path of the file in the
-  # bucket: (See Bucket#find_file)
+  # bucket: (See Bucket#file)
   #
   #   require "gcloud/storage"
   #
   #   storage = Gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.find_file "avatars/heidi/400x400.png"
+  #   file = bucket.file "avatars/heidi/400x400.png"
   #
   # You can also retrieve all files in a bucket: (See Bucket#files)
   #
@@ -212,7 +212,7 @@ module Gcloud
   #   storage = Gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.find_file "avatars/heidi/400x400.png"
+  #   file = bucket.file "avatars/heidi/400x400.png"
   #   file.download "/var/todo-app/avatars/heidi/400x400.png"
   #
   # == Using Signed URLs
@@ -226,7 +226,7 @@ module Gcloud
   #   storage = Gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.find_file "avatars/heidi/400x400.png"
+  #   file = bucket.file "avatars/heidi/400x400.png"
   #   shared_url = file.signed_url method: "GET",
   #                                expires: 300 # 5 minutes from now
   #
@@ -287,7 +287,7 @@ module Gcloud
   #   storage = Gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.find_file "avatars/heidi/400x400.png"
+  #   file = bucket.file "avatars/heidi/400x400.png"
   #
   #   email = "heidi@example.net"
   #   file.acl.add_reader "user-#{email}"
@@ -300,7 +300,7 @@ module Gcloud
   #   storage = Gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.find_file "avatars/heidi/400x400.png"
+  #   file = bucket.file "avatars/heidi/400x400.png"
   #
   #   email = "authors@example.net"
   #   file.acl.add_reader "group-#{email}"
@@ -312,7 +312,7 @@ module Gcloud
   #   storage = Gcloud.storage
   #
   #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.find_file "avatars/heidi/400x400.png"
+  #   file = bucket.file "avatars/heidi/400x400.png"
   #
   #   file.acl.public!
   #

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -43,7 +43,7 @@ module Gcloud
   #   storage = Gcloud.storage "my-todo-project",
   #                            "/path/to/keyfile.json"
   #
-  #   bucket = storage.find_bucket "my-bucket"
+  #   bucket = storage.bucket "my-bucket"
   #   file = bucket.find_file "path/to/my-file.ext"
   #
   def self.storage project = nil, keyfile = nil
@@ -75,7 +75,7 @@ module Gcloud
   #   storage = Gcloud.storage "my-todo-project",
   #                            "/path/to/keyfile.json"
   #
-  #   bucket = storage.find_bucket "my-bucket"
+  #   bucket = storage.bucket "my-bucket"
   #   file = bucket.find_file "path/to/my-file.ext"
   #
   # To learn more about Datastore, read the
@@ -87,13 +87,13 @@ module Gcloud
   # A Bucket is the container for your data. There is no limit on the number of
   # buckets that you can create in a project. You can use buckets to organize
   # and control access to your data. Each bucket has a unique name, which is how
-  # they are retrieved: (See Project#find_bucket)
+  # they are retrieved: (See Project#bucket)
   #
   #   require "gcloud/storage"
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #
   # You can also retrieve all buckets on a project: (See Project#buckets)
   #
@@ -147,7 +147,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.find_file "avatars/heidi/400x400.png"
   #
   # You can also retrieve all files in a bucket: (See Bucket#files)
@@ -156,7 +156,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   all_files = bucket.files
   #
   # Or you can retrieve all files in a specified path:
@@ -165,7 +165,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   avatar_files = bucket.files prefix: "avatars/"
   #
   # If you have a significant number of files, you may need to paginate through
@@ -175,7 +175,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #
   #   all_files = []
   #   tmp_files = bucket.files
@@ -199,7 +199,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
   #                      "avatars/heidi/400x400.png"
   #
@@ -211,7 +211,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.find_file "avatars/heidi/400x400.png"
   #   file.download "/var/todo-app/avatars/heidi/400x400.png"
   #
@@ -225,7 +225,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.find_file "avatars/heidi/400x400.png"
   #   shared_url = file.signed_url method: "GET",
   #                                expires: 300 # 5 minutes from now
@@ -246,7 +246,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #
   #   email = "heidi@example.net"
   #   bucket.acl.add_reader "user-#{email}"
@@ -258,7 +258,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #
   #   email = "authors@example.net"
   #   bucket.acl.add_reader "group-#{email}"
@@ -269,7 +269,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #
   #   bucket.acl.public!
   #
@@ -286,7 +286,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.find_file "avatars/heidi/400x400.png"
   #
   #   email = "heidi@example.net"
@@ -299,7 +299,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.find_file "avatars/heidi/400x400.png"
   #
   #   email = "authors@example.net"
@@ -311,7 +311,7 @@ module Gcloud
   #
   #   storage = Gcloud.storage
   #
-  #   bucket = storage.find_bucket "my-todo-app"
+  #   bucket = storage.bucket "my-todo-app"
   #   file = bucket.find_file "avatars/heidi/400x400.png"
   #
   #   file.acl.public!

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -326,6 +326,8 @@ module Gcloud
           upload_multipart file, path, options
         end
       end
+      alias_method :upload_file, :create_file
+      alias_method :new_file, :create_file
 
       ##
       # The Bucket::Acl instance used to control access to the bucket.

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -29,7 +29,7 @@ module Gcloud
     #   storage = Gcloud.storage
     #
     #   bucket = storage.bucket "my-bucket"
-    #   file = bucket.find_file "path/to/my-file.ext"
+    #   file = bucket.file "path/to/my-file.ext"
     #
     class Bucket
       ##
@@ -228,10 +228,10 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   puts file.name
       #
-      def find_file path, options = {}
+      def file path, options = {}
         ensure_connection!
         resp = connection.get_file name, path, options
         if resp.success?
@@ -240,6 +240,7 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_file, :file
 
       ##
       # Create a new File object by providing a path to a local file to upload

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -207,6 +207,7 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_files, :files
 
       ##
       # Retrieves a file matching the path.

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -28,7 +28,7 @@ module Gcloud
     #
     #   storage = Gcloud.storage
     #
-    #   bucket = storage.find_bucket "my-bucket"
+    #   bucket = storage.bucket "my-bucket"
     #   file = bucket.find_file "path/to/my-file.ext"
     #
     class Bucket
@@ -111,7 +111,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #   bucket.delete
       #
       # The API call to delete the bucket may be retried under certain
@@ -122,7 +122,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #   bucket.delete retries: 5
       #
       def delete options = {}
@@ -171,7 +171,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #   files = bucket.files
       #   files.each do |file|
       #     puts file.name
@@ -184,7 +184,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   all_files = []
       #   tmp_files = bucket.files
@@ -226,7 +226,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   puts file.name
@@ -281,7 +281,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   bucket.create_file "path/to/local.file.ext"
       #
@@ -291,7 +291,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   bucket.create_file "path/to/local.file.ext",
       #                      "destination/path/file.ext"
@@ -306,7 +306,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   bucket.create_file "path/to/local.file.ext",
       #                      "destination/path/file.ext",
@@ -346,7 +346,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #
       #   email = "heidi@example.net"
       #   bucket.acl.add_reader "user-#{email}"
@@ -358,7 +358,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #
       #   email = "authors@example.net"
       #   bucket.acl.add_reader "group-#{email}"
@@ -370,7 +370,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #
       #   bucket.acl.public!
       #
@@ -398,7 +398,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #
       #   email = "heidi@example.net"
       #   bucket.default_acl.add_reader "user-#{email}"
@@ -410,7 +410,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #
       #   email = "authors@example.net"
       #   bucket.default_acl.add_reader "group-#{email}"
@@ -422,7 +422,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #
       #   bucket.default_acl.public!
       def default_acl

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -25,7 +25,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   bucket.acl.readers.each { |reader| puts reader }
       #
@@ -65,7 +65,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.refresh!
         #
@@ -90,7 +90,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.owners.each { |owner| puts owner }
         #
@@ -112,7 +112,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.writers.each { |writer| puts writer }
         #
@@ -134,7 +134,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.readers.each { |reader| puts reader }
         #
@@ -170,7 +170,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.acl.add_owner "user-#{email}"
@@ -182,7 +182,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "authors@example.net"
         #   bucket.acl.add_owner "group-#{email}"
@@ -224,7 +224,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.acl.add_writer "user-#{email}"
@@ -236,7 +236,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "authors@example.net"
         #   bucket.acl.add_writer "group-#{email}"
@@ -278,7 +278,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.acl.add_reader "user-#{email}"
@@ -290,7 +290,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "authors@example.net"
         #   bucket.acl.add_reader "group-#{email}"
@@ -329,7 +329,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.acl.delete "user-#{email}"
@@ -361,7 +361,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.auth!
         #
@@ -383,7 +383,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.private!
         #
@@ -401,7 +401,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.project_private!
         #
@@ -420,7 +420,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.public!
         #
@@ -439,7 +439,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.public_write!
         #
@@ -473,7 +473,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   bucket.default_acl.readers.each { |reader| puts reader }
       #
@@ -514,7 +514,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.default_acl.refresh!
         #
@@ -539,7 +539,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.default_acl.owners.each { |owner| puts owner }
         #
@@ -561,7 +561,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.default_acl.writers.each { |writer| puts writer }
         #
@@ -583,7 +583,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.default_acl.readers.each { |reader| puts reader }
         #
@@ -619,7 +619,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_owner "user-#{email}"
@@ -631,7 +631,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "authors@example.net"
         #   bucket.default_acl.add_owner "group-#{email}"
@@ -673,7 +673,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_writer "user-#{email}"
@@ -685,7 +685,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "authors@example.net"
         #   bucket.default_acl.add_writer "group-#{email}"
@@ -727,7 +727,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_reader "user-#{email}"
@@ -739,7 +739,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "authors@example.net"
         #   bucket.default_acl.add_reader "group-#{email}"
@@ -779,7 +779,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   email = "heidi@example.net"
         #   bucket.default_acl.delete "user-#{email}"
@@ -811,7 +811,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.auth!
         #
@@ -833,7 +833,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.owner_full!
         #
@@ -852,7 +852,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.owner_read!
         #
@@ -871,7 +871,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.private!
         #
@@ -889,7 +889,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.project_private!
         #
@@ -908,7 +908,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   bucket.acl.public!
         #

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -28,7 +28,7 @@ module Gcloud
     #
     #   storage = Gcloud.storage
     #
-    #   bucket = storage.find_bucket "my-bucket"
+    #   bucket = storage.bucket "my-bucket"
     #
     #   file = bucket.find_file "path/to/my-file.ext"
     #   file.download "/downloads/#{bucket.name}/#{file.name}"
@@ -159,7 +159,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext"
@@ -171,7 +171,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :crc32c
@@ -182,7 +182,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :all
@@ -193,7 +193,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :none
@@ -254,7 +254,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.copy "path/to/destination/file.ext"
@@ -265,7 +265,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.copy "new-destination-bucket",
@@ -298,7 +298,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.delete
@@ -346,7 +346,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.find_file "avatars/heidi/400x400.png"
       #   shared_url = file.signed_url
       #
@@ -356,7 +356,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.find_file "avatars/heidi/400x400.png"
       #   shared_url = file.signed_url method: "GET",
       #                                expires: 300 # 5 minutes from now
@@ -386,7 +386,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.find_file "avatars/heidi/400x400.png"
       #
       #   email = "heidi@example.net"
@@ -399,7 +399,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.find_file "avatars/heidi/400x400.png"
       #
       #   email = "authors@example.net"
@@ -412,7 +412,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-todo-app"
+      #   bucket = storage.bucket "my-todo-app"
       #   file = bucket.find_file "avatars/heidi/400x400.png"
       #
       #   file.acl.public!

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -30,7 +30,7 @@ module Gcloud
     #
     #   bucket = storage.bucket "my-bucket"
     #
-    #   file = bucket.find_file "path/to/my-file.ext"
+    #   file = bucket.file "path/to/my-file.ext"
     #   file.download "/downloads/#{bucket.name}/#{file.name}"
     #
     class File
@@ -161,7 +161,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext"
       #
       # The download is verified by calculating the MD5 digest.
@@ -173,7 +173,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :crc32c
       #
       # Both the MD5 and CRC32c digest can be used by passing :all.
@@ -184,7 +184,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :all
       #
       # The download verification can be disabled by passing :none
@@ -195,7 +195,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :none
       #
       def download path, options = {}
@@ -256,7 +256,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.copy "path/to/destination/file.ext"
       #
       # The file can also be copied to a different bucket:
@@ -267,7 +267,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.copy "new-destination-bucket",
       #             "path/to/destination/file.ext"
       #
@@ -300,7 +300,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.delete
       #
       def delete
@@ -347,7 +347,7 @@ module Gcloud
       #   storage = Gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
-      #   file = bucket.find_file "avatars/heidi/400x400.png"
+      #   file = bucket.file "avatars/heidi/400x400.png"
       #   shared_url = file.signed_url
       #
       # Any of the option parameters may be specified:
@@ -357,7 +357,7 @@ module Gcloud
       #   storage = Gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
-      #   file = bucket.find_file "avatars/heidi/400x400.png"
+      #   file = bucket.file "avatars/heidi/400x400.png"
       #   shared_url = file.signed_url method: "GET",
       #                                expires: 300 # 5 minutes from now
       #
@@ -387,7 +387,7 @@ module Gcloud
       #   storage = Gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
-      #   file = bucket.find_file "avatars/heidi/400x400.png"
+      #   file = bucket.file "avatars/heidi/400x400.png"
       #
       #   email = "heidi@example.net"
       #   file.acl.add_reader "user-#{email}"
@@ -400,7 +400,7 @@ module Gcloud
       #   storage = Gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
-      #   file = bucket.find_file "avatars/heidi/400x400.png"
+      #   file = bucket.file "avatars/heidi/400x400.png"
       #
       #   email = "authors@example.net"
       #   file.acl.add_reader "group-#{email}"
@@ -413,7 +413,7 @@ module Gcloud
       #   storage = Gcloud.storage
       #
       #   bucket = storage.bucket "my-todo-app"
-      #   file = bucket.find_file "avatars/heidi/400x400.png"
+      #   file = bucket.file "avatars/heidi/400x400.png"
       #
       #   file.acl.public!
       #

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -27,7 +27,7 @@ module Gcloud
       #
       #   bucket = storage.bucket "my-bucket"
       #
-      #   file = bucket.find_file "path/to/my-file.ext"
+      #   file = bucket.file "path/to/my-file.ext"
       #   file.acl.readers.each { |reader| puts reader }
       #
       class Acl
@@ -70,7 +70,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.refresh!
         #
         def refresh!
@@ -96,7 +96,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.owners.each { |owner| puts owner }
         #
         def owners
@@ -119,7 +119,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.writers.each { |writer| puts writer }
         #
         def writers
@@ -142,7 +142,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.readers.each { |reader| puts reader }
         #
         def readers
@@ -185,7 +185,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   email = "heidi@example.net"
         #   file.acl.add_owner "user-#{email}"
         #
@@ -198,7 +198,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   email = "authors@example.net"
         #   file.acl.add_owner "group-#{email}"
         #
@@ -248,7 +248,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   email = "heidi@example.net"
         #   file.acl.add_writer "user-#{email}"
         #
@@ -261,7 +261,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   email = "authors@example.net"
         #   file.acl.add_writer "group-#{email}"
         #
@@ -311,7 +311,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   email = "heidi@example.net"
         #   file.acl.add_reader "user-#{email}"
         #
@@ -324,7 +324,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   email = "authors@example.net"
         #   file.acl.add_reader "group-#{email}"
         #
@@ -371,7 +371,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   email = "heidi@example.net"
         #   file.acl.delete "user-#{email}"
         #
@@ -404,7 +404,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.auth!
         #
         def auth!
@@ -427,7 +427,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.owner_full!
         #
         def owner_full!
@@ -447,7 +447,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.owner_read!
         #
         def owner_read!
@@ -467,7 +467,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.private!
         #
         def private!
@@ -486,7 +486,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.project_private!
         #
         def project_private!
@@ -506,7 +506,7 @@ module Gcloud
         #
         #   bucket = storage.bucket "my-bucket"
         #
-        #   file = bucket.find_file "path/to/my-file.ext"
+        #   file = bucket.file "path/to/my-file.ext"
         #   file.acl.public!
         #
         def public!

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -25,7 +25,7 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #
       #   file = bucket.find_file "path/to/my-file.ext"
       #   file.acl.readers.each { |reader| puts reader }
@@ -68,7 +68,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.refresh!
@@ -94,7 +94,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.owners.each { |owner| puts owner }
@@ -117,7 +117,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.writers.each { |writer| puts writer }
@@ -140,7 +140,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.readers.each { |reader| puts reader }
@@ -183,7 +183,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   email = "heidi@example.net"
@@ -196,7 +196,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   email = "authors@example.net"
@@ -246,7 +246,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   email = "heidi@example.net"
@@ -259,7 +259,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   email = "authors@example.net"
@@ -309,7 +309,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   email = "heidi@example.net"
@@ -322,7 +322,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   email = "authors@example.net"
@@ -369,7 +369,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   email = "heidi@example.net"
@@ -402,7 +402,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.auth!
@@ -425,7 +425,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.owner_full!
@@ -445,7 +445,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.owner_read!
@@ -465,7 +465,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.private!
@@ -484,7 +484,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.project_private!
@@ -504,7 +504,7 @@ module Gcloud
         #
         #   storage = Gcloud.storage
         #
-        #   bucket = storage.find_bucket "my-bucket"
+        #   bucket = storage.bucket "my-bucket"
         #
         #   file = bucket.find_file "path/to/my-file.ext"
         #   file.acl.public!

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -37,7 +37,7 @@ module Gcloud
     #
     #   storage = Gcloud.storage
     #
-    #   bucket = storage.find_bucket "my-bucket"
+    #   bucket = storage.bucket "my-bucket"
     #   file = bucket.find_file "path/to/my-file.ext"
     #
     # See Gcloud.storage
@@ -162,10 +162,10 @@ module Gcloud
       #
       #   storage = Gcloud.storage
       #
-      #   bucket = storage.find_bucket "my-bucket"
+      #   bucket = storage.bucket "my-bucket"
       #   puts bucket.name
       #
-      def find_bucket bucket_name
+      def bucket bucket_name
         resp = connection.get_bucket bucket_name
         if resp.success?
           Bucket.from_gapi resp.data, connection
@@ -174,6 +174,7 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_bucket, :bucket
 
       ##
       # Creates a new bucket.

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -143,6 +143,7 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_buckets, :buckets
 
       ##
       # Retrieves bucket by name.

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -38,7 +38,7 @@ module Gcloud
     #   storage = Gcloud.storage
     #
     #   bucket = storage.bucket "my-bucket"
-    #   file = bucket.find_file "path/to/my-file.ext"
+    #   file = bucket.file "path/to/my-file.ext"
     #
     # See Gcloud.storage
     class Project

--- a/regression/storage/test_storage.rb
+++ b/regression/storage/test_storage.rb
@@ -19,7 +19,7 @@ require "net/http"
 
 describe "Storage", :storage do
   let :bucket do
-    storage.find_bucket(bucket_name) ||
+    storage.bucket(bucket_name) ||
     storage.create_bucket(bucket_name)
   end
   let(:bucket_name) { $bucket_names.first }
@@ -41,7 +41,7 @@ describe "Storage", :storage do
   describe "getting buckets" do
     let(:new_buckets) do
       new_bucket_names.map do |b|
-        storage.find_bucket(b) ||
+        storage.bucket(b) ||
         storage.create_bucket(b)
       end
     end

--- a/regression/storage_helper.rb
+++ b/regression/storage_helper.rb
@@ -75,7 +75,7 @@ $bucket_names = 4.times.map { "gcloud-ruby-regression-#{t}-#{SecureRandom.hex(4)
 def clean_up_storage_buckets
   puts "Cleaning up storage buckets after tests."
   $bucket_names.each do |bucket_name|
-    if b = $storage.find_bucket(bucket_name)
+    if b = $storage.bucket(bucket_name)
       b.files.map { |f| f.delete }
       b.delete
     end

--- a/test/gcloud/storage/test_bucket.rb
+++ b/test/gcloud/storage/test_bucket.rb
@@ -151,6 +151,17 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     files.size.must_equal num_files
   end
 
+  it "lists files with find_files alias" do
+    num_files = 3
+    mock_connection.get "/storage/v1/b/#{bucket.name}/o" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       list_files_json(num_files)]
+    end
+
+    files = bucket.find_files
+    files.size.must_equal num_files
+  end
+
   it "paginates files" do
     mock_connection.get "/storage/v1/b/#{bucket.name}/o" do |env|
       env.params.wont_include "pageToken"

--- a/test/gcloud/storage/test_bucket.rb
+++ b/test/gcloud/storage/test_bucket.rb
@@ -43,6 +43,34 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     end
   end
 
+  it "creates a file with upload_file alias" do
+    new_file_name = random_file_path
+
+    mock_connection.post "/upload/storage/v1/b/#{bucket.name}/o" do |env|
+      env.params.wont_include "predefinedAcl"
+      [200, {"Content-Type"=>"application/json"},
+       create_file_json(bucket.name, new_file_name)]
+    end
+
+    Tempfile.open "gcloud-ruby" do |tmpfile|
+      bucket.upload_file tmpfile, new_file_name
+    end
+  end
+
+  it "creates a file with new_file alias" do
+    new_file_name = random_file_path
+
+    mock_connection.post "/upload/storage/v1/b/#{bucket.name}/o" do |env|
+      env.params.wont_include "predefinedAcl"
+      [200, {"Content-Type"=>"application/json"},
+       create_file_json(bucket.name, new_file_name)]
+    end
+
+    Tempfile.open "gcloud-ruby" do |tmpfile|
+      bucket.new_file tmpfile, new_file_name
+    end
+  end
+
   it "creates a file with predefined acl" do
     new_file_name = random_file_path
 

--- a/test/gcloud/storage/test_bucket.rb
+++ b/test/gcloud/storage/test_bucket.rb
@@ -259,7 +259,20 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     mock_connection.get "/storage/v1/b/#{bucket.name}/o/#{file_name}" do |env|
       URI(env.url).query.must_be :nil?
       [200, {"Content-Type"=>"application/json"},
-       create_file_json(bucket.name, file_name)]
+       find_file_json(bucket.name, file_name)]
+    end
+
+    file = bucket.file file_name
+    file.name.must_equal file_name
+  end
+
+  it "finds a file with find_file alias" do
+    file_name = "file.ext"
+
+    mock_connection.get "/storage/v1/b/#{bucket.name}/o/#{file_name}" do |env|
+      URI(env.url).query.must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       find_file_json(bucket.name, file_name)]
     end
 
     file = bucket.find_file file_name
@@ -273,10 +286,10 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     mock_connection.get "/storage/v1/b/#{bucket.name}/o/#{file_name}" do |env|
       URI(env.url).query.must_equal "generation=#{generation}"
       [200, {"Content-Type"=>"application/json"},
-       create_file_json(bucket.name, file_name)]
+       find_file_json(bucket.name, file_name)]
     end
 
-    file = bucket.find_file file_name, generation: generation
+    file = bucket.file file_name, generation: generation
     file.name.must_equal file_name
   end
 

--- a/test/gcloud/storage/test_bucket_acl.rb
+++ b/test/gcloud/storage/test_bucket_acl.rb
@@ -34,7 +34,7 @@ describe Gcloud::Storage::Bucket, :acl, :mock_storage do
        random_bucket_acl_hash(bucket_name).to_json]
     end
 
-    bucket = storage.find_bucket bucket_name
+    bucket = storage.bucket bucket_name
     bucket.name.must_equal bucket_name
     bucket.acl.owners.wont_be  :empty?
     bucket.acl.writers.must_be :empty?
@@ -54,7 +54,7 @@ describe Gcloud::Storage::Bucket, :acl, :mock_storage do
        random_bucket_acl_hash(bucket_name).to_json]
     end
 
-    bucket = storage.find_bucket bucket_name
+    bucket = storage.bucket bucket_name
     bucket.name.must_equal bucket_name
     bucket.acl.owners.wont_be  :empty?
     bucket.acl.writers.must_be :empty?
@@ -97,7 +97,7 @@ describe Gcloud::Storage::Bucket, :acl, :mock_storage do
        random_bucket_acl_hash(bucket_name).to_json]
     end
 
-    bucket = storage.find_bucket bucket_name
+    bucket = storage.bucket bucket_name
     bucket.name.must_equal bucket_name
     bucket.acl.owners.wont_be  :empty?
     bucket.acl.writers.must_be :empty?

--- a/test/gcloud/storage/test_default_acl.rb
+++ b/test/gcloud/storage/test_default_acl.rb
@@ -34,7 +34,7 @@ describe Gcloud::Storage::Bucket, :default_acl, :mock_storage do
        random_default_acl_hash(bucket_name).to_json]
     end
 
-    bucket = storage.find_bucket bucket_name
+    bucket = storage.bucket bucket_name
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.writers.must_be :empty?
@@ -54,7 +54,7 @@ describe Gcloud::Storage::Bucket, :default_acl, :mock_storage do
        random_default_acl_hash(bucket_name).to_json]
     end
 
-    bucket = storage.find_bucket bucket_name
+    bucket = storage.bucket bucket_name
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.writers.must_be :empty?
@@ -97,7 +97,7 @@ describe Gcloud::Storage::Bucket, :default_acl, :mock_storage do
        random_default_acl_hash(bucket_name).to_json]
     end
 
-    bucket = storage.find_bucket bucket_name
+    bucket = storage.bucket bucket_name
     bucket.name.must_equal bucket_name
     bucket.default_acl.owners.wont_be  :empty?
     bucket.default_acl.writers.must_be :empty?

--- a/test/gcloud/storage/test_file_acl.rb
+++ b/test/gcloud/storage/test_file_acl.rb
@@ -39,7 +39,7 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
        random_file_acl_hash(bucket_name, file_name).to_json]
     end
 
-    file = bucket.find_file file_name
+    file = bucket.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.writers.must_be :empty?
@@ -57,7 +57,7 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
        random_file_acl_hash(bucket_name, file_name).to_json]
     end
 
-    file = bucket.find_file file_name
+    file = bucket.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.writers.must_be :empty?
@@ -103,7 +103,7 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
        random_file_acl_hash(bucket_name, file_name).to_json]
     end
 
-    file = bucket.find_file file_name
+    file = bucket.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.writers.must_be :empty?
@@ -147,7 +147,7 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
        random_file_acl_hash(bucket_name, file_name).to_json]
     end
 
-    file = bucket.find_file file_name
+    file = bucket.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.writers.must_be :empty?
@@ -180,7 +180,7 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
        random_file_acl_hash(bucket_name, file_name).to_json]
     end
 
-    file = bucket.find_file file_name
+    file = bucket.file file_name
     file.name.must_equal file_name
     file.acl.owners.wont_be  :empty?
     file.acl.writers.must_be :empty?

--- a/test/gcloud/storage/test_project.rb
+++ b/test/gcloud/storage/test_project.rb
@@ -101,6 +101,17 @@ describe Gcloud::Storage::Project, :mock_storage do
     buckets.size.must_equal num_buckets
   end
 
+  it "lists buckets with find_buckets alias" do
+    num_buckets = 3
+    mock_connection.get "/storage/v1/b?project=#{project}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       list_buckets_json(num_buckets)]
+    end
+
+    buckets = storage.find_buckets
+    buckets.size.must_equal num_buckets
+  end
+
   it "paginates buckets" do
     mock_connection.get "/storage/v1/b?project=#{project}" do |env|
       env.params.wont_include "pageToken"

--- a/test/gcloud/storage/test_project.rb
+++ b/test/gcloud/storage/test_project.rb
@@ -159,6 +159,18 @@ describe Gcloud::Storage::Project, :mock_storage do
        find_bucket_json(bucket_name)]
     end
 
+    bucket = storage.bucket bucket_name
+    bucket.name.must_equal bucket_name
+  end
+
+  it "finds a bucket with find_bucket alias" do
+    bucket_name = "found-bucket"
+
+    mock_connection.get "/storage/v1/b/#{bucket_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       find_bucket_json(bucket_name)]
+    end
+
     bucket = storage.find_bucket bucket_name
     bucket.name.must_equal bucket_name
   end


### PR DESCRIPTION
With this change, the code to get buckets and files is now:

```ruby
require 'gcloud/storage'

storage = Gcloud.storage
bucket = storage.bucket "task-attachments"
file = bucket.file "path/to/my-file.ext"
```

Where before it was:

```ruby
require 'gcloud/storage'

storage = Gcloud.storage
bucket = storage.find_bucket "task-attachments"
file = bucket.find_file "path/to/my-file.ext"
```

The before code still works, as the `find_` methods are aliased to the new names.