### PR TITLE
Add Pubsub aliases

### DIFF
--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -99,6 +99,8 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_topic, :topic
+      alias_method :get_topic, :topic
 
       ##
       # Creates a new topic.

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -130,6 +130,7 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :new_topic, :create_topic
 
       ##
       # Retrieves a list of topics for the given project.

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -189,6 +189,8 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_topics, :topics
+      alias_method :list_topics, :topics
 
       ##
       # Retrieves subscription by name.

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -286,6 +286,8 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_subscriptions, :subscriptions
+      alias_method :list_subscriptions, :subscriptions
 
       protected
 

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -223,6 +223,8 @@ module Gcloud
           nil
         end
       end
+      alias_method :find_subscription, :subscription
+      alias_method :get_subscription, :subscription
 
       ##
       # Retrieves a list of subscriptions for the given project.

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -137,7 +137,7 @@ module Gcloud
       #                         deadline: 120,
       #                         endpoint: "https://example.com/push"
       #
-      def create_subscription subscription_name = nil, options = {}
+      def subscribe subscription_name = nil, options = {}
         ensure_connection!
         resp = connection.create_subscription name, subscription_name, options
         if resp.success?
@@ -147,7 +147,8 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
-      alias_method :subscribe, :create_subscription
+      alias_method :create_subscription, :subscribe
+      alias_method :new_subscription, :subscribe
 
       ##
       # Retrieves a subscription by name.

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -181,6 +181,8 @@ module Gcloud
           nil
         end
       end
+      alias_method :find_subscription, :subscription
+      alias_method :get_subscription, :subscription
 
       ##
       # Retrieves a list of subscription names for the given project.

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -243,6 +243,8 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
+      alias_method :find_subscriptions, :subscriptions
+      alias_method :list_subscriptions, :subscriptions
 
       ##
       # Publishes one or more messages to the topic.

--- a/regression/pubsub/test_pubsub.rb
+++ b/regression/pubsub/test_pubsub.rb
@@ -23,7 +23,7 @@ describe Gcloud::Pubsub, :pubsub do
 
   def retrieve_subscription topic, subscription_name
     topic.subscription(subscription_name) ||
-    topic.create_subscription(subscription_name)
+    topic.subscribe(subscription_name)
   end
 
   let(:new_topic_name) {  $topic_names.first }
@@ -169,7 +169,6 @@ describe Gcloud::Pubsub, :pubsub do
     end
 
     it "should allow creation of a subscription" do
-      # subscription = topic.create_subscription "new-subscription"
       subscription = topic.subscribe "#{$topic_prefix}-sub3"
       subscription.wont_be :nil?
       subscription.must_be_kind_of Gcloud::Pubsub::Subscription

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -203,6 +203,32 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     end
   end
 
+  it "lists subscriptions with find_subscriptions alias" do
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscriptions_json("fake-topic", 3)]
+    end
+
+    subs = pubsub.find_subscriptions
+    subs.count.must_equal 3
+    subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
+  end
+
+  it "lists subscriptions with list_subscriptions alias" do
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscriptions_json("fake-topic", 3)]
+    end
+
+    subs = pubsub.list_subscriptions
+    subs.count.must_equal 3
+    subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
+  end
+
   it "paginates subscriptions" do
     mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -29,6 +29,16 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     pubsub.create_topic new_topic_name
   end
 
+  it "creates a topic with new_topic_alias" do
+    new_topic_name = "new-topic-#{Time.now.to_i}"
+    mock_connection.put "/v1beta2/projects/#{project}/topics/#{new_topic_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       topic_json(new_topic_name)]
+    end
+
+    pubsub.new_topic new_topic_name
+  end
+
   it "gets a topic" do
     topic_name = "found-topic"
     mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -73,6 +73,28 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     topics.size.must_equal num_topics
   end
 
+  it "lists topics with find_topics alias" do
+    num_topics = 3
+    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       topics_json(num_topics)]
+    end
+
+    topics = pubsub.find_topics
+    topics.size.must_equal num_topics
+  end
+
+  it "lists topics with list_topics alias" do
+    num_topics = 3
+    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       topics_json(num_topics)]
+    end
+
+    topics = pubsub.list_topics
+    topics.size.must_equal num_topics
+  end
+
   it "paginates topics" do
     mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
       [200, {"Content-Type"=>"application/json"},

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -40,6 +40,28 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     topic.name.must_equal topic_path(topic_name)
   end
 
+  it "gets a topic with find_topic alias" do
+    topic_name = "found-topic"
+    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       topic_json(topic_name)]
+    end
+
+    topic = pubsub.find_topic topic_name
+    topic.name.must_equal topic_path(topic_name)
+  end
+
+  it "gets a topic with get_topic alias" do
+    topic_name = "found-topic"
+    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       topic_json(topic_name)]
+    end
+
+    topic = pubsub.get_topic topic_name
+    topic.name.must_equal topic_path(topic_name)
+  end
+
   it "lists topics" do
     num_topics = 3
     mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -166,6 +166,30 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
   end
 
+  it "gets a subscription with find_subscription alias" do
+    sub_name = "found-sub-#{Time.now.to_i}"
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json("random-topic", sub_name)]
+    end
+
+    sub = pubsub.find_subscription sub_name
+    sub.wont_be :nil?
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+  end
+
+  it "gets a subscription with get_subscription alias" do
+    sub_name = "found-sub-#{Time.now.to_i}"
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json("random-topic", sub_name)]
+    end
+
+    sub = pubsub.get_subscription sub_name
+    sub.wont_be :nil?
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+  end
+
   it "lists subscriptions" do
     mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},

--- a/test/gcloud/pubsub/test_topic.rb
+++ b/test/gcloud/pubsub/test_topic.rb
@@ -202,6 +202,32 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     end
   end
 
+  it "lists subscriptions with find_subscriptions alias" do
+    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscriptions_json(topic_name, 3)]
+    end
+
+    subs = topic.find_subscriptions
+    subs.count.must_equal 3
+    subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
+  end
+
+  it "lists subscriptions with list_subscriptions alias" do
+    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscriptions_json(topic_name, 3)]
+    end
+
+    subs = topic.list_subscriptions
+    subs.count.must_equal 3
+    subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
+  end
+
   it "paginates subscriptions" do
     mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},

--- a/test/gcloud/pubsub/test_topic.rb
+++ b/test/gcloud/pubsub/test_topic.rb
@@ -39,7 +39,33 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
        subscription_json(topic_name, new_sub_name)]
     end
 
+    sub = topic.subscribe new_sub_name
+    sub.wont_be :nil?
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+  end
+
+  it "creates a subscription with create_subscription alias" do
+    new_sub_name = "new-sub-#{Time.now.to_i}"
+    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+      JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json(topic_name, new_sub_name)]
+    end
+
     sub = topic.create_subscription new_sub_name
+    sub.wont_be :nil?
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+  end
+
+  it "creates a subscription with new_subscription alias" do
+    new_sub_name = "new-sub-#{Time.now.to_i}"
+    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+      JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json(topic_name, new_sub_name)]
+    end
+
+    sub = topic.new_subscription new_sub_name
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
   end
@@ -52,7 +78,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
        subscription_json(topic_name, nil)]
     end
 
-    sub = topic.create_subscription
+    sub = topic.subscribe
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
   end
@@ -67,7 +93,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
        subscription_json(topic_name, new_sub_name)]
     end
 
-    sub = topic.create_subscription new_sub_name, deadline: deadline
+    sub = topic.subscribe new_sub_name, deadline: deadline
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
   end
@@ -82,7 +108,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
        subscription_json(topic_name, new_sub_name)]
     end
 
-    sub = topic.create_subscription new_sub_name, endpoint: endpoint
+    sub = topic.subscribe new_sub_name, endpoint: endpoint
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
   end
@@ -109,7 +135,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     end
 
     assert_raises Gcloud::Pubsub::AlreadyExistsError do
-      topic.create_subscription existing_sub_name
+      topic.subscribe existing_sub_name
     end
   end
 
@@ -123,7 +149,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
     assert_raises Gcloud::Pubsub::NotFoundError do
       # Let's assume the topic has been deleted before calling create.
-      topic.create_subscription new_sub_name
+      topic.subscribe new_sub_name
     end
   end
 

--- a/test/gcloud/pubsub/test_topic.rb
+++ b/test/gcloud/pubsub/test_topic.rb
@@ -165,6 +165,30 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
   end
 
+  it "gets a subscription with find_subscription alias" do
+    sub_name = "found-sub-#{Time.now.to_i}"
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json(topic_name, sub_name)]
+    end
+
+    sub = topic.find_subscription sub_name
+    sub.wont_be :nil?
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+  end
+
+  it "gets a subscription with get_subscription alias" do
+    sub_name = "found-sub-#{Time.now.to_i}"
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json(topic_name, sub_name)]
+    end
+
+    sub = topic.get_subscription sub_name
+    sub.wont_be :nil?
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+  end
+
   it "lists subscriptions" do
     mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},


### PR DESCRIPTION
Add some common aliases for pubsub methods. Add aliases for the API methods like `get` and `list`, as well as common names like `find` and `new`.