### PR TITLE
Prevent missing project ID

### DIFF
--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -51,6 +51,8 @@ module Gcloud
       #
       # See Gcloud.bigquery
       def initialize project, credentials
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
       end
 

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -52,6 +52,8 @@ module Gcloud
       #
       # See Gcloud#datastore
       def initialize project, credentials #:nodoc:
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
       end
 

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -47,6 +47,8 @@ module Gcloud
       ##
       # Creates a new Connection instance.
       def initialize project, credentials #:nodoc:
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
       end
 

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -52,6 +52,8 @@ module Gcloud
       #
       # See Gcloud#storage
       def initialize project, credentials #:nodoc:
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
       end
 


### PR DESCRIPTION
Because no request is executed when a connection is initialized, errors due to missing
project ID arrive only when a specific API method is called, leading to confusion. Checking
for project ID in the initializer resolves this.

[closes #225]