### PR TITLE
Pass issuer and signing_key when creating a signed_url

### DIFF
--- a/lib/gcloud/storage/errors.rb
+++ b/lib/gcloud/storage/errors.rb
@@ -82,5 +82,13 @@ module Gcloud
         end
       end
     end
+
+    ##
+    # = SignedUrlUnavailable Error
+    #
+    # This is raised when File#signed_url is unable to generate a URL due to
+    # missing credentials needed to create the URL.
+    class SignedUrlUnavailable < Error
+    end
   end
 end

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -321,6 +321,14 @@ module Gcloud
       # }[https://cloud.google.com/storage/docs/access-control#Signed-URLs]
       # for more.
       #
+      # Generating a URL requires service account credentials, either by
+      # connecting with a service account when calling Gcloud.storage, or by
+      # passing in the service account +issuer+ and +signing_key+ values. A
+      # SignedUrlUnavailable is raised if the service account credentials are
+      # missing. Service account credentials are acquired by following the steps
+      # in {Service Account Authentication}[
+      # https://cloud.google.com/storage/docs/authentication#service_accounts].
+      #
       # === Parameters
       #
       # +options+::
@@ -339,6 +347,10 @@ module Gcloud
       #   The MD5 digest value in base64. If you provide this in the string, the
       #   client (usually a browser) must provide this HTTP header with this
       #   same value in its request. (+String+)
+      # <code>options[:issuer]</code>::
+      #   Service Account's Client Email. (+String+)
+      # <code>options[:signing_key]</code>::
+      #   Service Account's Private Key. (+OpenSSL::PKey::RSA+ or +String+)
       #
       # === Examples
       #
@@ -360,6 +372,23 @@ module Gcloud
       #   file = bucket.file "avatars/heidi/400x400.png"
       #   shared_url = file.signed_url method: "GET",
       #                                expires: 300 # 5 minutes from now
+      #
+      # Signed URLs require service account credentials. If you are not
+      # authenticated with a service account, those credentials can be passed in
+      # using the +issuer+ and +signing_key+ options. Although the private key
+      # can be passed as a string for convenience, creating and storing an
+      # instance of +OpenSSL::PKey::RSA+ is more efficient when making multiple
+      # calls to +signed_url+.
+      #
+      #   require "gcloud/storage"
+      #
+      #   storage = Gcloud.storage
+      #
+      #   bucket = storage.bucket "my-todo-app"
+      #   file = bucket.file "avatars/heidi/400x400.png"
+      #   key = OpenSSL::PKey::RSA.new "-----BEGIN PRIVATE KEY-----\n..."
+      #   shared_url = file.signed_url issuer: "service-account@gcloud.com",
+      #                                signing_key: key
       #
       def signed_url options = {}
         ensure_connection!

--- a/test/gcloud/storage/test_signed_url.rb
+++ b/test/gcloud/storage/test_signed_url.rb
@@ -1,0 +1,106 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe Gcloud::Storage::File, :signed_url, :mock_storage do
+  # Create a bucket object with the project's mocked connection object
+  let(:bucket_name) { "bucket" }
+  let(:bucket) { Gcloud::Storage::Bucket.from_gapi random_bucket_hash(bucket_name),
+                                                   storage.connection }
+
+  # Create a file object with the project's mocked connection object
+  let(:file_name) { "file.ext" }
+  let(:file) { Gcloud::Storage::File.from_gapi random_file_hash(bucket_name, file_name),
+                                               storage.connection }
+
+  it "uses the credentials' issuer and signing_key to generate signed_url" do
+    signing_key_mock = Minitest::Mock.new
+    signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, String]
+    credentials.issuer = "native_client_email"
+    credentials.signing_key = signing_key_mock
+
+    signed_url = file.signed_url
+
+    signed_url_params = CGI::parse(URI(signed_url).query)
+    signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
+    signed_url_params["Signature"].must_equal [Base64.encode64("native-signature").gsub("\n", "")]
+
+    signing_key_mock.verify
+  end
+
+  it "allows issuer and signing_key to be passed in as options" do
+    credentials.issuer = "native_client_email"
+    credentials.signing_key = PoisonSigningKey.new
+
+    signing_key_mock = Minitest::Mock.new
+    signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, String]
+
+    signed_url = file.signed_url issuer: "option_issuer",
+                                 signing_key: signing_key_mock
+
+    signed_url_params = CGI::parse(URI(signed_url).query)
+    signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
+    signed_url_params["Signature"].must_equal [Base64.encode64("option-signature").gsub("\n", "")]
+
+    signing_key_mock.verify
+  end
+
+  it "allows client_email and private to be passed in as options" do
+    credentials.issuer = "native_client_email"
+    credentials.signing_key = PoisonSigningKey.new
+
+    signing_key_mock = Minitest::Mock.new
+    signing_key_mock.expect :sign, "option-signature", [OpenSSL::Digest::SHA256, String]
+
+    OpenSSL::PKey::RSA.stub :new, signing_key_mock do
+
+      signed_url = file.signed_url client_email: "option_client_email",
+                                   private_key: "option_private_key"
+
+      signed_url_params = CGI::parse(URI(signed_url).query)
+      signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
+      signed_url_params["Signature"].must_equal [Base64.encode64("option-signature").gsub("\n", "")]
+
+    end
+
+    signing_key_mock.verify
+  end
+
+  it "raises when missing issuer" do
+    credentials.issuer = nil
+    credentials.signing_key = PoisonSigningKey.new
+
+    expect {
+      file.signed_url
+    }.must_raise Gcloud::Storage::SignedUrlUnavailable
+  end
+
+  it "raises when missing signing_key" do
+    credentials.issuer = "native_issuer"
+    credentials.signing_key = nil
+
+    expect {
+      file.signed_url
+    }.must_raise Gcloud::Storage::SignedUrlUnavailable
+  end
+
+  class PoisonSigningKey
+    def sign kind, sig
+      raise "The wrong signing_key was used"
+    end
+  end
+end


### PR DESCRIPTION
A service account's `issuer` and `signing_key` values are required to generate a `signed_url`. Initially, all gcloud-ruby connections were service accounts, but it now supports GCE and Cloud SDK credentials as well. These new types of credentials are missing the assertion values (`issuer` and `signing_key`). In order to generate signed_urls these values need to be passed in.

[fixes #181]