### PR TITLE
Add Lazy Pub/Sub Objects

### DIFF
--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -204,6 +204,19 @@ module Gcloud
         )
       end
 
+      def project_path
+        "projects/#{project}"
+      end
+
+      def topic_path topic_name
+        return topic_name if topic_name.include? "/"
+        "#{project_path}/topics/#{topic_name}"
+      end
+
+      def subscription_path subscription_name
+        "#{project_path}/subscriptions/#{subscription_name}"
+      end
+
       protected
 
       def subscription_data topic, options = {}
@@ -229,18 +242,6 @@ module Gcloud
         else
           Hash.try_convert(hash) || {}
         end
-      end
-
-      def project_path
-        "projects/#{project}"
-      end
-
-      def topic_path topic_name
-        "#{project_path}/topics/#{topic_name}"
-      end
-
-      def subscription_path subscription_name
-        "#{project_path}/subscriptions/#{subscription_name}"
       end
     end
   end

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -209,11 +209,12 @@ module Gcloud
       end
 
       def topic_path topic_name
-        return topic_name if topic_name.include? "/"
+        return topic_name if topic_name.to_s.include? "/"
         "#{project_path}/topics/#{topic_name}"
       end
 
       def subscription_path subscription_name
+        return subscription_name if subscription_name.to_s.include? "/"
         "#{project_path}/subscriptions/#{subscription_name}"
       end
 

--- a/lib/gcloud/pubsub/event.rb
+++ b/lib/gcloud/pubsub/event.rb
@@ -125,7 +125,7 @@ module Gcloud
         if resp.success?
           true
         else
-          ApiError.from_response(resp)
+          raise ApiError.from_response(resp)
         end
       end
 

--- a/lib/gcloud/pubsub/event.rb
+++ b/lib/gcloud/pubsub/event.rb
@@ -125,7 +125,7 @@ module Gcloud
         if resp.success?
           true
         else
-          raise ApiError.from_response(resp)
+          fail ApiError.from_response(resp)
         end
       end
 

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -246,6 +246,9 @@ module Gcloud
 
       ##
       # Retrieves subscription by name.
+      # This difference between this method and Project#get_subscription is
+      # that this method does not make an API call to Pub/Sub verify the
+      # subscription exists.
       #
       # === Parameters
       #
@@ -254,7 +257,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Gcloud::Pubsub::Subscription or nil if subscription does not exist
+      # Gcloud::Pubsub::Subscription
       #
       # === Example
       #
@@ -262,10 +265,37 @@ module Gcloud
       #
       #   pubsub = Gcloud.pubsub
       #
-      #   subscription = pubsub.subscription "my-topic-subscription"
+      #   subscription = pubsub.get_subscription "my-topic-subscription"
       #   puts subscription.name
       #
       def subscription subscription_name
+        ensure_connection!
+
+        Subscription.new_lazy subscription_name, connection
+      end
+
+      ##
+      # Retrieves subscription by name.
+      #
+      # === Parameters
+      #
+      # +subscription_name+::
+      #   Name of a subscription. (+String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Pubsub::Subscription or +nil+ if subscription does not exist
+      #
+      # === Example
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   subscription = pubsub.get_subscription "my-topic-subscription"
+      #   puts subscription.name
+      #
+      def get_subscription subscription_name
         ensure_connection!
         resp = connection.get_subscription subscription_name
         if resp.success?
@@ -274,8 +304,7 @@ module Gcloud
           nil
         end
       end
-      alias_method :find_subscription, :subscription
-      alias_method :get_subscription, :subscription
+      alias_method :find_subscription, :get_subscription
 
       ##
       # Retrieves a list of subscriptions for the given project.

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -87,9 +87,9 @@ module Gcloud
       #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
-      #   topic = pubsub.topic "my-topic"
+      #   topic = pubsub.get_topic "my-topic"
       #
-      def topic topic_name
+      def get_topic topic_name
         ensure_connection!
         resp = connection.get_topic topic_name
         if resp.success?
@@ -99,8 +99,59 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
-      alias_method :find_topic, :topic
-      alias_method :get_topic, :topic
+      alias_method :find_topic, :get_topic
+
+      ##
+      # Retrieves topic by name.
+      # This difference between this method and Project#get_topic is that this
+      # method does not make an API call to Pub/Sub verify the topic exists.
+      #
+      # === Parameters
+      #
+      # +topic_name+::
+      #   Name of a topic. (+String+)
+      # +options+::
+      #   An optional Hash for controlling additional behavor. (+Hash+)
+      # +options [:autocreate]+::
+      #   Flag to control whether the topic should be created when needed.
+      #   The default value is +true+. (+Boolean+)
+      #
+      # === Returns
+      #
+      # Gcloud::Pubsub::Topic
+      #
+      # === Examples
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #   topic = pubsub.topic "existing-topic"
+      #   msg = topic.publish "This is the first API call to Pub/Sub."
+      #
+      # By default the topic will be created in Pub/Sub when needed.
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #   topic = pubsub.topic "non-existing-topic"
+      #   msg = topic.publish "This will create the topic in Pub/Sub."
+      #
+      # Setting the autocomplete flag to false will not create the topic.
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #   topic = pubsub.topic "non-existing-topic"
+      #   msg = topic.publish "This raises." #=> Gcloud::Pubsub::NotFoundError
+      #
+      def topic topic_name, options = {}
+        ensure_connection!
+
+        autocreate = options[:autocreate]
+        autocreate = true if autocreate.nil?
+
+        Topic.new_lazy topic_name, connection, autocreate
+      end
 
       ##
       # Creates a new topic.

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -56,10 +56,25 @@ module Gcloud
       end
 
       ##
-      # The topic from which this subscription is receiving messages,
-      # in the form /topics/project-identifier/topic-name.
+      # The Topic from which this subscription is receiving messages.
+      #
+      # === Returns
+      #
+      # Topic
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   sub = pubsub.subscription "my-topic-sub"
+      #   sub.topic.name "projects/my-project/topics/my-topic"
+      #
       def topic
-        @gapi["topic"]
+        # Always disable autocreate, we don't want to recreate a topic that
+        # was intentionally deleted.
+        Topic.new_lazy @gapi["topic"], connection, false
       end
 
       ##

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -122,7 +122,7 @@ module Gcloud
         if resp.success?
           @gapi["pushConfig"]["pushEndpoint"] = new_endpoint if @gapi
         else
-          raise ApiError.from_response(resp)
+          fail ApiError.from_response(resp)
         end
       end
 
@@ -150,7 +150,8 @@ module Gcloud
       end
 
       ##
-      # Determines whether the subscription object was created with an HTTP call.
+      # Determines whether the subscription object was created with an
+      # HTTP call.
       #
       # === Example
       #
@@ -188,7 +189,7 @@ module Gcloud
         if resp.success?
           true
         else
-          raise ApiError.from_response(resp)
+          fail ApiError.from_response(resp)
         end
       end
 
@@ -303,7 +304,7 @@ module Gcloud
         if resp.success?
           @gapi = resp.data
         else
-          raise ApiError.from_response(resp)
+          fail ApiError.from_response(resp)
         end
       end
     end

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -47,12 +47,27 @@ module Gcloud
       def initialize #:nodoc:
         @connection = nil
         @gapi = {}
+        @name = nil
+        @exists = nil
+      end
+
+      ##
+      # New lazy Topic object without making an HTTP request.
+      def self.new_lazy name, conn #:nodoc:
+        sub = new.tap do |f|
+          f.gapi = nil
+          f.connection = conn
+        end
+        sub.instance_eval do
+          @name = conn.subscription_path(name)
+        end
+        sub
       end
 
       ##
       # The name of the subscription.
       def name
-        @gapi["name"]
+        @gapi ? @gapi["name"] : @name
       end
 
       ##
@@ -72,6 +87,7 @@ module Gcloud
       #   sub.topic.name "projects/my-project/topics/my-topic"
       #
       def topic
+        ensure_gapi!
         # Always disable autocreate, we don't want to recreate a topic that
         # was intentionally deleted.
         Topic.new_lazy @gapi["topic"], connection, false
@@ -87,12 +103,14 @@ module Gcloud
       # but but the message may already have been sent again.
       # Multiple acks to the message are allowed.
       def deadline
+        ensure_gapi!
         @gapi["ackDeadlineSeconds"]
       end
 
       ##
       # A URL locating the endpoint that messages are pushed.
       def endpoint
+        ensure_gapi!
         @gapi["pushConfig"]["pushEndpoint"] if @gapi["pushConfig"]
       end
 
@@ -102,10 +120,49 @@ module Gcloud
         ensure_connection!
         resp = connection.modify_push_config name, new_endpoint, {}
         if resp.success?
-          @gapi["pushConfig"]["pushEndpoint"] = new_endpoint
+          @gapi["pushConfig"]["pushEndpoint"] = new_endpoint if @gapi
         else
-          ApiError.from_response(resp)
+          raise ApiError.from_response(resp)
         end
+      end
+
+      ##
+      # Determines whether the subscription exists in the Pub/Sub service.
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   sub = pubsub.subscription "my-topic-sub"
+      #   sub.exists? #=> true
+      #
+      def exists?
+        # Always true if we have a gapi object
+        return true unless @gapi.nil?
+        # If we have a value, return it
+        return @exists unless @exists.nil?
+        ensure_gapi!
+        @exists = !@gapi.nil?
+      rescue NotFoundError
+        @exists = false
+      end
+
+      ##
+      # Determines whether the subscription object was created with an HTTP call.
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   sub = pubsub.get_subscription "my-topic-sub"
+      #   sub.lazy? #=> false
+      #
+      def lazy? #:nodoc:
+        @gapi.nil?
       end
 
       ##
@@ -131,7 +188,7 @@ module Gcloud
         if resp.success?
           true
         else
-          ApiError.from_response(resp)
+          raise ApiError.from_response(resp)
         end
       end
 
@@ -235,6 +292,19 @@ module Gcloud
       # Raise an error unless an active connection is available.
       def ensure_connection!
         fail "Must have active connection" unless connection
+      end
+
+      ##
+      # Ensures a Google API object exists.
+      def ensure_gapi!
+        ensure_connection!
+        return @gapi if @gapi
+        resp = connection.get_subscription @name
+        if resp.success?
+          @gapi = resp.data
+        else
+          raise ApiError.from_response(resp)
+        end
       end
     end
   end

--- a/lib/gcloud/pubsub/subscription/list.rb
+++ b/lib/gcloud/pubsub/subscription/list.rb
@@ -37,7 +37,7 @@ module Gcloud
         def self.from_resp resp, conn #:nodoc:
           subs = Array(resp.data["subscriptions"]).map do |gapi_object|
             if gapi_object.is_a? String
-              gapi_object
+              Subscription.new_lazy gapi_object, conn
             else
               Subscription.from_gapi gapi_object, conn
             end

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -96,7 +96,7 @@ module Gcloud
         if resp.success?
           true
         else
-          raise ApiError.from_response(resp)
+          fail ApiError.from_response(resp)
         end
       end
 
@@ -170,6 +170,37 @@ module Gcloud
       alias_method :new_subscription, :subscribe
 
       ##
+      # Retrieves subscription by name.
+      # This difference between this method and Topic#get_subscription is
+      # that this method does not make an API call to Pub/Sub verify the
+      # subscription exists.
+      #
+      # === Parameters
+      #
+      # +subscription_name+::
+      #   Name of a subscription. (+String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Pubsub::Subscription
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   subscription = topic.subscription "my-topic-subscription"
+      #   puts subscription.name
+      #
+      def subscription subscription_name
+        ensure_connection!
+
+        Subscription.new_lazy subscription_name, connection
+      end
+
+      ##
       # Retrieves a subscription by name.
       #
       # === Parameters
@@ -188,10 +219,10 @@ module Gcloud
       #   pubsub = Gcloud.pubsub
       #
       #   topic = pubsub.topic "my-topic"
-      #   subscription = topic.subscription "my-topic-subscription"
+      #   subscription = topic.get_subscription "my-topic-subscription"
       #   puts subscription.name
       #
-      def subscription subscription_name
+      def get_subscription subscription_name
         ensure_connection!
         resp = connection.get_subscription subscription_name
         if resp.success?
@@ -200,8 +231,7 @@ module Gcloud
           nil
         end
       end
-      alias_method :find_subscription, :subscription
-      alias_method :get_subscription, :subscription
+      alias_method :find_subscription, :get_subscription
 
       ##
       # Retrieves a list of subscription names for the given project.

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -319,6 +319,22 @@ module Gcloud
       end
 
       ##
+      # Determines whether the topic object was created with an HTTP call.
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   topic.lazy? #=> false
+      #
+      def lazy? #:nodoc:
+        false
+      end
+
+      ##
       # New Topic from a Google API Client object.
       def self.from_gapi gapi, conn #:nodoc:
         new.tap do |f|

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -303,6 +303,22 @@ module Gcloud
       end
 
       ##
+      # Determines whether the topic exists in the Pub/Sub service.
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   topic.exists? #=> true
+      #
+      def exists?
+        true
+      end
+
+      ##
       # New Topic from a Google API Client object.
       def self.from_gapi gapi, conn #:nodoc:
         new.tap do |f|

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -335,6 +335,23 @@ module Gcloud
       end
 
       ##
+      # Determines whether the lazy topic object should create a topic on the
+      # Pub/Sub service.
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   topic.autocreate? #=> true
+      #
+      def autocreate? #:nodoc:
+        false
+      end
+
+      ##
       # New Topic from a Google API Client object.
       def self.from_gapi gapi, conn #:nodoc:
         new.tap do |f|

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -96,7 +96,7 @@ module Gcloud
         if resp.success?
           true
         else
-          ApiError.from_response(resp)
+          raise ApiError.from_response(resp)
         end
       end
 

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -160,9 +160,11 @@ module Gcloud
         if resp.success?
           Subscription.from_gapi resp.data, connection
         else
-          # TODO: Handle ALREADY_EXISTS and NOT_FOUND
           fail ApiError.from_response(resp)
         end
+      rescue Gcloud::Pubsub::NotFoundError => e
+        retry if lazily_create_topic!
+        raise e
       end
       alias_method :create_subscription, :subscribe
       alias_method :new_subscription, :subscribe

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -219,7 +219,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Array of subscription name strings, not Subscription objects
+      # Array of Subscription objects (Subscription::List)
       #
       # === Examples
       #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -343,9 +343,6 @@ module Gcloud
         return @exists unless @exists.nil?
         ensure_gapi!
         @exists = !@gapi.nil?
-      rescue NotFoundError
-        # Raised error loading gapi? Set to false so we don't load again.
-        @exists = false
       end
 
       ##
@@ -400,22 +397,11 @@ module Gcloud
 
       ##
       # Ensures a Google API object exists.
-      # If autocreate is set to true, the topic will be created if possible.
       def ensure_gapi!
         ensure_connection!
-        retrieve_gapi!
-      end
-
-      ##
-      # Ensures that the gapi object exists.
-      def retrieve_gapi!
         return @gapi if @gapi
         resp = connection.get_topic @name
-        if resp.success?
-          @gapi = resp.data
-        else
-          fail ApiError.from_response(resp)
-        end
+        @gapi = resp.data if resp.success?
       end
 
       ##

--- a/regression/pubsub/test_pubsub.rb
+++ b/regression/pubsub/test_pubsub.rb
@@ -22,7 +22,7 @@ describe Gcloud::Pubsub, :pubsub do
   end
 
   def retrieve_subscription topic, subscription_name
-    topic.subscription(subscription_name) ||
+    topic.get_subscription(subscription_name) ||
     topic.subscribe(subscription_name)
   end
 
@@ -187,7 +187,7 @@ describe Gcloud::Pubsub, :pubsub do
     end
 
     it "should not error when asking for a non-existent subscription" do
-      subscription = topic.subscription "non-existent-subscription"
+      subscription = topic.get_subscription "non-existent-subscription"
       subscription.must_be :nil?
     end
 

--- a/regression/pubsub/test_pubsub.rb
+++ b/regression/pubsub/test_pubsub.rb
@@ -18,7 +18,7 @@ require "pubsub_helper"
 
 describe Gcloud::Pubsub, :pubsub do
   def retrieve_topic topic_name
-    pubsub.topic(topic_name) || pubsub.create_topic(topic_name)
+    pubsub.get_topic(topic_name) || pubsub.create_topic(topic_name)
   end
 
   def retrieve_subscription topic, subscription_name
@@ -26,8 +26,9 @@ describe Gcloud::Pubsub, :pubsub do
     topic.subscribe(subscription_name)
   end
 
-  let(:new_topic_name) {  $topic_names.first }
-  let(:topic_names)    {  $topic_names.last 3 }
+  let(:new_topic_name)  {  $topic_names[0] }
+  let(:topic_names)     {  $topic_names[3..5] }
+  let(:lazy_topic_name) {  $topic_names[6] }
 
   before do
     # create all topics
@@ -91,10 +92,21 @@ describe Gcloud::Pubsub, :pubsub do
       pubsub.topics.first.delete
       pubsub.topics.count.must_equal (old_topics_count - 1)
     end
+
+    describe :lazy do
+      it "gets a lazy topic object that can create itself" do
+        lazy_topic = pubsub.topic lazy_topic_name
+        lazy_topic.must_be :lazy?
+        lazy_topic.must_be :autocreate?
+        lazy_topic.wont_be :exists?
+        lazy_topic.publish "this will create the topic"
+        lazy_topic.must_be :exists?
+      end
+    end
   end
 
   describe "Subscriptions on Project" do
-    let(:topic) { retrieve_topic $topic_names.last }
+    let(:topic) { retrieve_topic $topic_names[2] }
 
     before do
       3.times.each do |i|

--- a/regression/pubsub/test_pubsub.rb
+++ b/regression/pubsub/test_pubsub.rb
@@ -159,7 +159,7 @@ describe Gcloud::Pubsub, :pubsub do
       subscriptions.count.must_equal subs.count
       subscriptions.each do |subscription|
         # subscriptions on topic are strings...
-        subscription.must_be_kind_of String
+        subscription.must_be_kind_of Gcloud::Pubsub::Subscription
       end
       subscriptions.token.must_be :nil?
     end
@@ -168,14 +168,14 @@ describe Gcloud::Pubsub, :pubsub do
       subscriptions = topic.subscriptions max: (subs.count - 1)
       subscriptions.count.must_equal (subs.count - 1)
       subscriptions.each do |subscription|
-        subscription.must_be_kind_of String
+        subscription.must_be_kind_of Gcloud::Pubsub::Subscription
       end
       subscriptions.token.wont_be :nil?
 
       # retrieve the next list of subscriptions
       next_subs = topic.subscriptions token: subscriptions.token
       next_subs.count.must_equal 1
-      next_subs.first.must_be_kind_of String
+      next_subs.first.must_be_kind_of Gcloud::Pubsub::Subscription
       next_subs.token.must_be :nil?
     end
 

--- a/regression/pubsub_helper.rb
+++ b/regression/pubsub_helper.rb
@@ -61,12 +61,12 @@ require "time"
 require "securerandom"
 t = Time.now.utc.iso8601.gsub ":", "-"
 $topic_prefix = "gcloud-ruby-regression-#{t}-".downcase
-$topic_names = 5.times.map { "#{$topic_prefix}-#{SecureRandom.hex(4)}".downcase }
+$topic_names = 7.times.map { "#{$topic_prefix}-#{SecureRandom.hex(4)}".downcase }
 
 def clean_up_pubsub_topics
   puts "Cleaning up pubsub topics after tests."
   $topic_names.each do |topic_name|
-    if t = $pubsub.topic(topic_name)
+    if t = $pubsub.get_topic(topic_name)
       # HACK: The topic's subscriptions are just the names
       # so call the delete API outside of the object model.
       t.subscriptions.map { |s| t.connection.delete_subscription s }

--- a/regression/pubsub_helper.rb
+++ b/regression/pubsub_helper.rb
@@ -67,9 +67,7 @@ def clean_up_pubsub_topics
   puts "Cleaning up pubsub topics after tests."
   $topic_names.each do |topic_name|
     if t = $pubsub.get_topic(topic_name)
-      # HACK: The topic's subscriptions are just the names
-      # so call the delete API outside of the object model.
-      t.subscriptions.map { |s| t.connection.delete_subscription s }
+      t.subscriptions.each { |s| s.delete }
       t.delete
     end
   end

--- a/test/gcloud/pubsub/subscription/test_acknowledge.rb
+++ b/test/gcloud/pubsub/subscription/test_acknowledge.rb
@@ -1,0 +1,78 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+
+  it "can acknowledge messages" do
+    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+      JSON.parse(env.body)["ackIds"].count.must_equal 3
+      JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
+      JSON.parse(env.body)["ackIds"].must_include "ack-id-2"
+      JSON.parse(env.body)["ackIds"].must_include "ack-id-3"
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.acknowledge "ack-id-1", "ack-id-2", "ack-id-3"
+  end
+
+  describe "lazy subscription object of a subscription that does exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "can acknowledge messages" do
+      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].count.must_equal 3
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-2"
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-3"
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.acknowledge "ack-id-1", "ack-id-2", "ack-id-3"
+    end
+  end
+
+  describe "lazy subscription object of a subscription that does not exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "raises NotFoundError when acknowledging messages" do
+      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].count.must_equal 3
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-2"
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-3"
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.acknowledge "ack-id-1", "ack-id-2", "ack-id-3"
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_attrs.rb
+++ b/test/gcloud/pubsub/subscription/test_attrs.rb
@@ -1,0 +1,154 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let(:sub_deadline) { sub_hash["ackDeadlineSeconds"] }
+  let(:sub_endpoint) { sub_hash["pushConfig"]["pushEndpoint"] }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+
+  it "gets endpoint from the Google API object" do
+    # No mocked connection means no connections are happening.
+    subscription.topic.must_be_kind_of Gcloud::Pubsub::Topic
+    subscription.topic.must_be :lazy?
+    subscription.topic.name.must_equal topic_path(topic_name)
+  end
+
+  it "gets endpoint from the Google API object" do
+    subscription.deadline.must_equal sub_deadline
+  end
+
+  it "gets endpoint from the Google API object" do
+    subscription.endpoint.must_equal sub_endpoint
+  end
+
+  it "can update the endpoint" do
+    new_push_endpoint = "https://foo.bar/baz"
+
+    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
+      JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal new_push_endpoint
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.endpoint = new_push_endpoint
+  end
+
+  describe "lazy subscription object of a subscription that does exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "makes an HTTP API call to retrieve topic" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [200, {"Content-Type"=>"application/json"},
+         sub_json]
+      end
+
+      subscription.topic.must_be_kind_of Gcloud::Pubsub::Topic
+      subscription.topic.must_be :lazy?
+      subscription.topic.name.must_equal topic_path(topic_name)
+    end
+
+    it "makes an HTTP API call to retrieve deadline" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [200, {"Content-Type"=>"application/json"},
+         sub_json]
+      end
+
+      subscription.deadline.must_equal sub_deadline
+    end
+
+    it "makes an HTTP API call to retrieve endpoint" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [200, {"Content-Type"=>"application/json"},
+         sub_json]
+      end
+
+      subscription.endpoint.must_equal sub_endpoint
+    end
+
+    it "makes an HTTP API call to update endpoint" do
+      new_push_endpoint = "https://foo.bar/baz"
+
+      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
+        JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal new_push_endpoint
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.endpoint = new_push_endpoint
+    end
+  end
+
+  describe "lazy subscription object of a subscription that does not exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "raises NotFoundError when retrieving topic" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.topic
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
+    it "raises NotFoundError when retrieving deadline" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.deadline
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
+    it "raises NotFoundError when retrieving endpoint" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.endpoint
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
+    it "raises NotFoundError when updating endpoint" do
+      new_push_endpoint = "https://foo.bar/baz"
+
+      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
+        JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal new_push_endpoint
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.endpoint = new_push_endpoint
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_delete.rb
+++ b/test/gcloud/pubsub/subscription/test_delete.rb
@@ -1,0 +1,66 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :delete, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+
+  it "can delete itself" do
+    mock_connection.delete "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.delete
+  end
+
+  describe "lazy subscription object of a subscription that does exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "can delete itself" do
+      mock_connection.delete "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.delete
+    end
+  end
+
+  describe "lazy subscription object of a subscription that does not exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "raises NotFoundError when deleting itself" do
+      mock_connection.delete "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.delete
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_exists.rb
+++ b/test/gcloud/pubsub/subscription/test_exists.rb
@@ -1,0 +1,69 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :exists, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json(topic_name, sub_name) }
+  let :subscription do
+    json = JSON.parse(sub_json)
+    Gcloud::Pubsub::Subscription.from_gapi json, pubsub.connection
+  end
+
+  it "knows if it exists when created with an HTTP method" do
+    # The absense of a mock_connection config means this test will fail
+    # if the method exists? makes an HTTP call.
+    subscription.must_be :exists?
+    # Additional exists? calls do not make HTTP calls either
+    subscription.must_be :exists?
+  end
+
+  describe "lazy subscription object of a subscription that exists" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "checks if the subscription exists by making an HTTP call" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [200, {"Content-Type"=>"application/json"},
+         sub_json]
+      end
+
+      subscription.must_be :exists?
+      # Additional exists? calls do not make HTTP calls
+      subscription.must_be :exists?
+    end
+  end
+
+  describe "lazy subscription object of a subscription that does not exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "checks if the subscription exists by making an HTTP call" do
+      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      subscription.wont_be :exists?
+      # Additional exists? calls do not make HTTP calls
+      subscription.wont_be :exists?
+    end
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_lazy.rb
+++ b/test/gcloud/pubsub/subscription/test_lazy.rb
@@ -1,0 +1,41 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :name, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_path) { subscription_path sub_name }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let :subscription do
+    json = JSON.parse(sub_json)
+    Gcloud::Pubsub::Subscription.from_gapi json, pubsub.connection
+  end
+
+  it "is not lazy when created with an HTTP method" do
+    subscription.wont_be :lazy?
+  end
+
+  describe "lazy subscription" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "is lazy" do
+      subscription.must_be :lazy?
+    end
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_name.rb
+++ b/test/gcloud/pubsub/subscription/test_name.rb
@@ -1,0 +1,52 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :name, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_path) { subscription_path sub_name }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let :subscription do
+    json = JSON.parse(sub_json)
+    Gcloud::Pubsub::Subscription.from_gapi json, pubsub.connection
+  end
+
+  it "gives the name returned from the HTTP method" do
+    subscription.name.must_equal sub_path
+  end
+
+  describe "lazy subscription given the short name" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "matches the name returned from the HTTP method" do
+      subscription.name.must_equal sub_path
+    end
+  end
+
+  describe "lazy subscription object given the full path" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_path,
+                                            pubsub.connection
+    end
+
+    it "matches the name returned from the HTTP method" do
+      subscription.name.must_equal sub_path
+    end
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_pull.rb
+++ b/test/gcloud/pubsub/subscription/test_pull.rb
@@ -1,0 +1,75 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+
+  it "can pull messages" do
+    event_msg = "pulled-message"
+    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       events_json(event_msg)]
+    end
+
+    events = subscription.pull
+    events.wont_be :empty?
+    events.first.message.data.must_equal event_msg
+  end
+
+  describe "lazy subscription object of a subscription that does exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "can pull messages" do
+      event_msg = "pulled-message"
+      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+        [200, {"Content-Type"=>"application/json"},
+         events_json(event_msg)]
+      end
+
+      events = subscription.pull
+      events.wont_be :empty?
+      events.first.message.data.must_equal event_msg
+    end
+  end
+
+  describe "lazy subscription object of a subscription that does not exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "raises NotFoundError when pulling messages" do
+      event_msg = "pulled-message"
+      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.pull
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+  end
+end

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -152,16 +152,25 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     topics.token.must_equal "next_page_token"
   end
 
-  it "gets a subscription" do
+  it "gets a lazy subscription" do
+    sub_name = "found-sub"
+    sub = pubsub.subscription sub_name
+    sub.name.must_equal subscription_path(sub_name)
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.must_be :lazy?
+  end
+
+  it "gets a subscription with get_subscription" do
     sub_name = "found-sub-#{Time.now.to_i}"
     mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscription_json("random-topic", sub_name)]
     end
 
-    sub = pubsub.subscription sub_name
+    sub = pubsub.get_subscription sub_name
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.wont_be :lazy?
   end
 
   it "gets a subscription with find_subscription alias" do
@@ -174,18 +183,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     sub = pubsub.find_subscription sub_name
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
-  end
-
-  it "gets a subscription with get_subscription alias" do
-    sub_name = "found-sub-#{Time.now.to_i}"
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
-      [200, {"Content-Type"=>"application/json"},
-       subscription_json("random-topic", sub_name)]
-    end
-
-    sub = pubsub.get_subscription sub_name
-    sub.wont_be :nil?
-    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.wont_be :lazy?
   end
 
   it "lists subscriptions" do

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -39,15 +39,23 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     pubsub.new_topic new_topic_name
   end
 
-  it "gets a topic" do
+  it "gets a lazy topic" do
+    topic_name = "found-topic"
+    topic = pubsub.topic topic_name
+    topic.name.must_equal topic_path(topic_name)
+    topic.must_be :lazy?
+  end
+
+  it "gets a topic with get_topic" do
     topic_name = "found-topic"
     mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        topic_json(topic_name)]
     end
 
-    topic = pubsub.topic topic_name
+    topic = pubsub.get_topic topic_name
     topic.name.must_equal topic_path(topic_name)
+    topic.wont_be :lazy?
   end
 
   it "gets a topic with find_topic alias" do
@@ -59,17 +67,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
     topic = pubsub.find_topic topic_name
     topic.name.must_equal topic_path(topic_name)
-  end
-
-  it "gets a topic with get_topic alias" do
-    topic_name = "found-topic"
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
-      [200, {"Content-Type"=>"application/json"},
-       topic_json(topic_name)]
-    end
-
-    topic = pubsub.get_topic topic_name
-    topic.name.must_equal topic_path(topic_name)
+    topic.wont_be :lazy?
   end
 
   it "lists topics" do

--- a/test/gcloud/pubsub/test_subscription.rb
+++ b/test/gcloud/pubsub/test_subscription.rb
@@ -27,7 +27,9 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "knows its topic" do
-    subscription.topic.must_equal topic_path(topic_name)
+    subscription.topic.must_be_kind_of Gcloud::Pubsub::Topic
+    subscription.topic.must_be :lazy?
+    subscription.topic.name.must_equal topic_path(topic_name)
   end
 
   it "has an ack deadline" do

--- a/test/gcloud/pubsub/test_topic.rb
+++ b/test/gcloud/pubsub/test_topic.rb
@@ -153,16 +153,26 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     end
   end
 
-  it "gets a subscription" do
+  it "gets a lazy subscription" do
+    sub_name = "found-sub-#{Time.now.to_i}"
+    sub = topic.subscription sub_name
+    sub.name.must_equal subscription_path(sub_name)
+    sub.wont_be :nil?
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.must_be :lazy?
+  end
+
+  it "gets a subscription with get_subscription" do
     sub_name = "found-sub-#{Time.now.to_i}"
     mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, sub_name)]
     end
 
-    sub = topic.subscription sub_name
+    sub = topic.get_subscription sub_name
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.wont_be :lazy?
   end
 
   it "gets a subscription with find_subscription alias" do
@@ -175,18 +185,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     sub = topic.find_subscription sub_name
     sub.wont_be :nil?
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
-  end
-
-  it "gets a subscription with get_subscription alias" do
-    sub_name = "found-sub-#{Time.now.to_i}"
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
-      [200, {"Content-Type"=>"application/json"},
-       subscription_json(topic_name, sub_name)]
-    end
-
-    sub = topic.get_subscription sub_name
-    sub.wont_be :nil?
-    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.wont_be :lazy?
   end
 
   it "lists subscriptions" do

--- a/test/gcloud/pubsub/test_topic.rb
+++ b/test/gcloud/pubsub/test_topic.rb
@@ -244,10 +244,16 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     first_subs.count.must_equal 3
     first_subs.token.wont_be :nil?
     first_subs.token.must_equal "next_page_token"
+    first_subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
 
     second_subs = topic.subscriptions token: first_subs.token
     second_subs.count.must_equal 2
     second_subs.token.must_be :nil?
+    second_subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
   end
 
   it "paginates subscriptions with max set" do
@@ -262,6 +268,9 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 3
     subs.token.wont_be :nil?
     subs.token.must_equal "next_page_token"
+    subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
   end
 
   it "paginates subscriptions without max set" do
@@ -275,6 +284,9 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     subs.count.must_equal 3
     subs.token.wont_be :nil?
     subs.token.must_equal "next_page_token"
+    subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
   end
 
   it "can publish a message" do

--- a/test/gcloud/pubsub/topic/test_autocreate.rb
+++ b/test/gcloud/pubsub/topic/test_autocreate.rb
@@ -1,0 +1,25 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+
+  it "knows if it will create a topci on the Pub/Sub service" do
+    topic.wont_be :autocreate?
+  end
+end

--- a/test/gcloud/pubsub/topic/test_exists.rb
+++ b/test/gcloud/pubsub/topic/test_exists.rb
@@ -1,0 +1,25 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+
+  it "knows if it exists" do
+    topic.must_be :exists?
+  end
+end

--- a/test/gcloud/pubsub/topic/test_exists.rb
+++ b/test/gcloud/pubsub/topic/test_exists.rb
@@ -19,7 +19,115 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
   let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
                                                 pubsub.connection }
 
-  it "knows if it exists" do
+  it "knows if it exists when created with an HTTP method" do
+    # The absense of a mock_connection config means this test will fail
+    # if the method exists? makes an HTTP call.
     topic.must_be :exists?
+    # Additional exists? calls do not make HTTP calls either
+    topic.must_be :exists?
+  end
+
+  describe "lazy topic object of a topic that exists" do
+    describe "lazy topic with default autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection }
+
+      it "checks if the topic exists by making an HTTP call" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           topic_json(topic_name)]
+        end
+
+        topic.must_be :exists?
+        # Additional exists? calls do not make HTTP calls
+        topic.must_be :exists?
+      end
+    end
+
+    describe "lazy topic with explicit autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "checks if the topic exists by making an HTTP call" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           topic_json(topic_name)]
+        end
+
+        topic.must_be :exists?
+        # Additional exists? calls do not make HTTP calls
+        topic.must_be :exists?
+      end
+    end
+
+    describe "lazy topic without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "checks if the topic exists by making an HTTP call" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           topic_json(topic_name)]
+        end
+
+        topic.must_be :exists?
+        # Additional exists? calls do not make HTTP calls
+        topic.must_be :exists?
+      end
+    end
+  end
+
+  describe "lazy topic object of a topic that does not exist" do
+    describe "lazy topic with default autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection }
+
+      it "checks if the topic exists by making an HTTP call" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        topic.wont_be :exists?
+        # Additional exists? calls do not make HTTP calls
+        topic.wont_be :exists?
+      end
+    end
+
+    describe "lazy topic with explicit autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "checks if the topic exists by making an HTTP call" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        topic.wont_be :exists?
+        # Additional exists? calls do not make HTTP calls
+        topic.wont_be :exists?
+      end
+    end
+
+    describe "lazy topic without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "checks if the topic exists by making an HTTP call" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        topic.wont_be :exists?
+        # Additional exists? calls do not make HTTP calls
+        topic.wont_be :exists?
+      end
+    end
   end
 end

--- a/test/gcloud/pubsub/topic/test_get_subscription.rb
+++ b/test/gcloud/pubsub/topic/test_get_subscription.rb
@@ -1,0 +1,135 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+  let(:found_sub_name) { "found-sub-#{Time.now.to_i}" }
+  let(:not_found_sub_name) { "found-sub-#{Time.now.to_i}" }
+
+  it "gets an existing subscription" do
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json(topic_name, found_sub_name)]
+    end
+
+    sub = topic.get_subscription found_sub_name
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.wont_be :lazy?
+  end
+
+  it "returns nil when getting an non-existant subscription" do
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+      [404, {"Content-Type"=>"application/json"},
+       not_found_error_json(not_found_sub_name)]
+    end
+
+    sub = topic.get_subscription found_sub_name
+    sub.must_be :nil?
+  end
+
+  describe "lazy topic that exists" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "gets an existing subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           subscription_json(topic_name, found_sub_name)]
+        end
+
+        sub = topic.get_subscription found_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.wont_be :lazy?
+      end
+
+      it "returns nil when getting an non-existant subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.get_subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "gets an existing subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           subscription_json(topic_name, found_sub_name)]
+        end
+
+        sub = topic.get_subscription found_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.wont_be :lazy?
+      end
+
+      it "returns nil when getting an non-existant subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.get_subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "returns nil when getting an non-existant subscription" do
+        # by definition, all subscriptions for this topic are non-existant
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.get_subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "returns nil when getting an non-existant subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.get_subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+  end
+end

--- a/test/gcloud/pubsub/topic/test_lazy.rb
+++ b/test/gcloud/pubsub/topic/test_lazy.rb
@@ -1,0 +1,25 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+
+  it "knows if it is lazy" do
+    topic.wont_be :lazy?
+  end
+end

--- a/test/gcloud/pubsub/topic/test_lazy.rb
+++ b/test/gcloud/pubsub/topic/test_lazy.rb
@@ -19,7 +19,36 @@ describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
   let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
                                                 pubsub.connection }
 
-  it "knows if it is lazy" do
+  it "is not lazy when created with an HTTP method" do
     topic.wont_be :lazy?
+  end
+
+  describe "lazy topic with default autocreate" do
+    let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.connection }
+
+    it "will autocreate when created lazily" do
+      topic.must_be :lazy?
+    end
+  end
+
+  describe "lazy topic with explicit autocreate" do
+    let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.connection,
+                                                 true }
+
+    it "will autocreate when created lazily" do
+      topic.must_be :lazy?
+    end
+  end
+
+  describe "lazy topic without autocomplete" do
+    let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                 pubsub.connection,
+                                                 false }
+
+    it "knows if it will create a topic on the Pub/Sub service" do
+      topic.must_be :lazy?
+    end
   end
 end

--- a/test/gcloud/pubsub/topic/test_name.rb
+++ b/test/gcloud/pubsub/topic/test_name.rb
@@ -14,21 +14,21 @@
 
 require "helper"
 
-describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
+describe Gcloud::Pubsub::Topic, :name, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
                                                 pubsub.connection }
 
-  it "will not autocreate when created with an HTTP method" do
-    topic.wont_be :autocreate?
+  it "gives the name returned from the HTTP method" do
+    topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
   end
 
   describe "lazy topic with default autocreate" do
     let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.connection }
 
-    it "will autocreate when created lazily" do
-      topic.must_be :autocreate?
+    it "matches the name returned from the HTTP method" do
+      topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
     end
   end
 
@@ -37,8 +37,8 @@ describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
                                                  pubsub.connection,
                                                  true }
 
-    it "will autocreate when created lazily" do
-      topic.must_be :autocreate?
+    it "matches the name returned from the HTTP method" do
+      topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
     end
   end
 
@@ -47,8 +47,8 @@ describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
                                                  pubsub.connection,
                                                  false }
 
-    it "knows if it will create a topic on the Pub/Sub service" do
-      topic.wont_be :autocreate?
+    it "matches the name returned from the HTTP method" do
+      topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
     end
   end
 end

--- a/test/gcloud/pubsub/topic/test_publish.rb
+++ b/test/gcloud/pubsub/topic/test_publish.rb
@@ -1,0 +1,304 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+  let(:message1) { "new-message-here" }
+  let(:message2) { "second-new-message" }
+  let(:message3) { "third-new-message" }
+  let(:msg_packed1) { [message1].pack("m") }
+  let(:msg_packed2) { [message2].pack("m") }
+  let(:msg_packed3) { [message3].pack("m") }
+
+  it "publishes a message" do
+    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+      JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+      [200, {"Content-Type"=>"application/json"},
+       { messageIds: ["msg1"] }.to_json]
+    end
+
+    msg = topic.publish message1
+    msg.must_be_kind_of Gcloud::Pubsub::Message
+    msg.message_id.must_equal "msg1"
+  end
+
+  it "publishes a message with attributes" do
+    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+      JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+      [200, {"Content-Type"=>"application/json"},
+       { messageIds: ["msg1"] }.to_json]
+    end
+
+    msg = topic.publish message1, format: :text
+    msg.must_be_kind_of Gcloud::Pubsub::Message
+    msg.message_id.must_equal "msg1"
+    msg.attributes["format"].must_equal "text"
+  end
+
+  it "publishes multiple messages with a block" do
+    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+      JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+      JSON.parse(env.body)["messages"].last["data"].must_equal  msg_packed3
+      [200, {"Content-Type"=>"application/json"},
+       { messageIds: ["msg1", "msg2", "msg3"] }.to_json]
+    end
+
+    msgs = topic.publish do |batch|
+      batch.publish message1
+      batch.publish message2
+      batch.publish message3, format: :none
+    end
+    msgs.count.must_equal 3
+    msgs.each { |msg| msg.must_be_kind_of Gcloud::Pubsub::Message }
+    msgs.first.message_id.must_equal "msg1"
+    msgs.last.message_id.must_equal "msg3"
+    msgs.last.attributes["format"].must_equal "none"
+  end
+
+  describe "lazy topic that exists" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "publishes a message" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1"] }.to_json]
+        end
+
+        msg = topic.publish message1
+        msg.must_be_kind_of Gcloud::Pubsub::Message
+        msg.message_id.must_equal "msg1"
+      end
+
+      it "publishes a message with attributes" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1"] }.to_json]
+        end
+
+        msg = topic.publish message1, format: :text
+        msg.must_be_kind_of Gcloud::Pubsub::Message
+        msg.message_id.must_equal "msg1"
+        msg.attributes["format"].must_equal "text"
+      end
+
+      it "publishes multiple messages with a block" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1", "msg2", "msg3"] }.to_json]
+        end
+
+        msgs = topic.publish do |batch|
+          batch.publish message1
+          batch.publish message2
+          batch.publish message3, format: :none
+        end
+        msgs.count.must_equal 3
+        msgs.each { |msg| msg.must_be_kind_of Gcloud::Pubsub::Message }
+        msgs.first.message_id.must_equal "msg1"
+        msgs.last.message_id.must_equal "msg3"
+        msgs.last.attributes["format"].must_equal "none"
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "publishes a message" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1"] }.to_json]
+        end
+
+        msg = topic.publish message1
+        msg.must_be_kind_of Gcloud::Pubsub::Message
+        msg.message_id.must_equal "msg1"
+      end
+
+      it "publishes a message with attributes" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1"] }.to_json]
+        end
+
+        msg = topic.publish message1, format: :text
+        msg.must_be_kind_of Gcloud::Pubsub::Message
+        msg.message_id.must_equal "msg1"
+        msg.attributes["format"].must_equal "text"
+      end
+
+      it "publishes multiple messages with a block" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          JSON.parse(env.body)["messages"].last["data"].must_equal  msg_packed3
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1", "msg2", "msg3"] }.to_json]
+        end
+
+        msgs = topic.publish do |batch|
+          batch.publish message1
+          batch.publish message2
+          batch.publish message3, format: :none
+        end
+        msgs.count.must_equal 3
+        msgs.each { |msg| msg.must_be_kind_of Gcloud::Pubsub::Message }
+        msgs.first.message_id.must_equal "msg1"
+        msgs.last.message_id.must_equal "msg3"
+        msgs.last.attributes["format"].must_equal "none"
+      end
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "publishes a message" do
+        #first, failed attempt to publish
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+        # second, successful attempt to create topic
+        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           topic_json(topic_name)]
+        end
+        # third, successful attempt to publish
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1"] }.to_json]
+        end
+
+        msg = topic.publish message1
+        msg.must_be_kind_of Gcloud::Pubsub::Message
+        msg.message_id.must_equal "msg1"
+      end
+
+      it "publishes a message with attributes" do
+        #first, failed attempt to publish
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+        # second, successful attempt to create topic
+        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           topic_json(topic_name)]
+        end
+        # third, successful attempt to publish
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1"] }.to_json]
+        end
+
+        msg = topic.publish message1, format: :text
+        msg.must_be_kind_of Gcloud::Pubsub::Message
+        msg.message_id.must_equal "msg1"
+        msg.attributes["format"].must_equal "text"
+      end
+
+      it "publishes multiple messages with a block" do
+        #first, failed attempt to publish
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+        # second, successful attempt to create topic
+        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           topic_json(topic_name)]
+        end
+        # third, successful attempt to publish
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
+          JSON.parse(env.body)["messages"].last["data"].must_equal  msg_packed3
+          [200, {"Content-Type"=>"application/json"},
+           { messageIds: ["msg1", "msg2", "msg3"] }.to_json]
+        end
+
+        msgs = topic.publish do |batch|
+          batch.publish message1
+          batch.publish message2
+          batch.publish message3, format: :none
+        end
+        msgs.count.must_equal 3
+        msgs.each { |msg| msg.must_be_kind_of Gcloud::Pubsub::Message }
+        msgs.first.message_id.must_equal "msg1"
+        msgs.last.message_id.must_equal "msg3"
+        msgs.last.attributes["format"].must_equal "none"
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "publishes a message" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        expect do
+          topic.publish message1
+        end.must_raise Gcloud::Pubsub::NotFoundError
+      end
+
+      it "publishes a message with attributes" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        expect do
+          topic.publish message1, format: :text
+        end.must_raise Gcloud::Pubsub::NotFoundError
+      end
+
+      it "publishes multiple messages with a block" do
+        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        expect do
+          topic.publish do |batch|
+            batch.publish message1
+            batch.publish message2
+            batch.publish message3, format: :none
+          end
+        end.must_raise Gcloud::Pubsub::NotFoundError
+      end
+    end
+  end
+end

--- a/test/gcloud/pubsub/topic/test_subscribe.rb
+++ b/test/gcloud/pubsub/topic/test_subscribe.rb
@@ -1,0 +1,120 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+  let(:new_sub_name) { "new-sub-#{Time.now.to_i}" }
+
+  it "creates a subscription when calling subscribe" do
+    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+      JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json(topic_name, new_sub_name)]
+    end
+
+    sub = topic.subscribe new_sub_name
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+  end
+
+  describe "lazy topic that exists" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "creates a subscription when calling subscribe" do
+        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+          JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
+          [200, {"Content-Type"=>"application/json"},
+           subscription_json(topic_name, new_sub_name)]
+        end
+
+        sub = topic.subscribe new_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "creates a subscription when calling subscribe" do
+        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+          JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
+          [200, {"Content-Type"=>"application/json"},
+           subscription_json(topic_name, new_sub_name)]
+        end
+
+        sub = topic.subscribe new_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+      end
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "creates a subscription when calling subscribe" do
+        #first, failed attempt to subscribe
+        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+        # second, successful attempt to create topic
+        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           topic_json(topic_name)]
+        end
+        # third, successful attempt to subscribe
+        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+          JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
+          [200, {"Content-Type"=>"application/json"},
+           subscription_json(topic_name, new_sub_name)]
+        end
+
+        sub = topic.subscribe new_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.name.must_equal "projects/#{project}/subscriptions/#{new_sub_name}"
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "raises NotFoundError when calling subscribe" do
+        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        expect do
+          topic.subscribe new_sub_name
+        end.must_raise Gcloud::Pubsub::NotFoundError
+      end
+    end
+  end
+end

--- a/test/gcloud/pubsub/topic/test_subscription.rb
+++ b/test/gcloud/pubsub/topic/test_subscription.rb
@@ -19,26 +19,18 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
   let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
                                                 pubsub.connection }
   let(:found_sub_name) { "found-sub-#{Time.now.to_i}" }
-  let(:not_found_sub_name) { "found-sub-#{Time.now.to_i}" }
+  let(:not_found_sub_name) { "not-found-sub-#{Time.now.to_i}" }
 
-  it "gets an existing subscription" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
-      [200, {"Content-Type"=>"application/json"},
-       subscription_json(topic_name, found_sub_name)]
-    end
-
+  it "gets lazy sub for an existing subscription" do
     sub = topic.subscription found_sub_name
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.must_be :lazy?
   end
 
-  it "returns nil when getting an non-existant subscription" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
-      [404, {"Content-Type"=>"application/json"},
-       not_found_error_json(not_found_sub_name)]
-    end
-
-    sub = topic.subscription found_sub_name
-    sub.must_be :nil?
+  it "returns lazy sub when getting an non-existant subscription" do
+    sub = topic.subscription not_found_sub_name
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    sub.must_be :lazy?
   end
 
   describe "lazy topic that exists" do
@@ -47,24 +39,16 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
                                                    pubsub.connection,
                                                    true }
 
-      it "gets an existing subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
-          [200, {"Content-Type"=>"application/json"},
-           subscription_json(topic_name, found_sub_name)]
-        end
-
+      it "gets lazy sub for an existing subscription" do
         sub = topic.subscription found_sub_name
         sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.must_be :lazy?
       end
 
-      it "returns nil when getting an non-existant subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
-          [404, {"Content-Type"=>"application/json"},
-           not_found_error_json(not_found_sub_name)]
-        end
-
-        sub = topic.subscription found_sub_name
-        sub.must_be :nil?
+      it "returns lazy sub when getting an non-existant subscription" do
+        sub = topic.subscription not_found_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.must_be :lazy?
       end
     end
 
@@ -73,24 +57,16 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
                                                    pubsub.connection,
                                                    false }
 
-      it "gets an existing subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
-          [200, {"Content-Type"=>"application/json"},
-           subscription_json(topic_name, found_sub_name)]
-        end
-
+      it "gets lazy sub for an existing subscription" do
         sub = topic.subscription found_sub_name
         sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.must_be :lazy?
       end
 
-      it "returns nil when getting an non-existant subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
-          [404, {"Content-Type"=>"application/json"},
-           not_found_error_json(not_found_sub_name)]
-        end
-
-        sub = topic.subscription found_sub_name
-        sub.must_be :nil?
+      it "returns lazy sub when getting an non-existant subscription" do
+        sub = topic.subscription not_found_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.must_be :lazy?
       end
     end
   end
@@ -101,15 +77,10 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
                                                    pubsub.connection,
                                                    true }
 
-      it "returns nil when getting an non-existant subscription" do
-        # by definition, all subscriptions for this topic are non-existant
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
-          [404, {"Content-Type"=>"application/json"},
-           not_found_error_json(not_found_sub_name)]
-        end
-
+      it "gets lazy sub for an existing subscription" do
         sub = topic.subscription found_sub_name
-        sub.must_be :nil?
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.must_be :lazy?
       end
     end
 
@@ -118,14 +89,10 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
                                                    pubsub.connection,
                                                    false }
 
-      it "returns nil when getting an non-existant subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
-          [404, {"Content-Type"=>"application/json"},
-           not_found_error_json(not_found_sub_name)]
-        end
-
-        sub = topic.subscription found_sub_name
-        sub.must_be :nil?
+      it "returns lazy sub when getting an non-existant subscription" do
+        sub = topic.subscription not_found_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        sub.must_be :lazy?
       end
     end
   end

--- a/test/gcloud/pubsub/topic/test_subscription.rb
+++ b/test/gcloud/pubsub/topic/test_subscription.rb
@@ -1,0 +1,132 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+  let(:found_sub_name) { "found-sub-#{Time.now.to_i}" }
+  let(:not_found_sub_name) { "found-sub-#{Time.now.to_i}" }
+
+  it "gets an existing subscription" do
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscription_json(topic_name, found_sub_name)]
+    end
+
+    sub = topic.subscription found_sub_name
+    sub.must_be_kind_of Gcloud::Pubsub::Subscription
+  end
+
+  it "returns nil when getting an non-existant subscription" do
+    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+      [404, {"Content-Type"=>"application/json"},
+       not_found_error_json(not_found_sub_name)]
+    end
+
+    sub = topic.subscription found_sub_name
+    sub.must_be :nil?
+  end
+
+  describe "lazy topic that exists" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "gets an existing subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           subscription_json(topic_name, found_sub_name)]
+        end
+
+        sub = topic.subscription found_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+      end
+
+      it "returns nil when getting an non-existant subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "gets an existing subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           subscription_json(topic_name, found_sub_name)]
+        end
+
+        sub = topic.subscription found_sub_name
+        sub.must_be_kind_of Gcloud::Pubsub::Subscription
+      end
+
+      it "returns nil when getting an non-existant subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "returns nil when getting an non-existant subscription" do
+        # by definition, all subscriptions for this topic are non-existant
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "returns nil when getting an non-existant subscription" do
+        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(not_found_sub_name)]
+        end
+
+        sub = topic.subscription found_sub_name
+        sub.must_be :nil?
+      end
+    end
+  end
+end

--- a/test/gcloud/pubsub/topic/test_subscriptions.rb
+++ b/test/gcloud/pubsub/topic/test_subscriptions.rb
@@ -1,0 +1,109 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+  it "lists subscriptions" do
+    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       subscriptions_json(topic_name, 3)]
+    end
+
+    subs = topic.subscriptions
+    subs.count.must_equal 3
+    subs.each do |sub|
+      sub.must_be_kind_of Gcloud::Pubsub::Subscription
+    end
+  end
+
+  describe "lazy topic that exists" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "lists subscriptions" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           subscriptions_json(topic_name, 3)]
+        end
+
+        subs = topic.subscriptions
+        subs.count.must_equal 3
+        subs.each do |sub|
+          sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        end
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "lists subscriptions" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+          [200, {"Content-Type"=>"application/json"},
+           subscriptions_json(topic_name, 3)]
+        end
+
+        subs = topic.subscriptions
+        subs.count.must_equal 3
+        subs.each do |sub|
+          sub.must_be_kind_of Gcloud::Pubsub::Subscription
+        end
+      end
+    end
+  end
+
+  describe "lazy topic that does not exist" do
+    describe "created with autocreate" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   true }
+
+      it "lists subscriptions" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        expect do
+          topic.subscriptions
+        end.must_raise Gcloud::Pubsub::NotFoundError
+      end
+    end
+
+    describe "created without autocomplete" do
+      let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
+                                                   pubsub.connection,
+                                                   false }
+
+      it "lists subscriptions" do
+        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+          [404, {"Content-Type"=>"application/json"},
+           not_found_error_json(topic_name)]
+        end
+
+        expect do
+          topic.subscriptions
+        end.must_raise Gcloud::Pubsub::NotFoundError
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -187,10 +187,10 @@ class MockPubsub < Minitest::Spec
     {
       "error" => {
         "code" => 404,
-        "message" => "Resource not found (resource=foo2).",
+        "message" => "Resource not found (resource=#{resource_name}).",
         "errors" => [
           {
-            "message" => "Resource not found (resource=foo2).",
+            "message" => "Resource not found (resource=#{resource_name}).",
             "domain" => "global",
             "reason" => "notFound"
           }


### PR DESCRIPTION
Add support for lazy objects that do not make HTTP calls when instantiated. This is an optimization to reduce the number of HTTP when using the Pub/Sub service. **This is a work in progress and is not completed yet.**

## Lazy Topic

- [x] Rename Project#get_topic (current logic, performs HTTP call)
- [x] Add Project#topic (gets lazy topic, autocreate in options)
- [x] Add Topic.new_lazy(name, connection, autocreate) (private API)
- [x] Add Topic#exists? (retrieves but does not create, public API)
- [x] Add Topic#lazy? (no gapi, private API)
- [x] Add Topic#autocreate? (if lazy? and flag set to autocreate, private API)
- [x] Topic#name (returns the correct path if lazy?)
- [x] Topic#publish (attempt if lazy? if that fails retrieve topic if lazy? and not autocreate?, retrieve or create topic if 
lazy? and autocreate?)
- [x] Topic#subscribe (attempt if lazy, create topic and retry if lazy? and response is not_found and autocreate?, otherwise raise error)
- [x] Subscription#topic (returns a lazy topic object instead of a string, lazy topic should not autocreate)
- [x] Connection#topic_path (return name when it contains the full path)

## Lazy Subscription

- [ ] Add Subscription#exists? (retrieves but does not create, public API)
- [ ] Add Subscription#lazy? (no gapi, private API)
- [ ] Subscription#name (returns the correct path if lazy?)
- [ ] Rename Project#get_subscription (current logic, performs HTTP call)
- [ ] Add Project#subscription (gets a lazy subscription)
- [ ] Rename Topic#get_subscription (current logic, performs HTTP call)
- [ ] Add Topic#subscription (gets a lazy subscription)
- [ ] Topic#subscriptions (attempt if lazy? if that fails raise error, return array of lazy subscriptions instead of array of strings)
- [ ] Connection#subscription_path  (return name when it contains the full path)

For background, see #146.