### PR TITLE
Update to Pub/Sub v1 API

### DIFF
--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -218,8 +218,9 @@ module Gcloud
   # Messages that are recieved can be acknowledged in Pub/Sub, marking the
   # message to be removed so it cannot be pulled again.
   #
-  # A Message that can be acknowledged is called an Event. Events can be
-  # acknowledged one at a time: (See Event#acknowledge!)
+  # A Message that can be acknowledged is called an ReceivedMesssage.
+  # ReceivedMesssages can be acknowledged one at a time:
+  # (See ReceivedMesssage#acknowledge!)
   #
   #   require "glcoud/pubsub"
   #
@@ -228,7 +229,7 @@ module Gcloud
   #   sub = pubsub.subscription "my-topic-sub"
   #   sub.pull.each { |msg| msg.acknowledge! }
   #
-  # Or, multiple events can be acknowledged in a single API call:
+  # Or, multiple messages can be acknowledged in a single API call:
   # (See Subscription#acknowledge)
   #
   #   require "glcoud/pubsub"
@@ -251,11 +252,11 @@ module Gcloud
   #   pubsub = Gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
-  #   event = sub.pull.first
-  #   if event
-  #     puts event.message.data
+  #   received_message = sub.pull.first
+  #   if received_message
+  #     puts received_message.message.data
   #     # Delay for 2 minutes
-  #     event.delay! 120
+  #     received_message.delay! 120
   #   end
   #
   # The message can also be made available for immediate redelivery:
@@ -265,11 +266,11 @@ module Gcloud
   #   pubsub = Gcloud.pubsub
   #
   #   sub = pubsub.subscription "my-topic-sub"
-  #   event = sub.pull.first
-  #   if event
-  #     puts event.message.data
+  #   received_message = sub.pull.first
+  #   if received_message
+  #     puts received_message.message.data
   #     # Mark for redelivery by setting the deadline to now
-  #     event.delay! 0
+  #     received_message.delay! 0
   #   end
   #
   module Pubsub

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -22,7 +22,7 @@ module Gcloud
     # Represents the connection to Pub/Sub,
     # as well as expose the API calls.
     class Connection #:nodoc:
-      API_VERSION = "v1beta2"
+      API_VERSION = "v1"
 
       attr_accessor :project
       attr_accessor :credentials #:nodoc:
@@ -196,11 +196,12 @@ module Gcloud
 
       ##
       # Modifies the ack deadline for a specific message.
-      def modify_ack_deadline subscription, id, deadline
+      def modify_ack_deadline subscription, ids, deadline
+        ids = Array ids
         @client.execute(
           api_method:  @pubsub.projects.subscriptions.modify_ack_deadline,
           parameters:  { subscription: subscription },
-          body_object: { ackId: id, ackDeadlineSeconds: deadline }
+          body_object: { ackIds: ids, ackDeadlineSeconds: deadline }
         )
       end
 

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -23,8 +23,8 @@ module Gcloud
     # Represents a Pub/Sub Message.
     #
     # Message objects are created by Topic#publish.
-    # Subscription#pull returns Event objects, which contain a Message object
-    # and can be acknowleged and/or delayed.
+    # Subscription#pull returns ReceivedMesssage objects, which contain a
+    # Message object and can be acknowleged and/or delayed.
     #
     #   require "glcoud/pubsub"
     #
@@ -35,10 +35,10 @@ module Gcloud
     #   message = topic.publish "new-message"
     #   puts message.data #=>  "new-message"
     #
-    #   # Pull an event/message
+    #   # Pull a message
     #   sub = pubsub.subscription "my-topic-sub"
-    #   event = sub.pull.first
-    #   puts event.message.data #=>  "new-message"
+    #   received_message = sub.pull.first
+    #   puts received_message.message.data #=>  "new-message"
     #
     class Message
       ##

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -72,6 +72,8 @@ module Gcloud
 
       ##
       # Retrieves topic by name.
+      # This difference between this method and Project#topic is that this
+      # method makes an API call to Pub/Sub verify the topic exists.
       #
       # === Parameters
       #
@@ -276,6 +278,8 @@ module Gcloud
 
       ##
       # Retrieves subscription by name.
+      # This difference between this method and Project#subscription is that
+      # this method makes an API call to Pub/Sub verify the subscription exists.
       #
       # === Parameters
       #

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -19,7 +19,7 @@ require "gcloud/pubsub/message"
 module Gcloud
   module Pubsub
     ##
-    # = Event
+    # = ReceivedMesssage
     #
     # Represents a Pub/Sub Message that can be acknowledged or delayed.
     #
@@ -28,13 +28,13 @@ module Gcloud
     #   pubsub = Gcloud.pubsub
     #
     #   sub = pubsub.subscription "my-topic-sub"
-    #   event = sub.pull.first
-    #   if event
-    #     puts event.message.data
-    #     event.acknowledge!
+    #   received_message = sub.pull.first
+    #   if received_message
+    #     puts received_message.message.data
+    #     received_message.acknowledge!
     #   end
     #
-    class Event
+    class ReceivedMesssage
       ##
       # The Subscription object.
       attr_accessor :subscription #:nodoc:
@@ -53,7 +53,7 @@ module Gcloud
       ##
       # The acknowledgment ID for the message being acknowledged.
       # This was returned by the Pub/Sub system in the Pull response.
-      # This ID must be used to acknowledge the received event.
+      # This ID must be used to acknowledge the received message.
       def ack_id
         @gapi["ackId"]
       end
@@ -75,10 +75,10 @@ module Gcloud
       #   pubsub = Gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
-      #   event = sub.pull.first
-      #   if event
-      #     puts event.message.data
-      #     event.acknowledge!
+      #   received_message = sub.pull.first
+      #   if received_message
+      #     puts received_message.message.data
+      #     received_message.acknowledge!
       #   end
       #
       def acknowledge!
@@ -110,11 +110,11 @@ module Gcloud
       #   pubsub = Gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
-      #   event = sub.pull.first
-      #   if event
-      #     puts event.message.data
+      #   received_message = sub.pull.first
+      #   if received_message
+      #     puts received_message.message.data
       #     # Delay for 2 minutes
-      #     event.delay! 120
+      #     received_message.delay! 120
       #   end
       #
       def delay! new_deadline
@@ -130,7 +130,7 @@ module Gcloud
       end
 
       ##
-      # New Event from a Google API Client object.
+      # New ReceivedMesssage from a Google API Client object.
       def self.from_gapi gapi, subscription #:nodoc:
         new.tap do |f|
           f.gapi         = gapi

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -66,6 +66,26 @@ module Gcloud
       alias_method :msg, :message
 
       ##
+      # The received message's data.
+      def data
+        message.data
+      end
+
+      ##
+      # The received message's attributes.
+      def attributes
+        message.attributes
+      end
+
+      ##
+      # The ID of received message, assigned by the server at publication time.
+      # Guaranteed to be unique within the topic.
+      def message_id
+        message.message_id
+      end
+      alias_method :msg_id, :message_id
+
+      ##
       # Acknowledges receipt of the message.
       #
       # === Example

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -320,7 +320,7 @@ module Gcloud
       #
       #   sub = pubsub.subscription "my-topic-sub"
       #   events = sub.pull
-      #   sub.delay 120, *events
+      #   sub.delay 120, events
       #
       def delay new_deadline, *messages
         ack_ids = coerce_ack_ids messages
@@ -367,7 +367,7 @@ module Gcloud
       # Makes sure the values are the +ack_id+.
       # If given several Event objects extract the +ack_id+ values.
       def coerce_ack_ids messages
-        Array(messages).map do |msg|
+        Array(messages).flatten.map do |msg|
           msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s
         end
       end

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -270,8 +270,8 @@ module Gcloud
       #
       # === Parameters
       #
-      # +ack_ids+::
-      #   One or more ack_id values. (+Event#ack_id+)
+      # +messages+::
+      #   One or more Event objects or ack_id values. (+Event+/+Event#ack_id+)
       #
       # === Example
       #
@@ -283,7 +283,8 @@ module Gcloud
       #   ack_ids = sub.pull.map { |msg| msg.ack_id }
       #   sub.acknowledge *ack_ids
       #
-      def acknowledge *ack_ids
+      def acknowledge *messages
+        ack_ids = coerce_ack_ids messages
         ensure_connection!
         resp = connection.acknowledge name, *ack_ids
         if resp.success?

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -295,6 +295,45 @@ module Gcloud
       alias_method :ack, :acknowledge
 
       ##
+      # Modifies the acknowledge deadline for messages.
+      #
+      # This indicates that more time is needed to process the messages, or to
+      # make the messages available for redelivery if the processing was
+      # interrupted.
+      #
+      # === Parameters
+      #
+      # +new_deadline+::
+      #   The new ack deadline in seconds from the time this request is sent
+      #   to the Pub/Sub system. Must be >= 0. For example, if the value is 10,
+      #   the new ack deadline will expire 10 seconds after the call is made.
+      #   Specifying zero may immediately make the messages available for
+      #   another pull request. (+Integer+)
+      # +ack_ids+::
+      #   One or more ack_id values. (+Event#ack_id+)
+      #
+      # === Example
+      #
+      #   require "glcoud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   sub = pubsub.subscription "my-topic-sub"
+      #   events = sub.pull
+      #   ack_ids = events.map { |msg| msg.ack_id }
+      #   sub.delay 120, *ack_ids
+      #
+      def delay new_deadline, *ack_ids
+        ensure_connection!
+        resp = connection.modify_ack_deadline name, ack_ids, new_deadline
+        if resp.success?
+          true
+        else
+          fail ApiError.from_response(resp)
+        end
+      end
+
+      ##
       # New Subscription from a Google API Client object.
       def self.from_gapi gapi, conn #:nodoc:
         new.tap do |f|

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -15,7 +15,7 @@
 
 require "gcloud/pubsub/errors"
 require "gcloud/pubsub/subscription/list"
-require "gcloud/pubsub/event"
+require "gcloud/pubsub/received_message"
 
 module Gcloud
   module Pubsub
@@ -219,7 +219,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Array of Gcloud::Pubsub::Event
+      # Array of Gcloud::Pubsub::ReceivedMesssage
       #
       # === Examples
       #
@@ -253,7 +253,7 @@ module Gcloud
         resp = connection.pull name, options
         if resp.success?
           Array(resp.data["receivedMessages"]).map do |gapi|
-            Event.from_gapi gapi, self
+            ReceivedMesssage.from_gapi gapi, self
           end
         else
           fail ApiError.from_response(resp)
@@ -271,7 +271,8 @@ module Gcloud
       # === Parameters
       #
       # +messages+::
-      #   One or more Event objects or ack_id values. (+Event+/+Event#ack_id+)
+      #   One or more ReceivedMesssage objects or ack_id values.
+      #   (+ReceivedMesssage+/+ReceivedMesssage#ack_id+)
       #
       # === Example
       #
@@ -311,7 +312,8 @@ module Gcloud
       #   Specifying zero may immediately make the messages available for
       #   another pull request. (+Integer+)
       # +messages+::
-      #   One or more Event objects or ack_id values. (+Event+/+Event#ack_id+)
+      #   One or more ReceivedMesssage objects or ack_id values.
+      #   (+ReceivedMesssage+/+ReceivedMesssage#ack_id+)
       #
       # === Example
       #
@@ -320,8 +322,8 @@ module Gcloud
       #   pubsub = Gcloud.pubsub
       #
       #   sub = pubsub.subscription "my-topic-sub"
-      #   events = sub.pull
-      #   sub.delay 120, events
+      #   messages = sub.pull
+      #   sub.delay 120, messages
       #
       def delay new_deadline, *messages
         ack_ids = coerce_ack_ids messages
@@ -366,7 +368,7 @@ module Gcloud
 
       ##
       # Makes sure the values are the +ack_id+.
-      # If given several Event objects extract the +ack_id+ values.
+      # If given several ReceivedMesssage objects extract the +ack_id+ values.
       def coerce_ack_ids messages
         Array(messages).flatten.map do |msg|
           msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -202,6 +202,8 @@ module Gcloud
 
       ##
       # Retrieves a subscription by name.
+      # This difference between this method and Topic#subscription is that
+      # this method makes an API call to Pub/Sub verify the subscription exists.
       #
       # === Parameters
       #

--- a/regression/pubsub/test_pubsub.rb
+++ b/regression/pubsub/test_pubsub.rb
@@ -195,7 +195,7 @@ describe Gcloud::Pubsub, :pubsub do
       subscription = topic.subscribe "#{$topic_prefix}-sub4"
       subscription.wont_be :nil?
       subscription.must_be_kind_of Gcloud::Pubsub::Subscription
-      # No events, should be empty
+      # No messages, should be empty
       events = subscription.pull
       events.must_be :empty?
       # Publish a new message

--- a/test/gcloud/pubsub/subscription/test_acknowledge.rb
+++ b/test/gcloud/pubsub/subscription/test_acknowledge.rb
@@ -22,15 +22,15 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
   let :subscription do
     Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
   end
-  let(:event1) { Gcloud::Pubsub::Event.from_gapi \
-                  JSON.parse(event_json("event1-msg-goes-here")), subscription }
-  let(:event2) { Gcloud::Pubsub::Event.from_gapi \
-                  JSON.parse(event_json("event2-msg-goes-here")), subscription }
-  let(:event3) { Gcloud::Pubsub::Event.from_gapi \
-                  JSON.parse(event_json("event3-msg-goes-here")), subscription }
+  let(:rec_message1) { Gcloud::Pubsub::ReceivedMesssage.from_gapi \
+                  JSON.parse(rec_message_json("rec_message1-msg-goes-here")), subscription }
+  let(:rec_message2) { Gcloud::Pubsub::ReceivedMesssage.from_gapi \
+                  JSON.parse(rec_message_json("rec_message2-msg-goes-here")), subscription }
+  let(:rec_message3) { Gcloud::Pubsub::ReceivedMesssage.from_gapi \
+                  JSON.parse(rec_message_json("rec_message3-msg-goes-here")), subscription }
 
   it "can acknowledge an ack id" do
-    ack_id = event1.ack_id
+    ack_id = rec_message1.ack_id
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].must_equal [ack_id]
@@ -41,7 +41,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
   end
 
   it "can acknowledge many ack ids" do
-    ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+    ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -52,7 +52,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
   end
 
   it "can acknowledge many ack ids in an array" do
-    ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+    ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -64,35 +64,35 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
   it "can acknowledge a message" do
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
-      JSON.parse(env.body)["ackIds"].must_equal [event1.ack_id]
+      JSON.parse(env.body)["ackIds"].must_equal [rec_message1.ack_id]
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    subscription.acknowledge event1
+    subscription.acknowledge rec_message1
   end
 
   it "can acknowledge many messages" do
-    events  = [event1, event3, event3]
-    ack_ids = events.map &:ack_id
+    rec_messages  = [rec_message1, rec_message3, rec_message3]
+    ack_ids = rec_messages.map &:ack_id
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].must_equal ack_ids
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    subscription.acknowledge *events
+    subscription.acknowledge *rec_messages
   end
 
   it "can acknowledge many messages in an array" do
-    events  = [event1, event3, event3]
-    ack_ids = events.map &:ack_id
+    rec_messages  = [rec_message1, rec_message3, rec_message3]
+    ack_ids = rec_messages.map &:ack_id
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].must_equal ack_ids
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    subscription.acknowledge events
+    subscription.acknowledge rec_messages
   end
 
   describe "lazy subscription object of a subscription that does exist" do
@@ -102,7 +102,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "can acknowledge an ack id" do
-      ack_id = event1.ack_id
+      ack_id = rec_message1.ack_id
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal [ack_id]
@@ -113,7 +113,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "can acknowledge many ack ids" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -124,7 +124,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "can acknowledge many ack ids in an array" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -136,35 +136,35 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
     it "can acknowledge a message" do
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal [event1.ack_id]
+        JSON.parse(env.body)["ackIds"].must_equal [rec_message1.ack_id]
         [200, {"Content-Type"=>"application/json"}, ""]
       end
 
-      subscription.acknowledge event1
+      subscription.acknowledge rec_message1
     end
 
     it "can acknowledge many messages" do
-      events  = [event1, event3, event3]
-      ack_ids = events.map &:ack_id
+      rec_messages  = [rec_message1, rec_message3, rec_message3]
+      ack_ids = rec_messages.map &:ack_id
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
         [200, {"Content-Type"=>"application/json"}, ""]
       end
 
-      subscription.acknowledge *events
+      subscription.acknowledge *rec_messages
     end
 
     it "can acknowledge many messages in an array" do
-      events  = [event1, event3, event3]
-      ack_ids = events.map &:ack_id
+      rec_messages  = [rec_message1, rec_message3, rec_message3]
+      ack_ids = rec_messages.map &:ack_id
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
         [200, {"Content-Type"=>"application/json"}, ""]
       end
 
-      subscription.acknowledge events
+      subscription.acknowledge rec_messages
     end
   end
 
@@ -175,7 +175,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "raises NotFoundError when acknowledging an ack id" do
-      ack_id = event1.ack_id
+      ack_id = rec_message1.ack_id
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal [ack_id]
@@ -189,7 +189,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "raises NotFoundError when acknowledging many ack ids" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -203,7 +203,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "raises NotFoundError when acknowledging many ack ids in an array" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -218,19 +218,19 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
     it "raises NotFoundError when acknowledging a message" do
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal [event1.ack_id]
+        JSON.parse(env.body)["ackIds"].must_equal [rec_message1.ack_id]
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end
 
       expect do
-        subscription.acknowledge event1
+        subscription.acknowledge rec_message1
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
 
     it "raises NotFoundError when acknowledging many messages" do
-      events  = [event1, event3, event3]
-      ack_ids = events.map &:ack_id
+      rec_messages  = [rec_message1, rec_message3, rec_message3]
+      ack_ids = rec_messages.map &:ack_id
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -239,13 +239,13 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
       end
 
       expect do
-        subscription.acknowledge *events
+        subscription.acknowledge *rec_messages
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
 
     it "raises NotFoundError when acknowledging many messages in an array" do
-      events  = [event1, event3, event3]
-      ack_ids = events.map &:ack_id
+      rec_messages  = [rec_message1, rec_message3, rec_message3]
+      ack_ids = rec_messages.map &:ack_id
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal ack_ids
@@ -254,7 +254,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
       end
 
       expect do
-        subscription.acknowledge events
+        subscription.acknowledge rec_messages
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
   end

--- a/test/gcloud/pubsub/subscription/test_acknowledge.rb
+++ b/test/gcloud/pubsub/subscription/test_acknowledge.rb
@@ -23,7 +23,17 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
   end
 
-  it "can acknowledge messages" do
+  it "can acknowledge an ack id" do
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+      JSON.parse(env.body)["ackIds"].count.must_equal 1
+      JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.acknowledge "ack-id-1"
+  end
+
+  it "can acknowledge many ack ids" do
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 3
       JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
@@ -41,7 +51,17 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
                                             pubsub.connection
     end
 
-    it "can acknowledge messages" do
+    it "can acknowledge an ack id" do
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].count.must_equal 1
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.acknowledge "ack-id-1"
+    end
+
+    it "can acknowledge many ack ids" do
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].count.must_equal 3
         JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
@@ -60,7 +80,20 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
                                             pubsub.connection
     end
 
-    it "raises NotFoundError when acknowledging messages" do
+    it "raises NotFoundError when acknowledging an ack_id" do
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].count.must_equal 1
+        JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.acknowledge "ack-id-1"
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
+    it "raises NotFoundError when acknowledging many ack ids" do
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].count.must_equal 3
         JSON.parse(env.body)["ackIds"].must_include "ack-id-1"

--- a/test/gcloud/pubsub/subscription/test_acknowledge.rb
+++ b/test/gcloud/pubsub/subscription/test_acknowledge.rb
@@ -24,7 +24,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
   end
 
   it "can acknowledge messages" do
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 3
       JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
       JSON.parse(env.body)["ackIds"].must_include "ack-id-2"
@@ -42,7 +42,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "can acknowledge messages" do
-      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].count.must_equal 3
         JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
         JSON.parse(env.body)["ackIds"].must_include "ack-id-2"
@@ -61,7 +61,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "raises NotFoundError when acknowledging messages" do
-      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].count.must_equal 3
         JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
         JSON.parse(env.body)["ackIds"].must_include "ack-id-2"

--- a/test/gcloud/pubsub/subscription/test_acknowledge.rb
+++ b/test/gcloud/pubsub/subscription/test_acknowledge.rb
@@ -51,6 +51,17 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     subscription.acknowledge *ack_ids
   end
 
+  it "can acknowledge many ack ids in an array" do
+    ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal ack_ids
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.acknowledge ack_ids
+  end
+
   it "can acknowledge a message" do
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].must_equal [event1.ack_id]
@@ -70,6 +81,18 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     subscription.acknowledge *events
+  end
+
+  it "can acknowledge many messages in an array" do
+    events  = [event1, event3, event3]
+    ack_ids = events.map &:ack_id
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal ack_ids
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.acknowledge events
   end
 
   describe "lazy subscription object of a subscription that does exist" do
@@ -100,6 +123,17 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
       subscription.acknowledge *ack_ids
     end
 
+    it "can acknowledge many ack ids in an array" do
+      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal ack_ids
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.acknowledge ack_ids
+    end
+
     it "can acknowledge a message" do
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal [event1.ack_id]
@@ -119,6 +153,18 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
       end
 
       subscription.acknowledge *events
+    end
+
+    it "can acknowledge many messages in an array" do
+      events  = [event1, event3, event3]
+      ack_ids = events.map &:ack_id
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal ack_ids
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.acknowledge events
     end
   end
 
@@ -156,6 +202,20 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
 
+    it "raises NotFoundError when acknowledging many ack ids in an array" do
+      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal ack_ids
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.acknowledge ack_ids
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
     it "raises NotFoundError when acknowledging a message" do
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
         JSON.parse(env.body)["ackIds"].must_equal [event1.ack_id]
@@ -180,6 +240,21 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
       expect do
         subscription.acknowledge *events
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
+    it "raises NotFoundError when acknowledging many messages in an array" do
+      events  = [event1, event3, event3]
+      ack_ids = events.map &:ack_id
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal ack_ids
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.acknowledge events
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
   end

--- a/test/gcloud/pubsub/subscription/test_attrs.rb
+++ b/test/gcloud/pubsub/subscription/test_attrs.rb
@@ -43,7 +43,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
   it "can update the endpoint" do
     new_push_endpoint = "https://foo.bar/baz"
 
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
       JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal new_push_endpoint
       [200, {"Content-Type"=>"application/json"}, ""]
     end
@@ -58,7 +58,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "makes an HTTP API call to retrieve topic" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [200, {"Content-Type"=>"application/json"},
          sub_json]
       end
@@ -69,7 +69,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "makes an HTTP API call to retrieve deadline" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [200, {"Content-Type"=>"application/json"},
          sub_json]
       end
@@ -78,7 +78,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "makes an HTTP API call to retrieve endpoint" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [200, {"Content-Type"=>"application/json"},
          sub_json]
       end
@@ -89,7 +89,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     it "makes an HTTP API call to update endpoint" do
       new_push_endpoint = "https://foo.bar/baz"
 
-      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
         JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal new_push_endpoint
         [200, {"Content-Type"=>"application/json"}, ""]
       end
@@ -105,7 +105,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "raises NotFoundError when retrieving topic" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end
@@ -116,7 +116,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "raises NotFoundError when retrieving deadline" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end
@@ -127,7 +127,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     end
 
     it "raises NotFoundError when retrieving endpoint" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end
@@ -140,7 +140,7 @@ describe Gcloud::Pubsub::Subscription, :attributes, :mock_pubsub do
     it "raises NotFoundError when updating endpoint" do
       new_push_endpoint = "https://foo.bar/baz"
 
-      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyPushConfig" do |env|
         JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal new_push_endpoint
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]

--- a/test/gcloud/pubsub/subscription/test_delay.rb
+++ b/test/gcloud/pubsub/subscription/test_delay.rb
@@ -1,0 +1,129 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+  let(:event1) { Gcloud::Pubsub::Event.from_gapi \
+                  JSON.parse(event_json("event1-msg-goes-here")), subscription }
+  let(:event2) { Gcloud::Pubsub::Event.from_gapi \
+                  JSON.parse(event_json("event2-msg-goes-here")), subscription }
+  let(:event3) { Gcloud::Pubsub::Event.from_gapi \
+                  JSON.parse(event_json("event3-msg-goes-here")), subscription }
+
+  it "can delay an ack id" do
+    ack_id = event1.ack_id
+    new_deadline = 42
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal             [ack_id]
+      JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.delay new_deadline, ack_id
+  end
+
+  it "can delay many ack ids" do
+    ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+    new_deadline = 42
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal             ack_ids
+      JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.delay new_deadline, *ack_ids
+  end
+
+  describe "lazy subscription object of a subscription that does exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "can delay an ack id" do
+      ack_id = event1.ack_id
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             [ack_id]
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.delay new_deadline, ack_id
+    end
+
+    it "can delay many ack ids" do
+      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             ack_ids
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.delay new_deadline, *ack_ids
+    end
+  end
+
+  describe "lazy subscription object of a subscription that does not exist" do
+    let :subscription do
+      Gcloud::Pubsub::Subscription.new_lazy sub_name,
+                                            pubsub.connection
+    end
+
+    it "raises NotFoundError when delaying an ack id" do
+      ack_id = event1.ack_id
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             [ack_id]
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.delay new_deadline, ack_id
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
+    it "raises NotFoundError when delaying many ack ids" do
+      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             ack_ids
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.delay new_deadline, *ack_ids
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_delay.rb
+++ b/test/gcloud/pubsub/subscription/test_delay.rb
@@ -55,6 +55,19 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     subscription.delay new_deadline, *ack_ids
   end
 
+  it "can delay many ack ids in an array" do
+    ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+    new_deadline = 42
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal             ack_ids
+      JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.delay new_deadline, ack_ids
+  end
+
   it "can delay a message" do
     new_deadline = 42
 
@@ -78,6 +91,19 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     end
 
     subscription.delay new_deadline, *events
+  end
+
+  it "can delay many messages in an array" do
+    events = [event1, event3, event3]
+    new_deadline = 42
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+      JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    subscription.delay new_deadline, events
   end
 
   describe "lazy subscription object of a subscription that does exist" do
@@ -112,6 +138,19 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
       subscription.delay new_deadline, *ack_ids
     end
 
+    it "can delay many ack ids in an array" do
+      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             ack_ids
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.delay new_deadline, ack_ids
+    end
+
     it "can delay a message" do
       new_deadline = 42
 
@@ -135,6 +174,19 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
       end
 
       subscription.delay new_deadline, *events
+    end
+
+    it "can delay many messages in an array" do
+      events = [event1, event3, event3]
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      subscription.delay new_deadline, events
     end
   end
 
@@ -176,6 +228,22 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
 
+    it "raises NotFoundError when delaying many ack ids in an array" do
+      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             ack_ids
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.delay new_deadline, ack_ids
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
     it "raises NotFoundError when delaying a message" do
       new_deadline = 42
 
@@ -204,6 +272,22 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
 
       expect do
         subscription.delay new_deadline, *events
+      end.must_raise Gcloud::Pubsub::NotFoundError
+    end
+
+    it "raises NotFoundError when delaying many messages in an array" do
+      events = [event1, event3, event3]
+      new_deadline = 42
+
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
+        JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+        JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
+        [404, {"Content-Type"=>"application/json"},
+         not_found_error_json(sub_name)]
+      end
+
+      expect do
+        subscription.delay new_deadline, events
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
   end

--- a/test/gcloud/pubsub/subscription/test_delay.rb
+++ b/test/gcloud/pubsub/subscription/test_delay.rb
@@ -22,15 +22,15 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
   let :subscription do
     Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
   end
-  let(:event1) { Gcloud::Pubsub::Event.from_gapi \
-                  JSON.parse(event_json("event1-msg-goes-here")), subscription }
-  let(:event2) { Gcloud::Pubsub::Event.from_gapi \
-                  JSON.parse(event_json("event2-msg-goes-here")), subscription }
-  let(:event3) { Gcloud::Pubsub::Event.from_gapi \
-                  JSON.parse(event_json("event3-msg-goes-here")), subscription }
+  let(:rec_message1) { Gcloud::Pubsub::ReceivedMesssage.from_gapi \
+                  JSON.parse(rec_message_json("rec_message1-msg-goes-here")), subscription }
+  let(:rec_message2) { Gcloud::Pubsub::ReceivedMesssage.from_gapi \
+                  JSON.parse(rec_message_json("rec_message2-msg-goes-here")), subscription }
+  let(:rec_message3) { Gcloud::Pubsub::ReceivedMesssage.from_gapi \
+                  JSON.parse(rec_message_json("rec_message3-msg-goes-here")), subscription }
 
   it "can delay an ack id" do
-    ack_id = event1.ack_id
+    ack_id = rec_message1.ack_id
     new_deadline = 42
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -43,7 +43,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
   end
 
   it "can delay many ack ids" do
-    ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+    ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     new_deadline = 42
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -56,7 +56,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
   end
 
   it "can delay many ack ids in an array" do
-    ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+    ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
     new_deadline = 42
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -72,38 +72,38 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     new_deadline = 42
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-      JSON.parse(env.body)["ackIds"].must_equal             [event1.ack_id]
+      JSON.parse(env.body)["ackIds"].must_equal             [rec_message1.ack_id]
       JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    subscription.delay new_deadline, event1
+    subscription.delay new_deadline, rec_message1
   end
 
   it "can delay many messages" do
-    events = [event1, event3, event3]
+    rec_messages = [rec_message1, rec_message3, rec_message3]
     new_deadline = 42
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-      JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+      JSON.parse(env.body)["ackIds"].must_equal             rec_messages.map(&:ack_id)
       JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    subscription.delay new_deadline, *events
+    subscription.delay new_deadline, *rec_messages
   end
 
   it "can delay many messages in an array" do
-    events = [event1, event3, event3]
+    rec_messages = [rec_message1, rec_message3, rec_message3]
     new_deadline = 42
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-      JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+      JSON.parse(env.body)["ackIds"].must_equal             rec_messages.map(&:ack_id)
       JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    subscription.delay new_deadline, events
+    subscription.delay new_deadline, rec_messages
   end
 
   describe "lazy subscription object of a subscription that does exist" do
@@ -113,7 +113,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     end
 
     it "can delay an ack id" do
-      ack_id = event1.ack_id
+      ack_id = rec_message1.ack_id
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -126,7 +126,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     end
 
     it "can delay many ack ids" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -139,7 +139,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     end
 
     it "can delay many ack ids in an array" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -155,38 +155,38 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal             [event1.ack_id]
+        JSON.parse(env.body)["ackIds"].must_equal             [rec_message1.ack_id]
         JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
         [200, {"Content-Type"=>"application/json"}, ""]
       end
 
-      subscription.delay new_deadline, event1
+      subscription.delay new_deadline, rec_message1
     end
 
     it "can delay many messages" do
-      events = [event1, event3, event3]
+      rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+        JSON.parse(env.body)["ackIds"].must_equal             rec_messages.map(&:ack_id)
         JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
         [200, {"Content-Type"=>"application/json"}, ""]
       end
 
-      subscription.delay new_deadline, *events
+      subscription.delay new_deadline, *rec_messages
     end
 
     it "can delay many messages in an array" do
-      events = [event1, event3, event3]
+      rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+        JSON.parse(env.body)["ackIds"].must_equal             rec_messages.map(&:ack_id)
         JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
         [200, {"Content-Type"=>"application/json"}, ""]
       end
 
-      subscription.delay new_deadline, events
+      subscription.delay new_deadline, rec_messages
     end
   end
 
@@ -197,7 +197,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     end
 
     it "raises NotFoundError when delaying an ack id" do
-      ack_id = event1.ack_id
+      ack_id = rec_message1.ack_id
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -213,7 +213,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     end
 
     it "raises NotFoundError when delaying many ack ids" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -229,7 +229,7 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
     end
 
     it "raises NotFoundError when delaying many ack ids in an array" do
-      ack_ids = [event1.ack_id, event3.ack_id, event3.ack_id]
+      ack_ids = [rec_message1.ack_id, rec_message3.ack_id, rec_message3.ack_id]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
@@ -248,46 +248,46 @@ describe Gcloud::Pubsub::Subscription, :delay, :mock_pubsub do
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal             [event1.ack_id]
+        JSON.parse(env.body)["ackIds"].must_equal             [rec_message1.ack_id]
         JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end
 
       expect do
-        subscription.delay new_deadline, event1
+        subscription.delay new_deadline, rec_message1
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
 
     it "raises NotFoundError when delaying many messages" do
-      events = [event1, event3, event3]
+      rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+        JSON.parse(env.body)["ackIds"].must_equal             rec_messages.map(&:ack_id)
         JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end
 
       expect do
-        subscription.delay new_deadline, *events
+        subscription.delay new_deadline, *rec_messages
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
 
     it "raises NotFoundError when delaying many messages in an array" do
-      events = [event1, event3, event3]
+      rec_messages = [rec_message1, rec_message3, rec_message3]
       new_deadline = 42
 
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:modifyAckDeadline" do |env|
-        JSON.parse(env.body)["ackIds"].must_equal             events.map(&:ack_id)
+        JSON.parse(env.body)["ackIds"].must_equal             rec_messages.map(&:ack_id)
         JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end
 
       expect do
-        subscription.delay new_deadline, events
+        subscription.delay new_deadline, rec_messages
       end.must_raise Gcloud::Pubsub::NotFoundError
     end
   end

--- a/test/gcloud/pubsub/subscription/test_delete.rb
+++ b/test/gcloud/pubsub/subscription/test_delete.rb
@@ -24,7 +24,7 @@ describe Gcloud::Pubsub::Subscription, :delete, :mock_pubsub do
   end
 
   it "can delete itself" do
-    mock_connection.delete "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+    mock_connection.delete "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
@@ -38,7 +38,7 @@ describe Gcloud::Pubsub::Subscription, :delete, :mock_pubsub do
     end
 
     it "can delete itself" do
-      mock_connection.delete "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.delete "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [200, {"Content-Type"=>"application/json"}, ""]
       end
 
@@ -53,7 +53,7 @@ describe Gcloud::Pubsub::Subscription, :delete, :mock_pubsub do
     end
 
     it "raises NotFoundError when deleting itself" do
-      mock_connection.delete "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.delete "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end

--- a/test/gcloud/pubsub/subscription/test_exists.rb
+++ b/test/gcloud/pubsub/subscription/test_exists.rb
@@ -38,7 +38,7 @@ describe Gcloud::Pubsub::Subscription, :exists, :mock_pubsub do
     end
 
     it "checks if the subscription exists by making an HTTP call" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [200, {"Content-Type"=>"application/json"},
          sub_json]
       end
@@ -56,7 +56,7 @@ describe Gcloud::Pubsub::Subscription, :exists, :mock_pubsub do
     end
 
     it "checks if the subscription exists by making an HTTP call" do
-      mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+      mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end

--- a/test/gcloud/pubsub/subscription/test_pull.rb
+++ b/test/gcloud/pubsub/subscription/test_pull.rb
@@ -24,15 +24,15 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
   end
 
   it "can pull messages" do
-    event_msg = "pulled-message"
+    rec_message_msg = "pulled-message"
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
       [200, {"Content-Type"=>"application/json"},
-       events_json(event_msg)]
+       rec_messages_json(rec_message_msg)]
     end
 
-    events = subscription.pull
-    events.wont_be :empty?
-    events.first.message.data.must_equal event_msg
+    rec_messages = subscription.pull
+    rec_messages.wont_be :empty?
+    rec_messages.first.message.data.must_equal rec_message_msg
   end
 
   describe "lazy subscription object of a subscription that does exist" do
@@ -42,15 +42,15 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "can pull messages" do
-      event_msg = "pulled-message"
+      rec_message_msg = "pulled-message"
       mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
         [200, {"Content-Type"=>"application/json"},
-         events_json(event_msg)]
+         rec_messages_json(rec_message_msg)]
       end
 
-      events = subscription.pull
-      events.wont_be :empty?
-      events.first.message.data.must_equal event_msg
+      rec_messages = subscription.pull
+      rec_messages.wont_be :empty?
+      rec_messages.first.message.data.must_equal rec_message_msg
     end
   end
 

--- a/test/gcloud/pubsub/subscription/test_pull.rb
+++ b/test/gcloud/pubsub/subscription/test_pull.rb
@@ -25,7 +25,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
   it "can pull messages" do
     event_msg = "pulled-message"
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
       [200, {"Content-Type"=>"application/json"},
        events_json(event_msg)]
     end
@@ -43,7 +43,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
 
     it "can pull messages" do
       event_msg = "pulled-message"
-      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
         [200, {"Content-Type"=>"application/json"},
          events_json(event_msg)]
       end
@@ -61,7 +61,7 @@ describe Gcloud::Pubsub::Subscription, :pull, :mock_pubsub do
     end
 
     it "raises NotFoundError when pulling messages" do
-      mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
         [404, {"Content-Type"=>"application/json"},
          not_found_error_json(sub_name)]
       end

--- a/test/gcloud/pubsub/test_event.rb
+++ b/test/gcloud/pubsub/test_event.rb
@@ -47,7 +47,7 @@ describe Gcloud::Pubsub::Event, :mock_pubsub do
   end
 
   it "can acknowledge" do
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 1
       JSON.parse(env.body)["ackIds"].first.must_equal event.ack_id
       [200, {"Content-Type"=>"application/json"}, ""]
@@ -57,7 +57,7 @@ describe Gcloud::Pubsub::Event, :mock_pubsub do
   end
 
   it "can ack" do
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 1
       JSON.parse(env.body)["ackIds"].first.must_equal event.ack_id
       [200, {"Content-Type"=>"application/json"}, ""]
@@ -69,8 +69,8 @@ describe Gcloud::Pubsub::Event, :mock_pubsub do
   it "can delay" do
     new_deadline = 42
 
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:modifyAckDeadline" do |env|
-      JSON.parse(env.body)["ackId"].must_equal              event.ack_id
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:modifyAckDeadline" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal             [event.ack_id]
       JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
       [200, {"Content-Type"=>"application/json"}, ""]
     end

--- a/test/gcloud/pubsub/test_message.rb
+++ b/test/gcloud/pubsub/test_message.rb
@@ -15,7 +15,7 @@
 require "helper"
 
 describe Gcloud::Pubsub::Message, :mock_pubsub do
-  let(:data)       { "event-msg-goes-here" }
+  let(:data)       { "rec_message-msg-goes-here" }
   let(:attributes) { { "foo" => "FOO", "bar" => "BAR" } }
   let(:msg)    { Gcloud::Pubsub::Message.new data, attributes }
 
@@ -36,22 +36,22 @@ describe Gcloud::Pubsub::Message, :mock_pubsub do
       json = JSON.parse(subscription_json(topic_name, subscription_name))
       Gcloud::Pubsub::Subscription.from_gapi json, pubsub.connection
     end
-    let(:event_name) { "event-name-goes-here" }
-    let(:event_msg)  { "event-msg-goes-here" }
-    let(:event_data)  { JSON.parse(event_json(event_msg)) }
-    let(:msg)     { Gcloud::Pubsub::Message.from_gapi event_data["message"] }
+    let(:rec_message_name) { "rec_message-name-goes-here" }
+    let(:rec_message_msg)  { "rec_message-msg-goes-here" }
+    let(:rec_message_data)  { JSON.parse(rec_message_json(rec_message_msg)) }
+    let(:msg)     { Gcloud::Pubsub::Message.from_gapi rec_message_data["message"] }
 
     it "knows its data" do
-      msg.data.must_equal event_data["message"]["data"]
+      msg.data.must_equal rec_message_data["message"]["data"]
     end
 
     it "knows its attributes" do
-      msg.attributes.must_equal event_data["message"]["attributes"]
+      msg.attributes.must_equal rec_message_data["message"]["attributes"]
     end
 
     it "knows its message_id" do
-      msg.msg_id.must_equal     event_data["message"]["messageId"]
-      msg.message_id.must_equal event_data["message"]["messageId"]
+      msg.msg_id.must_equal     rec_message_data["message"]["messageId"]
+      msg.message_id.must_equal rec_message_data["message"]["messageId"]
     end
   end
 end

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -21,7 +21,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "creates a topic" do
     new_topic_name = "new-topic-#{Time.now.to_i}"
-    mock_connection.put "/v1beta2/projects/#{project}/topics/#{new_topic_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/topics/#{new_topic_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        topic_json(new_topic_name)]
     end
@@ -31,7 +31,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "creates a topic with new_topic_alias" do
     new_topic_name = "new-topic-#{Time.now.to_i}"
-    mock_connection.put "/v1beta2/projects/#{project}/topics/#{new_topic_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/topics/#{new_topic_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        topic_json(new_topic_name)]
     end
@@ -48,7 +48,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "gets a topic with get_topic" do
     topic_name = "found-topic"
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        topic_json(topic_name)]
     end
@@ -60,7 +60,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "gets a topic with find_topic alias" do
     topic_name = "found-topic"
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        topic_json(topic_name)]
     end
@@ -72,7 +72,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "lists topics" do
     num_topics = 3
-    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics" do |env|
       [200, {"Content-Type"=>"application/json"},
        topics_json(num_topics)]
     end
@@ -83,7 +83,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "lists topics with find_topics alias" do
     num_topics = 3
-    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics" do |env|
       [200, {"Content-Type"=>"application/json"},
        topics_json(num_topics)]
     end
@@ -94,7 +94,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "lists topics with list_topics alias" do
     num_topics = 3
-    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics" do |env|
       [200, {"Content-Type"=>"application/json"},
        topics_json(num_topics)]
     end
@@ -104,11 +104,11 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "paginates topics" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics" do |env|
       [200, {"Content-Type"=>"application/json"},
        topics_json(3, "next_page_token")]
     end
-    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics" do |env|
       env.params.must_include "pageToken"
       env.params["pageToken"].must_equal "next_page_token"
       [200, {"Content-Type"=>"application/json"},
@@ -126,7 +126,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "paginates topics with max set" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics" do |env|
       env.params.must_include "pageSize"
       env.params["pageSize"].must_equal "3"
       [200, {"Content-Type"=>"application/json"},
@@ -140,7 +140,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "paginates topics without max set" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics" do |env|
       env.params.wont_include "pageSize"
       [200, {"Content-Type"=>"application/json"},
        topics_json(3, "next_page_token")]
@@ -162,7 +162,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "gets a subscription with get_subscription" do
     sub_name = "found-sub-#{Time.now.to_i}"
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscription_json("random-topic", sub_name)]
     end
@@ -175,7 +175,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
 
   it "gets a subscription with find_subscription alias" do
     sub_name = "found-sub-#{Time.now.to_i}"
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscription_json("random-topic", sub_name)]
     end
@@ -187,7 +187,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "lists subscriptions" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json("fake-topic", 3)]
     end
@@ -200,7 +200,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "lists subscriptions with find_subscriptions alias" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json("fake-topic", 3)]
     end
@@ -213,7 +213,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "lists subscriptions with list_subscriptions alias" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json("fake-topic", 3)]
     end
@@ -226,11 +226,11 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "paginates subscriptions" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json("fake-topic", 3, "next_page_token")]
     end
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions" do |env|
       env.params.must_include "pageToken"
       env.params["pageToken"].must_equal "next_page_token"
       [200, {"Content-Type"=>"application/json"},
@@ -248,7 +248,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "paginates subscriptions with max set" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions" do |env|
       env.params.must_include "pageSize"
       env.params["pageSize"].must_equal "3"
       [200, {"Content-Type"=>"application/json"},
@@ -262,7 +262,7 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
   end
 
   it "paginates subscriptions without max set" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions" do |env|
       env.params.wont_include "pageSize"
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json("fake-topic", 3, "next_page_token")]

--- a/test/gcloud/pubsub/test_received_message.rb
+++ b/test/gcloud/pubsub/test_received_message.rb
@@ -14,7 +14,7 @@
 
 require "helper"
 
-describe Gcloud::Pubsub::Event, :mock_pubsub do
+describe Gcloud::Pubsub::ReceivedMesssage, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
                                                 pubsub.connection }
@@ -23,58 +23,58 @@ describe Gcloud::Pubsub::Event, :mock_pubsub do
     json = JSON.parse(subscription_json(topic_name, subscription_name))
     Gcloud::Pubsub::Subscription.from_gapi json, pubsub.connection
   end
-  let(:event_name) { "event-name-goes-here" }
-  let(:event_msg)  { "event-msg-goes-here" }
-  let(:event_data)  { JSON.parse(event_json(event_msg)) }
-  let(:event) { Gcloud::Pubsub::Event.from_gapi event_data,
+  let(:rec_message_name) { "rec_message-name-goes-here" }
+  let(:rec_message_msg)  { "rec_message-msg-goes-here" }
+  let(:rec_message_data)  { JSON.parse(rec_message_json(rec_message_msg)) }
+  let(:rec_message) { Gcloud::Pubsub::ReceivedMesssage.from_gapi rec_message_data,
                                                 subscription }
 
   it "knows its subscription" do
-    event.subscription.wont_be :nil?
-    event.subscription.name.must_equal subscription_path(subscription_name)
+    rec_message.subscription.wont_be :nil?
+    rec_message.subscription.name.must_equal subscription_path(subscription_name)
   end
 
   it "knows its ack_id" do
-    event.ack_id.must_equal event_data["ackId"]
+    rec_message.ack_id.must_equal rec_message_data["ackId"]
   end
 
   it "has a message" do
-    event.message.wont_be :nil?
-    event.message.data.must_equal event_data["message"]["data"]
-    event.message.attributes.must_equal event_data["message"]["attributes"]
-    event.message.msg_id.must_equal event_data["message"]["messageId"]
-    event.message.message_id.must_equal event_data["message"]["messageId"]
+    rec_message.message.wont_be :nil?
+    rec_message.message.data.must_equal rec_message_data["message"]["data"]
+    rec_message.message.attributes.must_equal rec_message_data["message"]["attributes"]
+    rec_message.message.msg_id.must_equal rec_message_data["message"]["messageId"]
+    rec_message.message.message_id.must_equal rec_message_data["message"]["messageId"]
   end
 
   it "can acknowledge" do
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 1
-      JSON.parse(env.body)["ackIds"].first.must_equal event.ack_id
+      JSON.parse(env.body)["ackIds"].first.must_equal rec_message.ack_id
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    event.acknowledge!
+    rec_message.acknowledge!
   end
 
   it "can ack" do
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 1
-      JSON.parse(env.body)["ackIds"].first.must_equal event.ack_id
+      JSON.parse(env.body)["ackIds"].first.must_equal rec_message.ack_id
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    event.ack!
+    rec_message.ack!
   end
 
   it "can delay" do
     new_deadline = 42
 
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:modifyAckDeadline" do |env|
-      JSON.parse(env.body)["ackIds"].must_equal             [event.ack_id]
+      JSON.parse(env.body)["ackIds"].must_equal             [rec_message.ack_id]
       JSON.parse(env.body)["ackDeadlineSeconds"].must_equal new_deadline
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
-    event.delay! new_deadline
+    rec_message.delay! new_deadline
   end
 end

--- a/test/gcloud/pubsub/test_received_message.rb
+++ b/test/gcloud/pubsub/test_received_message.rb
@@ -46,6 +46,19 @@ describe Gcloud::Pubsub::ReceivedMesssage, :mock_pubsub do
     rec_message.message.message_id.must_equal rec_message_data["message"]["messageId"]
   end
 
+  it "knows the message's data" do
+    rec_message.data.must_equal rec_message.message.data
+  end
+
+  it "knows the message's attributes" do
+    rec_message.attributes.must_equal rec_message.message.attributes
+  end
+
+  it "knows the message's message_id" do
+    rec_message.msg_id.must_equal     rec_message.message.msg_id
+    rec_message.message_id.must_equal rec_message.message.message_id
+  end
+
   it "can acknowledge" do
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 1

--- a/test/gcloud/pubsub/test_subscription.rb
+++ b/test/gcloud/pubsub/test_subscription.rb
@@ -43,7 +43,7 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
   it "can update the endpoint" do
     new_push_endpoint = "https://foo.bar/baz"
 
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:modifyPushConfig" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:modifyPushConfig" do |env|
       JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal new_push_endpoint
       [200, {"Content-Type"=>"application/json"}, ""]
     end
@@ -52,7 +52,7 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can delete itself" do
-    mock_connection.delete "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}" do |env|
+    mock_connection.delete "/v1/projects/#{project}/subscriptions/#{subscription_name}" do |env|
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
@@ -61,7 +61,7 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
 
   it "can pull a message" do
     event_msg = "pulled-message"
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:pull" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:pull" do |env|
       [200, {"Content-Type"=>"application/json"},
        events_json(event_msg)]
     end
@@ -72,7 +72,7 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can acknowledge one message" do
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 1
       JSON.parse(env.body)["ackIds"].first.must_equal "ack-id-1"
       [200, {"Content-Type"=>"application/json"}, ""]
@@ -82,7 +82,7 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can acknowledge many messages" do
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 3
       JSON.parse(env.body)["ackIds"].must_include "ack-id-1"
       JSON.parse(env.body)["ackIds"].must_include "ack-id-2"
@@ -94,7 +94,7 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can acknowledge with ack" do
-    mock_connection.post "/v1beta2/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:acknowledge" do |env|
       JSON.parse(env.body)["ackIds"].count.must_equal 1
       JSON.parse(env.body)["ackIds"].first.must_equal "ack-id-1"
       [200, {"Content-Type"=>"application/json"}, ""]

--- a/test/gcloud/pubsub/test_subscription.rb
+++ b/test/gcloud/pubsub/test_subscription.rb
@@ -60,15 +60,15 @@ describe Gcloud::Pubsub::Subscription, :mock_pubsub do
   end
 
   it "can pull a message" do
-    event_msg = "pulled-message"
+    rec_message_msg = "pulled-message"
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{subscription_name}:pull" do |env|
       [200, {"Content-Type"=>"application/json"},
-       events_json(event_msg)]
+       rec_messages_json(rec_message_msg)]
     end
 
-    events = subscription.pull
-    events.wont_be :empty?
-    events.first.message.data.must_equal event_msg
+    rec_messages = subscription.pull
+    rec_messages.wont_be :empty?
+    rec_messages.first.message.data.must_equal rec_message_msg
   end
 
   it "can acknowledge one message" do

--- a/test/gcloud/pubsub/test_topic.rb
+++ b/test/gcloud/pubsub/test_topic.rb
@@ -24,7 +24,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "can delete itself" do
-    mock_connection.delete "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+    mock_connection.delete "/v1/projects/#{project}/topics/#{topic_name}" do |env|
       [200, {"Content-Type"=>"application/json"}, ""]
     end
 
@@ -33,7 +33,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "creates a subscription" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, new_sub_name)]
@@ -46,7 +46,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "creates a subscription with create_subscription alias" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, new_sub_name)]
@@ -59,7 +59,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "creates a subscription with new_subscription alias" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, new_sub_name)]
@@ -71,7 +71,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "creates a subscription without giving a name" do
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       JSON.parse(env.body)["name"].must_be :nil?
       [200, {"Content-Type"=>"application/json"},
@@ -86,7 +86,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   it "creates a subscription with a deadline" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     deadline = 42
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal              topic_path(topic_name)
       JSON.parse(env.body)["ackDeadlineSeconds"].must_equal deadline
       [200, {"Content-Type"=>"application/json"},
@@ -101,7 +101,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   it "creates a subscription with a push endpoint" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     endpoint = "http://foo.bar/baz"
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal                      topic_path(topic_name)
       JSON.parse(env.body)["pushConfig"]["pushEndpoint"].must_equal endpoint
       [200, {"Content-Type"=>"application/json"},
@@ -115,7 +115,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "creates a subscription when calling subscribe" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, new_sub_name)]
@@ -128,7 +128,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "raises when creating a subscription that already exists" do
     existing_sub_name = "existing-sub"
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{existing_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{existing_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       [409, {"Content-Type"=>"application/json"},
        already_exists_error_json(existing_sub_name)]
@@ -141,7 +141,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "raises when creating a subscription on a deleted topic" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       [404, {"Content-Type"=>"application/json"},
        not_found_error_json(topic_name)]
@@ -164,7 +164,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "gets a subscription with get_subscription" do
     sub_name = "found-sub-#{Time.now.to_i}"
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, sub_name)]
     end
@@ -177,7 +177,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "gets a subscription with find_subscription alias" do
     sub_name = "found-sub-#{Time.now.to_i}"
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{sub_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, sub_name)]
     end
@@ -189,7 +189,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "lists subscriptions" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json(topic_name, 3)]
     end
@@ -202,7 +202,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "lists subscriptions with find_subscriptions alias" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json(topic_name, 3)]
     end
@@ -215,7 +215,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "lists subscriptions with list_subscriptions alias" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json(topic_name, 3)]
     end
@@ -228,11 +228,11 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "paginates subscriptions" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json("fake-topic", 3, "next_page_token")]
     end
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       env.params.must_include "pageToken"
       env.params["pageToken"].must_equal "next_page_token"
       [200, {"Content-Type"=>"application/json"},
@@ -256,7 +256,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "paginates subscriptions with max set" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       env.params.must_include "pageSize"
       env.params["pageSize"].must_equal "3"
       [200, {"Content-Type"=>"application/json"},
@@ -273,7 +273,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   end
 
   it "paginates subscriptions without max set" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       env.params.wont_include "pageSize"
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json("fake-topic", 3, "next_page_token")]
@@ -291,7 +291,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   it "can publish a message" do
     message = "new-message-here"
     base_64_msg = [message].pack("m")
-    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+    mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
       JSON.parse(env.body)["messages"].first["data"].must_equal base_64_msg
       [200, {"Content-Type"=>"application/json"},
        { messageIds: ["msg1"] }.to_json]
@@ -305,7 +305,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   it "can publish a message with attributes" do
     message = "new-message-here"
     base_64_msg = [message].pack("m")
-    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+    mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
       JSON.parse(env.body)["messages"].first["data"].must_equal base_64_msg
       [200, {"Content-Type"=>"application/json"},
        { messageIds: ["msg1"] }.to_json]
@@ -323,7 +323,7 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     base_64_msg1 = [message1].pack("m")
     base_64_msg2 = [message2].pack("m")
 
-    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+    mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
       JSON.parse(env.body)["messages"].first["data"].must_equal base_64_msg1
       JSON.parse(env.body)["messages"].last["data"].must_equal  base_64_msg2
       [200, {"Content-Type"=>"application/json"},

--- a/test/gcloud/pubsub/topic/test_exists.rb
+++ b/test/gcloud/pubsub/topic/test_exists.rb
@@ -33,7 +33,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
                                                    pubsub.connection }
 
       it "checks if the topic exists by making an HTTP call" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            topic_json(topic_name)]
         end
@@ -50,7 +50,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
                                                    true }
 
       it "checks if the topic exists by making an HTTP call" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            topic_json(topic_name)]
         end
@@ -67,7 +67,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
                                                    false }
 
       it "checks if the topic exists by making an HTTP call" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            topic_json(topic_name)]
         end
@@ -85,7 +85,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
                                                    pubsub.connection }
 
       it "checks if the topic exists by making an HTTP call" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
@@ -102,7 +102,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
                                                    true }
 
       it "checks if the topic exists by making an HTTP call" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
@@ -119,7 +119,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
                                                    false }
 
       it "checks if the topic exists by making an HTTP call" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end

--- a/test/gcloud/pubsub/topic/test_get_subscription.rb
+++ b/test/gcloud/pubsub/topic/test_get_subscription.rb
@@ -22,7 +22,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
   let(:not_found_sub_name) { "found-sub-#{Time.now.to_i}" }
 
   it "gets an existing subscription" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, found_sub_name)]
     end
@@ -33,7 +33,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
   end
 
   it "returns nil when getting an non-existant subscription" do
-    mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
       [404, {"Content-Type"=>"application/json"},
        not_found_error_json(not_found_sub_name)]
     end
@@ -49,7 +49,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
                                                    true }
 
       it "gets an existing subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            subscription_json(topic_name, found_sub_name)]
         end
@@ -60,7 +60,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
       end
 
       it "returns nil when getting an non-existant subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(not_found_sub_name)]
         end
@@ -76,7 +76,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
                                                    false }
 
       it "gets an existing subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            subscription_json(topic_name, found_sub_name)]
         end
@@ -87,7 +87,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
       end
 
       it "returns nil when getting an non-existant subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(not_found_sub_name)]
         end
@@ -106,7 +106,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
 
       it "returns nil when getting an non-existant subscription" do
         # by definition, all subscriptions for this topic are non-existant
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(not_found_sub_name)]
         end
@@ -122,7 +122,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
                                                    false }
 
       it "returns nil when getting an non-existant subscription" do
-        mock_connection.get "/v1beta2/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
+        mock_connection.get "/v1/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(not_found_sub_name)]
         end

--- a/test/gcloud/pubsub/topic/test_publish.rb
+++ b/test/gcloud/pubsub/topic/test_publish.rb
@@ -26,7 +26,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
   let(:msg_packed3) { [message3].pack("m") }
 
   it "publishes a message" do
-    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+    mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
       JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
       [200, {"Content-Type"=>"application/json"},
        { messageIds: ["msg1"] }.to_json]
@@ -38,7 +38,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
   end
 
   it "publishes a message with attributes" do
-    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+    mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
       JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
       [200, {"Content-Type"=>"application/json"},
        { messageIds: ["msg1"] }.to_json]
@@ -51,7 +51,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
   end
 
   it "publishes multiple messages with a block" do
-    mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+    mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
       JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
       JSON.parse(env.body)["messages"].last["data"].must_equal  msg_packed3
       [200, {"Content-Type"=>"application/json"},
@@ -77,7 +77,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
                                                    true }
 
       it "publishes a message" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           [200, {"Content-Type"=>"application/json"},
            { messageIds: ["msg1"] }.to_json]
@@ -89,7 +89,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       end
 
       it "publishes a message with attributes" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           [200, {"Content-Type"=>"application/json"},
            { messageIds: ["msg1"] }.to_json]
@@ -102,7 +102,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       end
 
       it "publishes multiple messages with a block" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           [200, {"Content-Type"=>"application/json"},
            { messageIds: ["msg1", "msg2", "msg3"] }.to_json]
@@ -127,7 +127,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
                                                    false }
 
       it "publishes a message" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           [200, {"Content-Type"=>"application/json"},
            { messageIds: ["msg1"] }.to_json]
@@ -139,7 +139,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       end
 
       it "publishes a message with attributes" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           [200, {"Content-Type"=>"application/json"},
            { messageIds: ["msg1"] }.to_json]
@@ -152,7 +152,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       end
 
       it "publishes multiple messages with a block" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           JSON.parse(env.body)["messages"].last["data"].must_equal  msg_packed3
           [200, {"Content-Type"=>"application/json"},
@@ -181,17 +181,17 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
 
       it "publishes a message" do
         #first, failed attempt to publish
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
         # second, successful attempt to create topic
-        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            topic_json(topic_name)]
         end
         # third, successful attempt to publish
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           [200, {"Content-Type"=>"application/json"},
            { messageIds: ["msg1"] }.to_json]
@@ -204,17 +204,17 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
 
       it "publishes a message with attributes" do
         #first, failed attempt to publish
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
         # second, successful attempt to create topic
-        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            topic_json(topic_name)]
         end
         # third, successful attempt to publish
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           [200, {"Content-Type"=>"application/json"},
            { messageIds: ["msg1"] }.to_json]
@@ -228,17 +228,17 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
 
       it "publishes multiple messages with a block" do
         #first, failed attempt to publish
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
         # second, successful attempt to create topic
-        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            topic_json(topic_name)]
         end
         # third, successful attempt to publish
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           JSON.parse(env.body)["messages"].first["data"].must_equal msg_packed1
           JSON.parse(env.body)["messages"].last["data"].must_equal  msg_packed3
           [200, {"Content-Type"=>"application/json"},
@@ -264,7 +264,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
                                                    false }
 
       it "publishes a message" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
@@ -275,7 +275,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       end
 
       it "publishes a message with attributes" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
@@ -286,7 +286,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       end
 
       it "publishes multiple messages with a block" do
-        mock_connection.post "/v1beta2/projects/#{project}/topics/#{topic_name}:publish" do |env|
+        mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end

--- a/test/gcloud/pubsub/topic/test_subscribe.rb
+++ b/test/gcloud/pubsub/topic/test_subscribe.rb
@@ -21,7 +21,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
   let(:new_sub_name) { "new-sub-#{Time.now.to_i}" }
 
   it "creates a subscription when calling subscribe" do
-    mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+    mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
       JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
       [200, {"Content-Type"=>"application/json"},
        subscription_json(topic_name, new_sub_name)]
@@ -39,7 +39,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
                                                    true }
 
       it "creates a subscription when calling subscribe" do
-        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
           JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
           [200, {"Content-Type"=>"application/json"},
            subscription_json(topic_name, new_sub_name)]
@@ -57,7 +57,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
                                                    false }
 
       it "creates a subscription when calling subscribe" do
-        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
           JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
           [200, {"Content-Type"=>"application/json"},
            subscription_json(topic_name, new_sub_name)]
@@ -78,17 +78,17 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
 
       it "creates a subscription when calling subscribe" do
         #first, failed attempt to subscribe
-        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
         # second, successful attempt to create topic
-        mock_connection.put "/v1beta2/projects/#{project}/topics/#{topic_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/topics/#{topic_name}" do |env|
           [200, {"Content-Type"=>"application/json"},
            topic_json(topic_name)]
         end
         # third, successful attempt to subscribe
-        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
           JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
           [200, {"Content-Type"=>"application/json"},
            subscription_json(topic_name, new_sub_name)]
@@ -106,7 +106,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
                                                    false }
 
       it "raises NotFoundError when calling subscribe" do
-        mock_connection.put "/v1beta2/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
+        mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end

--- a/test/gcloud/pubsub/topic/test_subscriptions.rb
+++ b/test/gcloud/pubsub/topic/test_subscriptions.rb
@@ -19,7 +19,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
   let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
                                                 pubsub.connection }
   it "lists subscriptions" do
-    mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
       [200, {"Content-Type"=>"application/json"},
        subscriptions_json(topic_name, 3)]
     end
@@ -38,7 +38,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
                                                    true }
 
       it "lists subscriptions" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
           [200, {"Content-Type"=>"application/json"},
            subscriptions_json(topic_name, 3)]
         end
@@ -57,7 +57,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
                                                    false }
 
       it "lists subscriptions" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
           [200, {"Content-Type"=>"application/json"},
            subscriptions_json(topic_name, 3)]
         end
@@ -78,7 +78,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
                                                    true }
 
       it "lists subscriptions" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end
@@ -95,7 +95,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
                                                    false }
 
       it "lists subscriptions" do
-        mock_connection.get "/v1beta2/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
+        mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
           [404, {"Content-Type"=>"application/json"},
            not_found_error_json(topic_name)]
         end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -147,13 +147,13 @@ class MockPubsub < Minitest::Spec
     }.to_json
   end
 
-  def event_json message
+  def event_json message, id = rand(1000000)
     {
-      "ackId" => "ack-id-123456789",
+      "ackId" => "ack-id-#{id}",
       "message" => {
         "data" => [message].pack("m"),
         "attributes" => {},
-        "messageId" => "msg-id-123456789",
+        "messageId" => "msg-id-#{id}",
       }
     }.to_json
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -147,7 +147,7 @@ class MockPubsub < Minitest::Spec
     }.to_json
   end
 
-  def event_json message, id = rand(1000000)
+  def rec_message_json message, id = rand(1000000)
     {
       "ackId" => "ack-id-#{id}",
       "message" => {
@@ -158,10 +158,10 @@ class MockPubsub < Minitest::Spec
     }.to_json
   end
 
-  def events_json message
+  def rec_messages_json message
     {
       "receivedMessages" => [
-        JSON.parse(event_json(message))
+        JSON.parse(rec_message_json(message))
       ]
     }.to_json
   end


### PR DESCRIPTION
This PR includes the following:

- [x] Update to Pub/Sub v1 API
- [x] Add Subscription#delay to make use of the improved v1 API
- [x] Allow Subscription#delay to accept Event objects
- [x] Allow Subscription#delay to accept an array as well as splatted args
- [x] Allow Subscription#acknowledge to accept Event objects
- [x] Allow Subscription#acknowledge to accept an array as well as splatted args
- [x] Rename Event to ReceivedMesssage to closer match the v1 API
- [x] Add Message attribute methods ReceivedMesssage
- [x] Improved documentation for non-lazy methods that always make an API call (missing from last week's doc PR)

[closes #177]