### PR TITLE
Improve error messaging when uploading files

### DIFF
--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -326,9 +326,7 @@ module Gcloud
       #
       def create_file file, path = nil, options = {}
         ensure_connection!
-        # TODO: Raise if file doesn't exist
-        # ensure_file_exists!
-        fail unless ::File.file? file
+        ensure_file_exists! file
 
         options[:acl] = File::Acl.predefined_rule_for options[:acl]
 
@@ -464,6 +462,13 @@ module Gcloud
       # Raise an error unless an active connection is available.
       def ensure_connection!
         fail "Must have active connection" unless connection
+      end
+
+      ##
+      # Raise an error if the file is not found.
+      def ensure_file_exists! file
+        return if ::File.file? file
+        fail ArgumentError, "cannot find file #{file}"
       end
 
       ##

--- a/test/gcloud/storage/test_bucket.rb
+++ b/test/gcloud/storage/test_bucket.rb
@@ -140,6 +140,17 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     end
   end
 
+  it "raises when given a file that does not exist" do
+    bad_file_path = "/this/file/does/not/exist.ext"
+
+    refute ::File.file?(bad_file_path)
+
+    err = expect {
+      bucket.create_file bad_file_path
+    }.must_raise ArgumentError
+    err.message.must_match bad_file_path
+  end
+
   it "lists files" do
     num_files = 3
     mock_connection.get "/storage/v1/b/#{bucket.name}/o" do |env|


### PR DESCRIPTION
If the file given does not exist, an error is raised.
Previously, an generic error was raised without any messaging.
Now we are raising an ArgumentError with a helpful message stating
that the file given does not exist.

[closes #220]