### PR TITLE
Changes for feedback from the Pub/Sub team

### DIFF
--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -274,6 +274,46 @@ module Gcloud
   #   received_messages = sub.pull
   #   sub.delay 120, received_messages
   #
+  # == Listening for Messages
+  #
+  # Long running workers are easy to create with +listen+, which runs an
+  # infinitely blocking loop to process messages as they are received. (See
+  # Subscription#listen)
+  #
+  #   require "gcloud/pubsub"
+  #
+  #   pubsub = Gcloud.pubsub
+  #
+  #   sub = pubsub.subscription "my-topic-sub"
+  #   sub.listen do |msg|
+  #     # process msg
+  #   end
+  #
+  # Messages are retrieved in batches for efficiency. The number of messages
+  # pulled per batch can be limited with the +max+ option:
+  #
+  #   require "gcloud/pubsub"
+  #
+  #   pubsub = Gcloud.pubsub
+  #
+  #   sub = pubsub.subscription "my-topic-sub"
+  #   sub.listen max: 20 do |msg|
+  #     # process msg
+  #   end
+  #
+  # When processing time and the acknowledgement deadline are a concern,
+  # messages can be automatically acknowledged as they are pulled with the
+  # +autoack+ option:
+  #
+  #   require "gcloud/pubsub"
+  #
+  #   pubsub = Gcloud.pubsub
+  #
+  #   sub = pubsub.subscription "my-topic-sub"
+  #   sub.listen autoack: true do |msg|
+  #     # process msg
+  #   end
+  #
   module Pubsub
   end
 end

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -161,16 +161,6 @@ module Gcloud
   #   sub = topic.subscribe "my-topic-sub"
   #   puts sub.name # => "my-topic-sub"
   #
-  # The name is optional, and will be generated if not given.
-  #
-  #   require "gcloud/pubsub"
-  #
-  #   pubsub = Gcloud.pubsub
-  #
-  #   topic = pubsub.topic "my-topic"
-  #   sub = topic.subscribe "my-topic-sub"
-  #   puts sub.name # => "generated-sub-name"
-  #
   # The subscription can be created that specifies the number of seconds to
   # wait to be acknowledged as well as an endpoint URL to push the messages to:
   #

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -185,7 +185,7 @@ module Gcloud
   #
   # == Pulling Messages
   #
-  # Messages are pulled from a Subscription.
+  # Messages are pulled from a Subscription. (See Subscription#pull)
   #
   #   require "gcloud/pubsub"
   #
@@ -193,16 +193,6 @@ module Gcloud
   #
   #   sub = pubsub.subscription "my-topic-sub"
   #   msgs = sub.pull
-  #
-  # The pull request can block until messages are available by setting the
-  # +:immediate+ option to +false+:
-  #
-  #   require "gcloud/pubsub"
-  #
-  #   pubsub = Gcloud.pubsub
-  #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   msgs = sub.pull immediate: false
   #
   # A maximum number of messages returned can also be specified:
   #
@@ -212,6 +202,16 @@ module Gcloud
   #
   #   sub = pubsub.subscription "my-topic-sub", max: 10
   #   msgs = sub.pull
+  #
+  # The request for messages can also block until messages are available.
+  # (See Subscription#wait_for_messages)
+  #
+  #   require "gcloud/pubsub"
+  #
+  #   pubsub = Gcloud.pubsub
+  #
+  #   sub = pubsub.subscription "my-topic-sub"
+  #   msgs = sub.wait_for_messages
   #
   # == Acknowledging a Message
   #

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -194,14 +194,15 @@ module Gcloud
   #   sub = pubsub.subscription "my-topic-sub"
   #   msgs = sub.pull
   #
-  # Results can be returned immediately with the +:immediate+ option:
+  # The pull request can block until messages are available by setting the
+  # +:immediate+ option to +false+:
   #
   #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub", immediate: true
-  #   msgs = sub.pull
+  #   sub = pubsub.subscription "my-topic-sub"
+  #   msgs = sub.pull immediate: false
   #
   # A maximum number of messages returned can also be specified:
   #

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -173,6 +173,40 @@ module Gcloud
   #                         deadline: 120,
   #                         endpoint: "https://example.com/push"
   #
+  # == Working Across Projects
+  #
+  # All calls to the Pub/Sub service use the same project and credentials
+  # provided to the Gcloud.pubsub method. However, it is common to reference
+  # topics or subscriptions in other projects, which can be achieved by using
+  # the +project+ option. The main credentials must have permissions to the
+  # topics and subscriptions in other projects.
+  #
+  #   require "gcloud/pubsub"
+  #
+  #   pubsub = Gcloud.pubsub # my-project-id
+  #
+  #   # Get a topic in the current project
+  #   my_topic = pubsub.topic "my-topic"
+  #   my_topic.name #=> "projects/my-project-id/topics/my-topic"
+  #   # Get a topic in another project
+  #   other_topic = pubsub.topic "other-topic", project: "other-project-id"
+  #   other_topic.name #=> "projects/other-project-id/topics/other-topic"
+  #
+  # It is possible to create a subscription in the current project that pulls
+  # from a topic in another project:
+  #
+  #   require "gcloud/pubsub"
+  #
+  #   pubsub = Gcloud.pubsub # my-project-id
+  #
+  #   # Get a topic in another project
+  #   topic = pubsub.topic "other-topic", project: "other-project-id"
+  #   # Create a subscription in the current project that pulls from
+  #   # the topic in another project
+  #   sub = topic.subscribe "my-sub"
+  #   sub.name #=> "projects/my-project-id/subscriptions/my-sub"
+  #   sub.topic.name #=> "projects/other-project-id/topics/other-topic"
+  #
   # == Pulling Messages
   #
   # Messages are pulled from a Subscription. (See Subscription#pull)

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -160,6 +160,23 @@ module Gcloud
         )
       end
 
+      def get_subscription_policy subscription_name, options = {}
+        @client.execute(
+          api_method: @pubsub.projects.subscriptions.get_iam_policy,
+          parameters: {
+            resource: subscription_path(subscription_name, options) }
+        )
+      end
+
+      def set_subscription_policy subscription_name, new_policy, options = {}
+        @client.execute(
+          api_method: @pubsub.projects.subscriptions.set_iam_policy,
+          parameters: {
+            resource: subscription_path(subscription_name, options) },
+          body_object: { policy: new_policy }
+        )
+      end
+
       ##
       # Adds one or more messages to the topic.
       # Returns NOT_FOUND if the topic does not exist.

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -44,26 +44,26 @@ module Gcloud
       # this method is only useful to check the existence of a topic.
       # If other attributes are added in the future,
       # they will be returned here.
-      def get_topic topic_name
+      def get_topic topic_name, options = {}
         @client.execute(
           api_method: @pubsub.projects.topics.get,
-          parameters: { topic: topic_path(topic_name) }
+          parameters: { topic: topic_path(topic_name, options) }
         )
       end
 
       ##
       # Creates the given topic with the given name.
-      def create_topic topic_name
+      def create_topic topic_name, options = {}
         @client.execute(
           api_method: @pubsub.projects.topics.create,
-          parameters: { name: topic_path(topic_name) }
+          parameters: { name: topic_path(topic_name, options) }
         )
       end
 
       ##
       # Lists matching topics.
       def list_topics options = {}
-        params = { project: project_path,
+        params = { project: project_path(options),
                    pageToken: options.delete(:token),
                    pageSize: options.delete(:max)
                  }.delete_if { |_, v| v.nil? }
@@ -92,24 +92,25 @@ module Gcloud
         data = subscription_data topic, options
         @client.execute(
           api_method: @pubsub.projects.subscriptions.create,
-          parameters: { name: subscription_path(subscription_name) },
+          parameters: { name: subscription_path(subscription_name, options) },
           body_object: data
         )
       end
 
       ##
       # Gets the details of a subscription.
-      def get_subscription subscription_name
+      def get_subscription subscription_name, options = {}
         @client.execute(
           api_method: @pubsub.projects.subscriptions.get,
-          parameters: { subscription: subscription_path(subscription_name) }
+          parameters: {
+            subscription: subscription_path(subscription_name, options) }
         )
       end
 
       ##
       # Lists matching subscriptions by project.
       def list_subscriptions options = {}
-        params = { project: project_path,
+        params = { project: project_path(options),
                    pageToken: options.delete(:token),
                    pageSize: options.delete(:max)
                  }.delete_if { |_, v| v.nil? }
@@ -205,18 +206,19 @@ module Gcloud
         )
       end
 
-      def project_path
-        "projects/#{project}"
+      def project_path options = {}
+        project_name = options[:project] || project
+        "projects/#{project_name}"
       end
 
-      def topic_path topic_name
+      def topic_path topic_name, options = {}
         return topic_name if topic_name.to_s.include? "/"
-        "#{project_path}/topics/#{topic_name}"
+        "#{project_path(options)}/topics/#{topic_name}"
       end
 
-      def subscription_path subscription_name
+      def subscription_path subscription_name, options = {}
         return subscription_name if subscription_name.to_s.include? "/"
-        "#{project_path}/subscriptions/#{subscription_name}"
+        "#{project_path(options)}/subscriptions/#{subscription_name}"
       end
 
       protected

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -88,7 +88,7 @@ module Gcloud
 
       ##
       # Creates a subscription on a given topic for a given subscriber.
-      def create_subscription topic, subscription_name = nil, options = {}
+      def create_subscription topic, subscription_name, options = {}
         data = subscription_data topic, options
         @client.execute(
           api_method: @pubsub.projects.subscriptions.create,

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -86,6 +86,21 @@ module Gcloud
         )
       end
 
+      def get_topic_policy topic_name, options = {}
+        @client.execute(
+          api_method: @pubsub.projects.topics.get_iam_policy,
+          parameters: { resource: topic_path(topic_name, options) }
+        )
+      end
+
+      def set_topic_policy topic_name, new_policy, options = {}
+        @client.execute(
+          api_method: @pubsub.projects.topics.set_iam_policy,
+          parameters: { resource: topic_path(topic_name, options) },
+          body_object: { policy: new_policy }
+        )
+      end
+
       ##
       # Creates a subscription on a given topic for a given subscriber.
       def create_subscription topic, subscription_name, options = {}

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -64,7 +64,9 @@ module Gcloud
       ##
       # The received attributes.
       def attributes
-        @gapi["attributes"]
+        attrs = @gapi["attributes"]
+        attrs = attrs.to_hash if attrs.respond_to? :to_hash
+        attrs
       end
 
       ##

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -117,6 +117,10 @@ module Gcloud
       # <code>options[:autocreate]</code>::
       #   Flag to control whether the topic should be created when needed.
       #   The default value is +true+. (+Boolean+)
+      # <code>options[:project]</code>::
+      #   If the topic belongs to a project other than the one currently
+      #   connected to, the alternate project ID can be specified here.
+      #   (+String+)
       #
       # === Returns
       #
@@ -146,13 +150,17 @@ module Gcloud
       #   topic = pubsub.topic "non-existing-topic"
       #   msg = topic.publish "This raises." #=> Gcloud::Pubsub::NotFoundError
       #
+      # A topic in a different project can be created using the +project+ flag.
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #   topic = pubsub.topic "another-topic", project: "another-project"
+      #
       def topic topic_name, options = {}
         ensure_connection!
 
-        autocreate = options[:autocreate]
-        autocreate = true if autocreate.nil?
-
-        Topic.new_lazy topic_name, connection, autocreate
+        Topic.new_lazy topic_name, connection, options
       end
 
       ##

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -210,6 +210,9 @@ module Gcloud
       #   The maximum number of messages to return for this request. The Pub/Sub
       #   system may return fewer than the number specified. The default value
       #   is +100+, the maximum value is +1000+. (+Integer+)
+      # <code>options[:autoack]</code>::
+      #   Automatically acknowledge the message as it is pulled. The default
+      #   value is +false+. (+Boolean+)
       #
       # === Returns
       #
@@ -248,9 +251,11 @@ module Gcloud
         ensure_connection!
         resp = connection.pull name, options
         if resp.success?
-          Array(resp.data["receivedMessages"]).map do |gapi|
+          messages = Array(resp.data["receivedMessages"]).map do |gapi|
             ReceivedMessage.from_gapi gapi, self
           end
+          acknowledge messages if options[:autoack]
+          messages
         else
           fail ApiError.from_response(resp)
         end
@@ -274,6 +279,9 @@ module Gcloud
       #   The maximum number of messages to return for this request. The Pub/Sub
       #   system may return fewer than the number specified. The default value
       #   is +100+, the maximum value is +1000+. (+Integer+)
+      # <code>options[:autoack]</code>::
+      #   Automatically acknowledge the message as it is pulled. The default
+      #   value is +false+. (+Boolean+)
       #
       # === Returns
       #

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -188,6 +188,9 @@ module Gcloud
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
+      # Disabled rubocop because these lines are needed.
+
       ##
       # Pulls messages from the server. Returns an empty list if there are no
       # messages available in the backlog. Raises an ApiError with status
@@ -251,7 +254,11 @@ module Gcloud
         else
           fail ApiError.from_response(resp)
         end
+      rescue Faraday::TimeoutError
+        []
       end
+
+      # rubocop:enable Metrics/MethodLength
 
       ##
       # Acknowledges receipt of a message. After an ack,

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -53,13 +53,13 @@ module Gcloud
 
       ##
       # New lazy Topic object without making an HTTP request.
-      def self.new_lazy name, conn #:nodoc:
+      def self.new_lazy name, conn, options = {} #:nodoc:
         sub = new.tap do |f|
           f.gapi = nil
           f.connection = conn
         end
         sub.instance_eval do
-          @name = conn.subscription_path(name)
+          @name = conn.subscription_path(name, options)
         end
         sub
       end
@@ -90,7 +90,7 @@ module Gcloud
         ensure_gapi!
         # Always disable autocreate, we don't want to recreate a topic that
         # was intentionally deleted.
-        Topic.new_lazy @gapi["topic"], connection, false
+        Topic.new_lazy @gapi["topic"], connection, autocreate: false
       end
 
       ##

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -303,7 +303,7 @@ module Gcloud
 
       ##
       # Poll the backend for new messages. This runs a loop to ping the API,
-      # blocking indefinitely, yielding retrieved messages as they are recieved.
+      # blocking indefinitely, yielding retrieved messages as they are received.
       #
       # === Parameters
       #

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -199,11 +199,10 @@ module Gcloud
       # +options+::
       #   An optional Hash for controlling additional behavior. (+Hash+)
       # <code>options[:immediate]</code>::
-      #   When +true+, the system will respond immediately, either with a
-      #   message if available or +nil+ if no message is available. When not
-      #   specified, or when +false+, the call will block until a message is
-      #   available, or may return UNAVAILABLE if no messages become available
-      #   within a reasonable amount of time. (+Boolean+)
+      #   When +true+ the system will respond immediately even if it is not able
+      #   to return messages. When +false+ the system is allowed to wait until
+      #   it can return least one message. No messages are returned when a
+      #   request times out. The default value is +true+. (+Boolean+)
       # <code>options[:max]</code>::
       #   The maximum number of messages to return for this request. The Pub/Sub
       #   system may return fewer than the number specified. The default value
@@ -222,14 +221,16 @@ module Gcloud
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.pull.each { |msg| msg.acknowledge! }
       #
-      # Results can be returned immediately with the +:immediate+ option:
+      # The call can wait until results can be returned by setting the
+      # +:immediate+ option to +false+:
       #
       #   require "gcloud/pubsub"
       #
       #   pubsub = Gcloud.pubsub
       #
-      #   sub = pubsub.subscription "my-topic-sub", immediate: true
-      #   sub.pull.each { |msg| msg.acknowledge! }
+      #   sub = pubsub.subscription "my-topic-sub"
+      #   msgs = sub.pull immediate: false
+      #   msgs.each { |msg| msg.acknowledge! }
       #
       # A maximum number of messages returned can also be specified:
       #

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -224,7 +224,16 @@ module Gcloud
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.pull.each { |msg| msg.acknowledge! }
       #
-      # The call can wait until results can be returned by setting the
+      # A maximum number of messages returned can also be specified:
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   sub = pubsub.subscription "my-topic-sub", max: 10
+      #   sub.pull.each { |msg| msg.acknowledge! }
+      #
+      # The call can block until messages are available by setting the
       # +:immediate+ option to +false+:
       #
       #   require "gcloud/pubsub"
@@ -234,15 +243,6 @@ module Gcloud
       #   sub = pubsub.subscription "my-topic-sub"
       #   msgs = sub.pull immediate: false
       #   msgs.each { |msg| msg.acknowledge! }
-      #
-      # A maximum number of messages returned can also be specified:
-      #
-      #   require "gcloud/pubsub"
-      #
-      #   pubsub = Gcloud.pubsub
-      #
-      #   sub = pubsub.subscription "my-topic-sub", max: 10
-      #   sub.pull.each { |msg| msg.acknowledge! }
       #
       def pull options = {}
         ensure_connection!
@@ -259,6 +259,39 @@ module Gcloud
       end
 
       # rubocop:enable Metrics/MethodLength
+
+      ##
+      # Pulls from the server while waiting for messages to become available.
+      # This is the same as:
+      #
+      #   subscription.pull immediate: false
+      #
+      # === Parameters
+      #
+      # +options+::
+      #   An optional Hash for controlling additional behavior. (+Hash+)
+      # <code>options[:max]</code>::
+      #   The maximum number of messages to return for this request. The Pub/Sub
+      #   system may return fewer than the number specified. The default value
+      #   is +100+, the maximum value is +1000+. (+Integer+)
+      #
+      # === Returns
+      #
+      # Array of Gcloud::Pubsub::ReceivedMessage
+      #
+      # === Example
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   sub = pubsub.subscription "my-topic-sub"
+      #   msgs = sub.wait_for_messages
+      #   msgs.each { |msg| msg.acknowledge! }
+      #
+      def wait_for_messages options = {}
+        pull options.merge(immediate: false)
+      end
 
       ##
       # Acknowledges receipt of a message. After an ack,

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -358,6 +358,107 @@ module Gcloud
       end
 
       ##
+      # Gets the access control policy.
+      #
+      # === Parameters
+      #
+      # +options+::
+      #   An optional Hash for controlling additional behavior. (+Hash+)
+      # <code>options[:force]</code>::
+      #   Force the latest policy to be retrieved from the Pub/Sub service when
+      #   +true. Otherwise the policy will be memoized to reduce the number of
+      #   API calls made to the Pub/Sub service. The default is +false+.
+      #   (+Boolean+)
+      #
+      # === Returns
+      #
+      # A hash that conforms to the following structure:
+      #
+      #   {
+      #     "bindings" => [{
+      #       "role" => "roles/viewer",
+      #       "members" => ["serviceAccount:your-service-account"]
+      #     }],
+      #     "rules" => []
+      #   }
+      #
+      # === Examples
+      #
+      # By default, the policy values are memoized to reduce the number of API
+      # calls to the Pub/Sub service.
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   puts topic.policy["bindings"]
+      #   puts topic.policy["rules"]
+      #
+      # To retrieve the latest policy from the Pub/Sub service, use the +force+
+      # flag.
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   policy = topic.policy force: true
+      #
+      def policy options = {}
+        @policy = nil if options[:force]
+        @policy ||= begin
+          ensure_connection!
+          resp = connection.get_topic_policy name
+          policy = resp.data["policy"]
+          policy = policy.to_hash if policy.respond_to? :to_hash
+          policy
+        end
+      end
+
+      ##
+      # Sets the access control policy.
+      #
+      # === Parameters
+      #
+      # +new_policy+::
+      #   A hash that conforms to the following structure:
+      #
+      #     {
+      #       "bindings" => [{
+      #         "role" => "roles/viewer",
+      #         "members" => ["serviceAccount:your-service-account"]
+      #       }],
+      #       "rules" => []
+      #     }
+      #
+      # === Example
+      #
+      #   require "gcloud/pubsub"
+      #
+      #   pubsub = Gcloud.pubsub
+      #
+      #   viewer_policy = {
+      #     "bindings" => [{
+      #       "role" => "roles/viewer",
+      #       "members" => ["serviceAccount:your-service-account"]
+      #     }]
+      #   }
+      #   topic = pubsub.topic "my-topic"
+      #   topic.policy = viewer_policy
+      #
+      def policy= new_policy
+        ensure_connection!
+        resp = connection.set_topic_policy name, new_policy
+        if resp.success?
+          @policy = resp.data["policy"]
+          @policy = @policy.to_hash if @policy.respond_to? :to_hash
+        else
+          fail ApiError.from_response(resp)
+        end
+      end
+
+      ##
       # Determines whether the topic exists in the Pub/Sub service.
       #
       # === Example

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -104,9 +104,11 @@ module Gcloud
       # === Parameters
       #
       # +subscription_name+::
-      #   Name of the new subscription. If the name is not provided in the
-      #   request, the server will assign a random name for this subscription
-      #   on the same project as the topic. (+String+)
+      #   Name of the new subscription. Must start with a letter, and contain
+      #   only letters ([A-Za-z]), numbers ([0-9], dashes (-), underscores (_),
+      #   periods (.), tildes (~), plus (+) or percent signs (%). It must be
+      #   between 3 and 255 characters in length, and it must not start with
+      #   "goog". (+String+)
       # +options+::
       #   An optional Hash for controlling additional behavior. (+Hash+)
       # <code>options[:deadline]</code>::
@@ -152,7 +154,7 @@ module Gcloud
       #                         deadline: 120,
       #                         endpoint: "https://example.com/push"
       #
-      def subscribe subscription_name = nil, options = {}
+      def subscribe subscription_name, options = {}
         ensure_connection!
         resp = connection.create_subscription name, subscription_name, options
         if resp.success?

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -53,16 +53,16 @@ module Gcloud
 
       ##
       # New lazy Topic object without making an HTTP request.
-      def self.new_lazy name, conn, autocreate = true #:nodoc:
-        topic = new.tap do |f|
-          f.gapi = nil
-          f.connection = conn
+      def self.new_lazy name, conn, options = {} #:nodoc:
+        options[:autocreate] = true if options[:autocreate].nil?
+        new.tap do |t|
+          t.gapi = nil
+          t.connection = conn
+          t.instance_eval do
+            @name = conn.topic_path(name, options)
+            @autocreate = options[:autocreate]
+          end
         end
-        topic.instance_eval do
-          @name = conn.topic_path(name)
-          @autocreate = autocreate
-        end
-        topic
       end
 
       ##

--- a/test/gcloud/pubsub/message/test_attributes.rb
+++ b/test/gcloud/pubsub/message/test_attributes.rb
@@ -1,0 +1,38 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Message, :attributes do
+  let(:message_hash) do
+    {
+      "data" => ["hello world"].pack("m"),
+      "attributes" => { "foo" => "FOO", "bar" => "BAR" }
+    }
+  end
+  let(:message_gapi) do
+    data = message_hash
+    data["attributes"] = AutoParse::Instance.new data["attributes"]
+    AutoParse::Instance.new data
+  end
+  let(:message_obj) do
+    Gcloud::Pubsub::Message.from_gapi message_gapi
+  end
+
+  it "has attributes as a Hash even when being a Google API object" do
+    message_obj.attributes["foo"].must_equal "FOO"
+    message_obj.attributes.keys.must_include "bar"
+    message_obj.attributes.must_be_kind_of Hash
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_listen.rb
+++ b/test/gcloud/pubsub/subscription/test_listen.rb
@@ -1,0 +1,112 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+class Gcloud::Pubsub::ListenMustStopInTests < StandardError; end
+
+describe Gcloud::Pubsub::Subscription, :listen, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+  let(:empty_json) { { "receivedMessages" => [] }.to_json }
+
+  it "can listen for messages" do
+    rec_message_msg = "pulled-message"
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       rec_messages_json(rec_message_msg)]
+    end
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       rec_messages_json(rec_message_msg)]
+    end
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      raise Gcloud::Pubsub::ListenMustStopInTests,
+            "time to break the loop by raising an error"
+    end
+
+    expect do
+      subscription.listen do |msg|
+        msg.must_be_kind_of Gcloud::Pubsub::ReceivedMessage
+      end
+    end.must_raise Gcloud::Pubsub::ListenMustStopInTests
+  end
+
+  it "sleeps when there are no results returned" do
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       empty_json]
+    end
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+        empty_json]
+    end
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      raise Gcloud::Pubsub::ListenMustStopInTests,
+            "time to break the loop by raising an error"
+    end
+
+    $listen_sleep_mock = Minitest::Mock.new
+    $listen_sleep_mock.expect :mock_sleep, nil, [1]
+    $listen_sleep_mock.expect :mock_sleep, nil, [1]
+    def subscription.sleep delay
+      $listen_sleep_mock.mock_sleep delay
+    end
+
+    expect do
+      subscription.listen do |msg|
+        msg.must_be_kind_of Gcloud::Pubsub::ReceivedMessage
+      end
+    end.must_raise Gcloud::Pubsub::ListenMustStopInTests
+
+    $listen_sleep_mock.verify
+    $listen_sleep_mock = nil
+  end
+
+  it "sleeps for the value passed in :delay" do
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       empty_json]
+    end
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+        empty_json]
+    end
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      raise Gcloud::Pubsub::ListenMustStopInTests,
+            "time to break the loop by raising an error"
+    end
+
+    $listen_sleep_mock = Minitest::Mock.new
+    $listen_sleep_mock.expect :mock_sleep, nil, [999]
+    $listen_sleep_mock.expect :mock_sleep, nil, [999]
+    def subscription.sleep delay
+      $listen_sleep_mock.mock_sleep delay
+    end
+
+    expect do
+      subscription.listen(delay: 999) do |msg|
+        msg.must_be_kind_of Gcloud::Pubsub::ReceivedMessage
+      end
+    end.must_raise Gcloud::Pubsub::ListenMustStopInTests
+
+    $listen_sleep_mock.verify
+    $listen_sleep_mock = nil
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_policy.rb
+++ b/test/gcloud/pubsub/subscription/test_policy.rb
@@ -1,0 +1,152 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+
+  it "gets the IAM Policy" do
+    policy_json = {
+      "policy" => {
+        "bindings" => [{
+          "role" => "roles/viewer",
+          "members" => [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ],
+        }],
+      }
+    }.to_json
+
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}:getIamPolicy" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       policy_json]
+    end
+
+    policy = subscription.policy
+    policy.must_be_kind_of Hash
+    policy["bindings"].count.must_equal 1
+    policy["bindings"].first["role"].must_equal "roles/viewer"
+    policy["bindings"].first["members"].count.must_equal 2
+    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
+    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "memoizes policy" do
+    policy_hash = {
+      "bindings" => [{
+        "role" => "roles/viewer",
+        "members" => [
+          "user:viewer@example.com",
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+        ],
+      }]
+    }
+
+    subscription.instance_variable_set "@policy", policy_hash
+
+    # No mocks, no errors, no HTTP calls are made
+    policy = subscription.policy
+    policy.must_be_kind_of Hash
+    policy["bindings"].count.must_equal 1
+    policy["bindings"].first["role"].must_equal "roles/viewer"
+    policy["bindings"].first["members"].count.must_equal 2
+    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
+    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "makes API calls when forced, even if already memoized" do
+    policy_hash = {
+      "bindings" => [{
+        "role" => "roles/viewer",
+        "members" => [
+          "user:viewer@example.com",
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+        ],
+      }]
+    }
+
+    policy_json = {
+      "policy" => {
+        "bindings" => [{
+          "role" => "roles/owner",
+          "members" => [
+            "user:owner@example.com",
+            "serviceAccount:0987654321@developer.gserviceaccount.com"
+          ],
+        }],
+      }
+    }.to_json
+
+    mock_connection.get "/v1/projects/#{project}/subscriptions/#{sub_name}:getIamPolicy" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       policy_json]
+    end
+
+    subscription.instance_variable_set "@policy", policy_hash
+    returned_policy = subscription.policy
+    returned_policy.must_be_kind_of Hash
+    returned_policy["bindings"].count.must_equal 1
+    returned_policy["bindings"].first["role"].must_equal "roles/viewer"
+    returned_policy["bindings"].first["members"].count.must_equal 2
+    returned_policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
+    returned_policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+
+    policy = subscription.policy force: true
+    policy.must_be_kind_of Hash
+    policy["bindings"].count.must_equal 1
+    policy["bindings"].first["role"].must_equal "roles/owner"
+    policy["bindings"].first["members"].count.must_equal 2
+    policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
+    policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+  end
+
+  it "sets the IAM Policy" do
+    new_policy = {
+      "bindings" => [{
+        "role" => "roles/owner",
+        "members" => [
+          "user:owner@example.com",
+          "serviceAccount:0987654321@developer.gserviceaccount.com"
+        ],
+      }],
+    }
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:setIamPolicy" do |env|
+      json_policy = JSON.parse env.body
+      json_policy["policy"]["bindings"].count.must_equal 1
+      json_policy["policy"]["bindings"].first["role"].must_equal "roles/owner"
+      json_policy["policy"]["bindings"].first["members"].count.must_equal 2
+      json_policy["policy"]["bindings"].first["members"].first.must_equal "user:owner@example.com"
+      json_policy["policy"]["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+      [200, {"Content-Type"=>"application/json"},
+       { "policy" => new_policy }.to_json]
+    end
+
+    subscription.policy = new_policy
+    # Setting the policy also memoizes the policy
+    subscription.policy["bindings"].count.must_equal 1
+    subscription.policy["bindings"].first["role"].must_equal "roles/owner"
+    subscription.policy["bindings"].first["members"].count.must_equal 2
+    subscription.policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
+    subscription.policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_pull_autoack.rb
+++ b/test/gcloud/pubsub/subscription/test_pull_autoack.rb
@@ -1,0 +1,59 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :pull, :autoack, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+  let(:rec_msg1_json) { rec_message_json "rec_msg1-msg-goes-here" }
+  let(:rec_msg2_json) { rec_message_json "rec_msg2-msg-goes-here" }
+  let(:rec_msg3_json) { rec_message_json "rec_msg3-msg-goes-here" }
+  let(:rec_msgs_json) do
+    {
+      "receivedMessages" => [
+        JSON.parse(rec_msg1_json),
+        JSON.parse(rec_msg2_json),
+        JSON.parse(rec_msg3_json),
+      ]
+    }.to_json
+  end
+  let(:rec_msg1) { Gcloud::Pubsub::ReceivedMessage.from_gapi \
+                  JSON.parse(rec_msg1_json), subscription }
+  let(:rec_msg2) { Gcloud::Pubsub::ReceivedMessage.from_gapi \
+                  JSON.parse(rec_msg2_json), subscription }
+  let(:rec_msg3) { Gcloud::Pubsub::ReceivedMessage.from_gapi \
+                  JSON.parse(rec_msg3_json), subscription }
+
+  it "can auto acknowledge when pulling messages" do
+    ack_ids = [rec_msg1.ack_id, rec_msg2.ack_id, rec_msg3.ack_id]
+
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       rec_msgs_json]
+    end
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:acknowledge" do |env|
+      JSON.parse(env.body)["ackIds"].must_equal ack_ids
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    rec_messages = subscription.pull autoack: true
+    rec_messages.count.must_equal 3
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_pull_wait.rb
+++ b/test/gcloud/pubsub/subscription/test_pull_wait.rb
@@ -1,0 +1,50 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Subscription, :pull, :wait, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_json) { subscription_json topic_name, sub_name }
+  let(:sub_hash) { JSON.parse sub_json }
+  let :subscription do
+    Gcloud::Pubsub::Subscription.from_gapi sub_hash, pubsub.connection
+  end
+
+  it "can pull messages without returning immediately" do
+    rec_message_msg = "pulled-message"
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      # We could sleep here, but, really, why?
+      JSON.parse(env.body)["returnImmediately"].must_equal false
+      [200, {"Content-Type"=>"application/json"},
+       rec_messages_json(rec_message_msg)]
+    end
+
+    rec_messages = subscription.pull immediate: false
+    rec_messages.wont_be :empty?
+    rec_messages.first.message.data.must_equal rec_message_msg
+  end
+
+  it "will not error when a request times out with Faraday::TimeoutError" do
+    rec_message_msg = "pulled-message"
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      # simulate a timed out HTTP request
+      raise Faraday::TimeoutError
+    end
+
+    rec_messages = subscription.pull immediate: false
+    rec_messages.must_be :empty?
+  end
+end

--- a/test/gcloud/pubsub/subscription/test_pull_wait.rb
+++ b/test/gcloud/pubsub/subscription/test_pull_wait.rb
@@ -52,7 +52,6 @@ describe Gcloud::Pubsub::Subscription, :pull, :wait, :mock_pubsub do
   end
 
   it "will not error when a request times out with Faraday::TimeoutError" do
-    rec_message_msg = "pulled-message"
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
       # simulate a timed out HTTP request
       raise Faraday::TimeoutError

--- a/test/gcloud/pubsub/subscription/test_pull_wait.rb
+++ b/test/gcloud/pubsub/subscription/test_pull_wait.rb
@@ -37,6 +37,20 @@ describe Gcloud::Pubsub::Subscription, :pull, :wait, :mock_pubsub do
     rec_messages.first.message.data.must_equal rec_message_msg
   end
 
+  it "can pull messages by calling wait_for_messages" do
+    rec_message_msg = "pulled-message"
+    mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|
+      # We could sleep here, but, really, why?
+      JSON.parse(env.body)["returnImmediately"].must_equal false
+      [200, {"Content-Type"=>"application/json"},
+       rec_messages_json(rec_message_msg)]
+    end
+
+    rec_messages = subscription.wait_for_messages
+    rec_messages.wont_be :empty?
+    rec_messages.first.message.data.must_equal rec_message_msg
+  end
+
   it "will not error when a request times out with Faraday::TimeoutError" do
     rec_message_msg = "pulled-message"
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:pull" do |env|

--- a/test/gcloud/pubsub/test_project.rb
+++ b/test/gcloud/pubsub/test_project.rb
@@ -70,6 +70,22 @@ describe Gcloud::Pubsub::Project, :mock_pubsub do
     topic.wont_be :lazy?
   end
 
+  it "gets a lazy topic by providing the full name" do
+    topic_name = "projects/another-project/topics/another-topic"
+    topic = pubsub.topic topic_name
+    topic.name.must_equal topic_name
+    topic.name.wont_match project_path
+    topic.must_be :lazy?
+  end
+
+  it "gets a lazy topic by providing alternate project" do
+    topic_name = "another-topic"
+    topic = pubsub.topic topic_name, project: "another-project"
+    topic.name.must_equal "projects/another-project/topics/another-topic"
+    topic.name.wont_match project_path
+    topic.must_be :lazy?
+  end
+
   it "lists topics" do
     num_topics = 3
     mock_connection.get "/v1/projects/#{project}/topics" do |env|

--- a/test/gcloud/pubsub/test_topic.rb
+++ b/test/gcloud/pubsub/test_topic.rb
@@ -70,19 +70,6 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
     sub.must_be_kind_of Gcloud::Pubsub::Subscription
   end
 
-  it "creates a subscription without giving a name" do
-    mock_connection.put "/v1/projects/#{project}/subscriptions/" do |env|
-      JSON.parse(env.body)["topic"].must_equal topic_path(topic_name)
-      JSON.parse(env.body)["name"].must_be :nil?
-      [200, {"Content-Type"=>"application/json"},
-       subscription_json(topic_name, nil)]
-    end
-
-    sub = topic.subscribe
-    sub.wont_be :nil?
-    sub.must_be_kind_of Gcloud::Pubsub::Subscription
-  end
-
   it "creates a subscription with a deadline" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     deadline = 42

--- a/test/gcloud/pubsub/topic/test_autocreate.rb
+++ b/test/gcloud/pubsub/topic/test_autocreate.rb
@@ -35,7 +35,7 @@ describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
   describe "lazy topic with explicit autocreate" do
     let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.connection,
-                                                 true }
+                                                 autocreate: true }
 
     it "will autocreate when created lazily" do
       topic.must_be :autocreate?
@@ -45,7 +45,7 @@ describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
   describe "lazy topic without autocomplete" do
     let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.connection,
-                                                 false }
+                                                 autocreate: false }
 
     it "knows if it will create a topic on the Pub/Sub service" do
       topic.wont_be :autocreate?

--- a/test/gcloud/pubsub/topic/test_exists.rb
+++ b/test/gcloud/pubsub/topic/test_exists.rb
@@ -47,7 +47,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
     describe "lazy topic with explicit autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "checks if the topic exists by making an HTTP call" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
@@ -64,7 +64,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
     describe "lazy topic without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "checks if the topic exists by making an HTTP call" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
@@ -99,7 +99,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
     describe "lazy topic with explicit autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "checks if the topic exists by making an HTTP call" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|
@@ -116,7 +116,7 @@ describe Gcloud::Pubsub::Topic, :exists, :mock_pubsub do
     describe "lazy topic without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "checks if the topic exists by making an HTTP call" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}" do |env|

--- a/test/gcloud/pubsub/topic/test_get_subscription.rb
+++ b/test/gcloud/pubsub/topic/test_get_subscription.rb
@@ -46,7 +46,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "gets an existing subscription" do
         mock_connection.get "/v1/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
@@ -73,7 +73,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "gets an existing subscription" do
         mock_connection.get "/v1/projects/#{project}/subscriptions/#{found_sub_name}" do |env|
@@ -102,7 +102,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "returns nil when getting an non-existant subscription" do
         # by definition, all subscriptions for this topic are non-existant
@@ -119,7 +119,7 @@ describe Gcloud::Pubsub::Topic, :get_subscription, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "returns nil when getting an non-existant subscription" do
         mock_connection.get "/v1/projects/#{project}/subscriptions/#{not_found_sub_name}" do |env|

--- a/test/gcloud/pubsub/topic/test_lazy.rb
+++ b/test/gcloud/pubsub/topic/test_lazy.rb
@@ -35,7 +35,7 @@ describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
   describe "lazy topic with explicit autocreate" do
     let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.connection,
-                                                 true }
+                                                 autocreate: true }
 
     it "will autocreate when created lazily" do
       topic.must_be :lazy?
@@ -45,7 +45,7 @@ describe Gcloud::Pubsub::Topic, :lazy, :mock_pubsub do
   describe "lazy topic without autocomplete" do
     let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.connection,
-                                                 false }
+                                                 autocreate: false }
 
     it "knows if it will create a topic on the Pub/Sub service" do
       topic.must_be :lazy?

--- a/test/gcloud/pubsub/topic/test_name.rb
+++ b/test/gcloud/pubsub/topic/test_name.rb
@@ -35,7 +35,7 @@ describe Gcloud::Pubsub::Topic, :name, :mock_pubsub do
   describe "lazy topic with explicit autocreate" do
     let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.connection,
-                                                 true }
+                                                 autocreate: true }
 
     it "matches the name returned from the HTTP method" do
       topic.name.must_equal "projects/#{project}/topics/#{topic_name}"
@@ -45,7 +45,7 @@ describe Gcloud::Pubsub::Topic, :name, :mock_pubsub do
   describe "lazy topic without autocomplete" do
     let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                  pubsub.connection,
-                                                 false }
+                                                 autocreate: false }
 
     it "matches the name returned from the HTTP method" do
       topic.name.must_equal "projects/#{project}/topics/#{topic_name}"

--- a/test/gcloud/pubsub/topic/test_policy.rb
+++ b/test/gcloud/pubsub/topic/test_policy.rb
@@ -1,0 +1,148 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:topic) { Gcloud::Pubsub::Topic.from_gapi JSON.parse(topic_json(topic_name)),
+                                                pubsub.connection }
+
+  it "gets the IAM Policy" do
+    policy_json = {
+      "policy" => {
+        "bindings" => [{
+          "role" => "roles/viewer",
+          "members" => [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ],
+        }],
+      }
+    }.to_json
+
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}:getIamPolicy" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       policy_json]
+    end
+
+    policy = topic.policy
+    policy.must_be_kind_of Hash
+    policy["bindings"].count.must_equal 1
+    policy["bindings"].first["role"].must_equal "roles/viewer"
+    policy["bindings"].first["members"].count.must_equal 2
+    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
+    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "memoizes policy" do
+    policy_hash = {
+      "bindings" => [{
+        "role" => "roles/viewer",
+        "members" => [
+          "user:viewer@example.com",
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+        ],
+      }]
+    }
+
+    topic.instance_variable_set "@policy", policy_hash
+
+    # No mocks, no errors, no HTTP calls are made
+    policy = topic.policy
+    policy.must_be_kind_of Hash
+    policy["bindings"].count.must_equal 1
+    policy["bindings"].first["role"].must_equal "roles/viewer"
+    policy["bindings"].first["members"].count.must_equal 2
+    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
+    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "makes API calls when forced, even if already memoized" do
+    policy_hash = {
+      "bindings" => [{
+        "role" => "roles/viewer",
+        "members" => [
+          "user:viewer@example.com",
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+        ],
+      }]
+    }
+
+    policy_json = {
+      "policy" => {
+        "bindings" => [{
+          "role" => "roles/owner",
+          "members" => [
+            "user:owner@example.com",
+            "serviceAccount:0987654321@developer.gserviceaccount.com"
+          ],
+        }],
+      }
+    }.to_json
+
+    mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}:getIamPolicy" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       policy_json]
+    end
+
+    topic.instance_variable_set "@policy", policy_hash
+    returned_policy = topic.policy
+    returned_policy.must_be_kind_of Hash
+    returned_policy["bindings"].count.must_equal 1
+    returned_policy["bindings"].first["role"].must_equal "roles/viewer"
+    returned_policy["bindings"].first["members"].count.must_equal 2
+    returned_policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
+    returned_policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+
+    policy = topic.policy force: true
+    policy.must_be_kind_of Hash
+    policy["bindings"].count.must_equal 1
+    policy["bindings"].first["role"].must_equal "roles/owner"
+    policy["bindings"].first["members"].count.must_equal 2
+    policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
+    policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+  end
+
+  it "sets the IAM Policy" do
+    new_policy = {
+      "bindings" => [{
+        "role" => "roles/owner",
+        "members" => [
+          "user:owner@example.com",
+          "serviceAccount:0987654321@developer.gserviceaccount.com"
+        ],
+      }],
+    }
+
+    mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:setIamPolicy" do |env|
+      json_policy = JSON.parse env.body
+      json_policy["policy"]["bindings"].count.must_equal 1
+      json_policy["policy"]["bindings"].first["role"].must_equal "roles/owner"
+      json_policy["policy"]["bindings"].first["members"].count.must_equal 2
+      json_policy["policy"]["bindings"].first["members"].first.must_equal "user:owner@example.com"
+      json_policy["policy"]["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+      [200, {"Content-Type"=>"application/json"},
+       { "policy" => new_policy }.to_json]
+    end
+
+    topic.policy = new_policy
+    # Setting the policy also memoizes the policy
+    topic.policy["bindings"].count.must_equal 1
+    topic.policy["bindings"].first["role"].must_equal "roles/owner"
+    topic.policy["bindings"].first["members"].count.must_equal 2
+    topic.policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
+    topic.policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+  end
+end

--- a/test/gcloud/pubsub/topic/test_publish.rb
+++ b/test/gcloud/pubsub/topic/test_publish.rb
@@ -74,7 +74,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "publishes a message" do
         mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
@@ -124,7 +124,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "publishes a message" do
         mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|
@@ -177,7 +177,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "publishes a message" do
         #first, failed attempt to publish
@@ -261,7 +261,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "publishes a message" do
         mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:publish" do |env|

--- a/test/gcloud/pubsub/topic/test_subscribe.rb
+++ b/test/gcloud/pubsub/topic/test_subscribe.rb
@@ -36,7 +36,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "creates a subscription when calling subscribe" do
         mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
@@ -54,7 +54,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "creates a subscription when calling subscribe" do
         mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|
@@ -74,7 +74,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "creates a subscription when calling subscribe" do
         #first, failed attempt to subscribe
@@ -103,7 +103,7 @@ describe Gcloud::Pubsub::Topic, :subscribe, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "raises NotFoundError when calling subscribe" do
         mock_connection.put "/v1/projects/#{project}/subscriptions/#{new_sub_name}" do |env|

--- a/test/gcloud/pubsub/topic/test_subscription.rb
+++ b/test/gcloud/pubsub/topic/test_subscription.rb
@@ -37,7 +37,7 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "gets lazy sub for an existing subscription" do
         sub = topic.subscription found_sub_name
@@ -55,7 +55,7 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "gets lazy sub for an existing subscription" do
         sub = topic.subscription found_sub_name
@@ -75,7 +75,7 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "gets lazy sub for an existing subscription" do
         sub = topic.subscription found_sub_name
@@ -87,7 +87,7 @@ describe Gcloud::Pubsub::Topic, :subscription, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "returns lazy sub when getting an non-existant subscription" do
         sub = topic.subscription not_found_sub_name

--- a/test/gcloud/pubsub/topic/test_subscriptions.rb
+++ b/test/gcloud/pubsub/topic/test_subscriptions.rb
@@ -35,7 +35,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "lists subscriptions" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
@@ -54,7 +54,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "lists subscriptions" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
@@ -75,7 +75,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
     describe "created with autocreate" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   true }
+                                                   autocreate: true }
 
       it "lists subscriptions" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|
@@ -92,7 +92,7 @@ describe Gcloud::Pubsub::Topic, :subscriptions, :mock_pubsub do
     describe "created without autocomplete" do
       let(:topic) { Gcloud::Pubsub::Topic.new_lazy topic_name,
                                                    pubsub.connection,
-                                                   false }
+                                                   autocreate: false }
 
       it "lists subscriptions" do
         mock_connection.get "/v1/projects/#{project}/topics/#{topic_name}/subscriptions" do |env|


### PR DESCRIPTION
Make changes requested by the Pub/Sub team during their review. #58

- [x] Ensure `Message#attributes` returns a Hash (and not a Google API Client object)
- [x] `Topic#pull` should return immediately by default
- [x] Add `Subscription#wait_for_messages` alias for `pull immediate: false`
- [x] Add auto acknowledgement when pulling messages (`Subscription#pull autoack: true`)
- [x] Add `Subscription#listen` code
- [x] Document listen feature in main pub/sub docs
- [x] Add docs for subscribing to topic in a different project
- [x] Add project syntax (`pubsub.topic "name", project: "project-id"`)
- [x] Add `Topic#policy` and `Topic#policy=` code/docs
- [x] Add `Subscription#policy` and `Subscription#policy=` code/docs

