### PR TITLE
Correct rubocop warnings

### DIFF
--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -102,7 +102,7 @@ module Gcloud
       # Transaction#start must be called afterwards.
       def reset!
         @shared_mutation = nil
-        @id  = nil
+        @id = nil
         @_auto_id_entities = []
       end
 

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -512,6 +512,9 @@ module Gcloud
         @gapi.nil?
       end
 
+      # rubocop:disable Style/TrivialAccessors
+      # Disabled rubocop because you can't use "?" in an attr.
+
       ##
       # Determines whether the lazy topic object should create a topic on the
       # Pub/Sub service.
@@ -529,6 +532,8 @@ module Gcloud
       def autocreate? #:nodoc:
         @autocreate
       end
+
+      # rubocop:enable Style/TrivialAccessors
 
       ##
       # New Topic from a Google API Client object.

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -561,7 +561,7 @@ module Gcloud
         end
 
         def generate_signed_url issuer, signed_string, expires
-          signature = Base64.encode64(signed_string).gsub("\n", "")
+          signature = Base64.encode64(signed_string).delete("\n")
           "#{ext_url}?GoogleAccessId=#{CGI.escape issuer}" \
                     "&Expires=#{expires}" \
                     "&Signature=#{CGI.escape signature}"

--- a/test/gcloud/storage/test_signed_url.rb
+++ b/test/gcloud/storage/test_signed_url.rb
@@ -37,7 +37,7 @@ describe Gcloud::Storage::File, :signed_url, :mock_storage do
 
     signed_url_params = CGI::parse(URI(signed_url).query)
     signed_url_params["GoogleAccessId"].must_equal ["native_client_email"]
-    signed_url_params["Signature"].must_equal [Base64.encode64("native-signature").gsub("\n", "")]
+    signed_url_params["Signature"].must_equal [Base64.encode64("native-signature").delete("\n")]
 
     signing_key_mock.verify
   end
@@ -54,7 +54,7 @@ describe Gcloud::Storage::File, :signed_url, :mock_storage do
 
     signed_url_params = CGI::parse(URI(signed_url).query)
     signed_url_params["GoogleAccessId"].must_equal ["option_issuer"]
-    signed_url_params["Signature"].must_equal [Base64.encode64("option-signature").gsub("\n", "")]
+    signed_url_params["Signature"].must_equal [Base64.encode64("option-signature").delete("\n")]
 
     signing_key_mock.verify
   end
@@ -73,7 +73,7 @@ describe Gcloud::Storage::File, :signed_url, :mock_storage do
 
       signed_url_params = CGI::parse(URI(signed_url).query)
       signed_url_params["GoogleAccessId"].must_equal ["option_client_email"]
-      signed_url_params["Signature"].must_equal [Base64.encode64("option-signature").gsub("\n", "")]
+      signed_url_params["Signature"].must_equal [Base64.encode64("option-signature").delete("\n")]
 
     end
 


### PR DESCRIPTION
Rubycop 0.33 changed some rules, update the code to reflect these changes.