### PR TITLE
Fix incorrect method names on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ require "gcloud/storage"
 storage = Gcloud.storage "my-todo-project-id",
                          "/path/to/keyfile.json"
 
-bucket = storage.bucket "task-attachments"
+bucket = storage.find_bucket "task-attachments"
 
-file = bucket.file "path/to/my-file.ext"
+file = bucket.find_file "path/to/my-file.ext"
 
 # Download the file to the local file system
 file.download "/tasks/attachments/#{file.name}"
 
 # Copy the file to a backup bucket
-backup = storage.bucket "task-attachment-backups"
+backup = storage.find_bucket "task-attachment-backups"
 file.copy backup, file.name
 ```
 


### PR DESCRIPTION
**References:** 
- [Gcloud::Storage::Project#find_bucket](http://googlecloudplatform.github.io/gcloud-ruby/docs/v0.1.1/Gcloud/Storage/Project.html#method-i-find_bucket)
- [Gcloud::Storage::Bucket#find_file](http://googlecloudplatform.github.io/gcloud-ruby/docs/v0.1.1/Gcloud/Storage/Bucket.html#method-i-find_file)