### PR TITLE
Initialize ApiError from response status if no data

### DIFF
--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -259,7 +259,7 @@ module Gcloud
         if resp.success?
           Dataset.from_gapi resp.data, connection
         else
-          return nil if resp.data["error"]["code"] == 404
+          return nil if resp.status == 404
           fail ApiError.from_response(resp)
         end
       end
@@ -416,7 +416,7 @@ module Gcloud
         if resp.success?
           Job.from_gapi resp.data, connection
         else
-          return nil if resp.data["error"]["code"] == 404
+          return nil if resp.status == 404
           fail ApiError.from_response(resp)
         end
       end

--- a/lib/gcloud/bigquery/query_data.rb
+++ b/lib/gcloud/bigquery/query_data.rb
@@ -88,9 +88,6 @@ module Gcloud
         end
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # Disabling because its better to keep this logic together.
-
       ##
       # The BigQuery Job that was created to run the query.
       def job
@@ -101,12 +98,10 @@ module Gcloud
         if resp.success?
           @job = Job.from_gapi resp.data, connection
         else
-          return nil if resp.data["error"]["code"] == 404
+          return nil if resp.status == 404
           fail ApiError.from_response(resp)
         end
       end
-
-      # rubocop:enable Metrics/AbcSize
 
       ##
       # New Data from a response object.


### PR DESCRIPTION
Since `resp.data` can be nil, create ApiError using `status` and `error_message` if it is not present. Also use resp.status to test for 404 responses.
[closes #224]