### PR TITLE
Fix gcloud typo

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -44,7 +44,7 @@ completed_tasks = dataset.run query
 See the [gcloud-ruby Pub/Sub API documentation](rdoc-ref:Gcloud::Pubsub) to learn how to connect to Cloud Pub/Sub using this library.
 
 ```ruby
-require "glcoud/pubsub"
+require "gcloud/pubsub"
 
 pubsub = Gcloud.pubsub
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ completed_tasks = dataset.run query
 #### Preview
 
 ```ruby
-require "glcoud/pubsub"
+require "gcloud/pubsub"
 
 pubsub = Gcloud.pubsub
 

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -40,7 +40,7 @@ module Gcloud
   #
   # === Example
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore "my-todo-project",
   #                              "/path/to/keyfile.json"
@@ -76,7 +76,7 @@ module Gcloud
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you.
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore "my-todo-project",
   #                              "/path/to/keyfile.json"
@@ -100,14 +100,14 @@ module Gcloud
   # <tt>name</tt> value. A single record can be retrieved by calling
   # Gcloud::Datastore::Dataset#find and passing the parts of the key:
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   entity = dataset.find "Task", "start"
   #
   # Optionally, Gcloud::Datastore::Dataset#find can be given a Key object:
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   key = Gcloud::Datastore::Key.new "Task", 12345
@@ -120,7 +120,7 @@ module Gcloud
   # Multiple records can be found that match criteria.
   # (See Gcloud::Datastore::Query#where)
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   query = Gcloud::Datastore::Query.new
@@ -130,7 +130,7 @@ module Gcloud
   #
   # Records can also be ordered. (See Gcloud::Datastore::Query#order)
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   query = Gcloud::Datastore::Query.new
@@ -142,7 +142,7 @@ module Gcloud
   # The number of records returned can be specified.
   # (See Gcloud::Datastore::Query#limit)
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   query = Gcloud::Datastore::Query.new
@@ -155,7 +155,7 @@ module Gcloud
   # Records' Key structures can also be queried.
   # (See Gcloud::Datastore::Query#ancestor)
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #
@@ -173,7 +173,7 @@ module Gcloud
   # to return them all. The returned records will have a <tt>cursor</tt> if
   # there are more available.
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #
@@ -204,7 +204,7 @@ module Gcloud
   # The entity must have a Key to be saved. If the Key is incomplete then
   # it will be completed when saved.
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   entity = Gcloud::Datastore::Entity.new
@@ -221,7 +221,7 @@ module Gcloud
   # String, Integer, Date, Time, and even other Entity or Key objects. Changes
   # to the Entity's properties are persisted by calling Dataset#save.
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   entity = datastore.find "User", "heidi"
@@ -237,7 +237,7 @@ module Gcloud
   # Entities can be removed from Datastore by calling Dataset#delete and passing
   # the Entity object or the entity's Key object.
   #
-  #   require "glcoud/datastore"
+  #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore
   #   entity = datastore.find "User", "heidi"

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -149,7 +149,7 @@ module Gcloud
       #
       # The Key can be set before the entity is saved.
       #
-      #   require "glcoud/datastore"
+      #   require "gcloud/datastore"
       #
       #   dataset = Gcloud.datastore
       #   entity = Gcloud::Datastore::Entity.new

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -51,7 +51,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/datastore"
+      #   require "gcloud/datastore"
       #
       #   dataset = Gcloud.datastore "my-todo-project",
       #                              "/path/to/keyfile.json"
@@ -70,7 +70,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/datastore"
+      #   require "gcloud/datastore"
       #
       #   dataset = Gcloud.datastore "my-todo-project",
       #                              "/path/to/keyfile.json"
@@ -188,7 +188,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/datastore"
+      #   require "gcloud/datastore"
       #
       #   dataset = Gcloud.datastore
       #

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -38,7 +38,7 @@ module Gcloud
   #
   # === Example
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -71,7 +71,7 @@ module Gcloud
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -87,7 +87,7 @@ module Gcloud
   # A Topic is a named resource to which messages are sent by publishers.
   # A Topic is found by its name. (See Project#topic)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #   topic = pubsub.topic "my-topic"
@@ -105,7 +105,7 @@ module Gcloud
   #
   # Messages are published to a topic. (See Topic#publish)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -114,7 +114,7 @@ module Gcloud
   #
   # Messages can also be published with attributes:
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -125,7 +125,7 @@ module Gcloud
   #
   # Multiple messages can be published at the same time by passing a block:
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -142,7 +142,7 @@ module Gcloud
   # a single, specific Topic, to be delivered to the subscribing application.
   # A Subscription is found by its name. (See Topic#subscription)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -154,7 +154,7 @@ module Gcloud
   #
   # A Subscription is created from a Topic. (See Topic#subscribe)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -164,7 +164,7 @@ module Gcloud
   #
   # The name is optional, and will be generated if not given.
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -175,7 +175,7 @@ module Gcloud
   # The subscription can be created that specifies the number of seconds to
   # wait to be acknoeledged as well as an endpoint URL to push the messages to:
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -188,7 +188,7 @@ module Gcloud
   #
   # Messages are pulled from a Subscription.
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -197,7 +197,7 @@ module Gcloud
   #
   # Results can be returned immediately with the +:immediate+ option:
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -206,7 +206,7 @@ module Gcloud
   #
   # A maximum number of messages returned can also be specified:
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -222,7 +222,7 @@ module Gcloud
   # ReceivedMesssages can be acknowledged one at a time:
   # (See ReceivedMesssage#acknowledge!)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -232,7 +232,7 @@ module Gcloud
   # Or, multiple messages can be acknowledged in a single API call:
   # (See Subscription#acknowledge)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -248,7 +248,7 @@ module Gcloud
   # redelivery if the processing was interrupted.
   # (See ReceivedMesssage#delay!)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -262,7 +262,7 @@ module Gcloud
   #
   # The message can also be made available for immediate redelivery:
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
@@ -277,7 +277,7 @@ module Gcloud
   # Multiple messages can be delayed or made available for immediate redelivery:
   # (See Subscription#delay)
   #
-  #   require "glcoud/pubsub"
+  #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -26,7 +26,7 @@ module Gcloud
     # Subscription#pull returns ReceivedMesssage objects, which contain a
     # Message object and can be acknowleged and/or delayed.
     #
-    #   require "glcoud/pubsub"
+    #   require "gcloud/pubsub"
     #
     #   pubsub = Gcloud.pubsub
     #

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -30,7 +30,7 @@ module Gcloud
     # Message is a combination of data and attributes that a publisher sends to
     # a topic and is eventually delivered to subscribers.
     #
-    #   require "glcoud/pubsub"
+    #   require "gcloud/pubsub"
     #
     #   pubsub = Gcloud.pubsub
     #

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -23,7 +23,7 @@ module Gcloud
     #
     # Represents a Pub/Sub Message that can be acknowledged or delayed.
     #
-    #   require "glcoud/pubsub"
+    #   require "gcloud/pubsub"
     #
     #   pubsub = Gcloud.pubsub
     #
@@ -90,7 +90,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -125,7 +125,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -25,7 +25,7 @@ module Gcloud
     # Represents a Pub/Sub subscription, contains the stream of messages from a
     # single, specific Topic, to be delivered to the subscribing application.
     #
-    #   require "glcoud/pubsub"
+    #   require "gcloud/pubsub"
     #
     #   pubsub = Gcloud.pubsub
     #
@@ -79,7 +79,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -131,7 +131,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -155,7 +155,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -176,7 +176,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -223,7 +223,7 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -232,7 +232,7 @@ module Gcloud
       #
       # Results can be returned immediately with the +:immediate+ option:
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -241,7 +241,7 @@ module Gcloud
       #
       # A maximum number of messages returned can also be speified:
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -276,7 +276,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -317,7 +317,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -26,7 +26,7 @@ module Gcloud
     # Represents a Pub/Sub topic. Belongs to a Project and creates Subscription
     # and publishes messages.
     #
-    #   require "glcoud/pubsub"
+    #   require "gcloud/pubsub"
     #
     #   pubsub = Gcloud.pubsub
     #
@@ -83,7 +83,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -124,7 +124,7 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -134,7 +134,7 @@ module Gcloud
       #
       # The name is optional, and will be generated if not given.
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -145,7 +145,7 @@ module Gcloud
       # The subscription can be created that waits two minutes for
       # acknowledgement and pushed all messages to an endpoint
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -186,7 +186,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -216,7 +216,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -255,7 +255,7 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -268,7 +268,7 @@ module Gcloud
       # If you have a significant number of subscriptions, you may need to
       # paginate through them: (See Subscription::List#token)
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -314,7 +314,7 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -323,7 +323,7 @@ module Gcloud
       #
       # Additionally, a message can be published with attributes:
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -334,7 +334,7 @@ module Gcloud
       #
       # Multiple messages can be published at the same time by passing a block:
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -361,7 +361,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -382,7 +382,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
@@ -399,7 +399,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/pubsub"
+      #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -38,7 +38,7 @@ module Gcloud
   #
   # === Example
   #
-  #   require "glcoud/storage"
+  #   require "gcloud/storage"
   #
   #   storage = Gcloud.storage "my-todo-project",
   #                            "/path/to/keyfile.json"
@@ -70,7 +70,7 @@ module Gcloud
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
   #
-  #   require "glcoud/storage"
+  #   require "gcloud/storage"
   #
   #   storage = Gcloud.storage "my-todo-project",
   #                            "/path/to/keyfile.json"

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -24,7 +24,7 @@ module Gcloud
     #
     # Represents a Storage bucket. Belongs to a Project and has many Files.
     #
-    #   require "glcoud/storage"
+    #   require "gcloud/storage"
     #
     #   storage = Gcloud.storage
     #

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -21,7 +21,7 @@ module Gcloud
       #
       # Represents a Bucket's Access Control List.
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -61,7 +61,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -86,7 +86,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -108,7 +108,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -130,7 +130,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -166,7 +166,7 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -178,7 +178,7 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -220,7 +220,7 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -232,7 +232,7 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -274,7 +274,7 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -286,7 +286,7 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -325,7 +325,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -357,7 +357,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -379,7 +379,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -397,7 +397,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -416,7 +416,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -435,7 +435,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -469,7 +469,7 @@ module Gcloud
       #
       # Represents a Bucket's Default Access Control List.
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -510,7 +510,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -535,7 +535,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -557,7 +557,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -579,7 +579,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -615,7 +615,7 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -627,7 +627,7 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -669,7 +669,7 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -681,7 +681,7 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -723,7 +723,7 @@ module Gcloud
         # Access to a bucket can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -735,7 +735,7 @@ module Gcloud
         # Access to a bucket can be granted to a group by appending +"group-"+
         # to the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -775,7 +775,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -807,7 +807,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -829,7 +829,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -848,7 +848,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -867,7 +867,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -885,7 +885,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -904,7 +904,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -24,7 +24,7 @@ module Gcloud
     #
     # Represents the File/Object that belong to a Bucket.
     #
-    #   require "glcoud/storage"
+    #   require "gcloud/storage"
     #
     #   storage = Gcloud.storage
     #
@@ -155,7 +155,7 @@ module Gcloud
       #
       # === Examples
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -167,7 +167,7 @@ module Gcloud
       # The download is verified by calculating the MD5 digest.
       # The CRC32c digest can be used by passing :crc32c.
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -178,7 +178,7 @@ module Gcloud
       #
       # Both the MD5 and CRC32c digest can be used by passing :all.
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -189,7 +189,7 @@ module Gcloud
       #
       # The download verification can be disabled by passing :none
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -250,7 +250,7 @@ module Gcloud
       #
       # The file can also be copied to a new path in the current bucket:
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -261,7 +261,7 @@ module Gcloud
       #
       # The file can also be copied to a different bucket:
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -294,7 +294,7 @@ module Gcloud
       #
       # === Example
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -21,7 +21,7 @@ module Gcloud
       #
       # Represents a File's Access Control List.
       #
-      #   require "glcoud/storage"
+      #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
       #
@@ -64,7 +64,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -90,7 +90,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -113,7 +113,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -136,7 +136,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -179,7 +179,7 @@ module Gcloud
         # Access to a file can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -192,7 +192,7 @@ module Gcloud
         # Access to a file can be granted to a group by appending +"group-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -242,7 +242,7 @@ module Gcloud
         # Access to a file can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -255,7 +255,7 @@ module Gcloud
         # Access to a file can be granted to a group by appending +"group-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -305,7 +305,7 @@ module Gcloud
         # Access to a file can be granted to a user by appending +"user-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -318,7 +318,7 @@ module Gcloud
         # Access to a file can be granted to a group by appending +"group-"+ to
         # the email address:
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -365,7 +365,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -398,7 +398,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -421,7 +421,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -441,7 +441,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -461,7 +461,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -480,7 +480,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #
@@ -500,7 +500,7 @@ module Gcloud
         #
         # === Example
         #
-        #   require "glcoud/storage"
+        #   require "gcloud/storage"
         #
         #   storage = Gcloud.storage
         #


### PR DESCRIPTION
There are several instances in the documentation where 'gcloud' is mispelled.
Fix the spelling. [Closes #187]