### PR TITLE
Allow use of custom scopes when connecting to service APIs

### DIFF
--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -70,11 +70,26 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
+  # === Parameters
+  #
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scopes are:
+  #
+  #   * +https://www.googleapis.com/auth/datastore+
+  #   * +https://www.googleapis.com/auth/userinfo.email+
+  #
   # === Returns
   #
   # Gcloud::Datastore::Dataset
   #
-  # === Example
+  # === Examples
   #
   #   require "gcloud"
   #
@@ -88,6 +103,15 @@ module Gcloud
   #
   #   dataset.save entity
   #
+  # You shouldn't need to override the default scope, but it is possible to do
+  # so with the +scope+ option:
+  #
+  #   require "gcloud"
+  #
+  #   gcloud  = Gcloud.new
+  #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
+  #   dataset = gcloud.datastore scope: platform_scope
+  #
   def datastore options = {}
     require "gcloud/datastore"
     Gcloud.datastore @project, @keyfile, options
@@ -97,11 +121,25 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
+  # === Parameters
+  #
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/devstorage.full_control+
+  #
   # === Returns
   #
   # Gcloud::Storage::Project
   #
-  # === Example
+  # === Examples
   #
   #   require "gcloud"
   #
@@ -109,6 +147,16 @@ module Gcloud
   #   storage = gcloud.storage
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
+  #
+  # The default scope can be overridden with the +scope+ option. For more
+  # information see {Storage OAuth 2.0
+  # Authentication}[https://cloud.google.com/storage/docs/authentication#oauth].
+  #
+  #   require "gcloud"
+  #
+  #   gcloud  = Gcloud.new
+  #   readonly_scope = "https://www.googleapis.com/auth/devstorage.read_only"
+  #   readonly_storage = gcloud.storage scope: readonly_scope
   #
   def storage options = {}
     require "gcloud/storage"
@@ -119,11 +167,25 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
+  # === Parameters
+  #
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/pubsub+
+  #
   # === Returns
   #
   # Gcloud::Pubsub::Project
   #
-  # === Example
+  # === Examples
   #
   #   require "gcloud"
   #
@@ -131,6 +193,14 @@ module Gcloud
   #   pubsub = gcloud.pubsub
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
+  #
+  # The default scope can be overridden with the +scope+ option:
+  #
+  #   require "gcloud"
+  #
+  #   gcloud  = Gcloud.new
+  #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
+  #   pubsub = gcloud.pubsub scope: platform_scope
   #
   def pubsub options = {}
     require "gcloud/pubsub"
@@ -141,11 +211,25 @@ module Gcloud
   # Creates a new object for connecting to the BigQuery service.
   # Each call creates a new connection.
   #
+  # === Parameters
+  #
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/bigquery+
+  #
   # === Returns
   #
   # Gcloud::Bigquery::Project
   #
-  # === Example
+  # === Examples
   #
   #   require "gcloud"
   #
@@ -156,6 +240,14 @@ module Gcloud
   #   table.data.each do |row|
   #     puts row
   #   end
+  #
+  # The default scope can be overridden with the +scope+ option:
+  #
+  #   require "gcloud"
+  #
+  #   gcloud  = Gcloud.new
+  #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
+  #   bigquery = gcloud.bigquery scope: platform_scope
   #
   def bigquery options = {}
     require "gcloud/bigquery"

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -88,9 +88,9 @@ module Gcloud
   #
   #   dataset.save entity
   #
-  def datastore
+  def datastore options = {}
     require "gcloud/datastore"
-    Gcloud.datastore @project, @keyfile
+    Gcloud.datastore @project, @keyfile, options
   end
 
   ##
@@ -110,9 +110,9 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  def storage
+  def storage options = {}
     require "gcloud/storage"
-    Gcloud.storage @project, @keyfile
+    Gcloud.storage @project, @keyfile, options
   end
 
   ##
@@ -132,9 +132,9 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  def pubsub
+  def pubsub options = {}
     require "gcloud/pubsub"
-    Gcloud.pubsub @project, @keyfile
+    Gcloud.pubsub @project, @keyfile, options
   end
 
   ##
@@ -157,9 +157,9 @@ module Gcloud
   #     puts row
   #   end
   #
-  def bigquery
+  def bigquery options = {}
     require "gcloud/bigquery"
-    Gcloud.bigquery @project, @keyfile
+    Gcloud.bigquery @project, @keyfile, options
   end
 
   ##

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -43,12 +43,12 @@ module Gcloud
   #   dataset = bigquery.dataset "my_dataset"
   #   table = dataset.table "my_table"
   #
-  def self.bigquery project = nil, keyfile = nil
+  def self.bigquery project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Bigquery::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Bigquery::Credentials.default
+      credentials = Gcloud::Bigquery::Credentials.default options
     else
-      credentials = Gcloud::Bigquery::Credentials.new keyfile
+      credentials = Gcloud::Bigquery::Credentials.new keyfile, options
     end
     Gcloud::Bigquery::Project.new project, credentials
   end

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -30,6 +30,17 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/bigquery+
   #
   # === Returns
   #

--- a/lib/gcloud/bigquery/credentials.rb
+++ b/lib/gcloud/bigquery/credentials.rb
@@ -20,8 +20,7 @@ module Gcloud
     ##
     # Represents the Oauth2 signing logic for Bigquery.
     class Credentials < Gcloud::Credentials #:nodoc:
-      SCOPE = ["https://www.googleapis.com/auth/bigquery",
-               "https://www.googleapis.com/auth/cloud-platform"]
+      SCOPE = ["https://www.googleapis.com/auth/bigquery"]
       PATH_ENV_VARS = %w(BIGQUERY_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(BIGQUERY_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON)
     end

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -133,7 +133,7 @@ module Gcloud
       # client options for initializing signet client
       { token_credential_uri: options["token_credential_uri"],
         audience: options["audience"],
-        scope: options["scope"],
+        scope: Array(options["scope"]),
         issuer: options["client_email"],
         signing_key: OpenSSL::PKey::RSA.new(options["private_key"]) }
     end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -33,6 +33,18 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scopes are:
+  #
+  #   * +https://www.googleapis.com/auth/datastore+
+  #   * +https://www.googleapis.com/auth/userinfo.email+
   #
   # === Returns
   #

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -52,12 +52,12 @@ module Gcloud
   #
   #   dataset.save entity
   #
-  def self.datastore project = nil, keyfile = nil
+  def self.datastore project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Datastore::Dataset.default_project
     if keyfile.nil?
-      credentials = Gcloud::Datastore::Credentials.default
+      credentials = Gcloud::Datastore::Credentials.default options
     else
-      credentials = Gcloud::Datastore::Credentials.new keyfile
+      credentials = Gcloud::Datastore::Credentials.new keyfile, options
     end
     Gcloud::Datastore::Dataset.new project, credentials
   end

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -45,12 +45,12 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  def self.pubsub project = nil, keyfile = nil
+  def self.pubsub project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Pubsub::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Pubsub::Credentials.default
+      credentials = Gcloud::Pubsub::Credentials.default options
     else
-      credentials = Gcloud::Pubsub::Credentials.new keyfile
+      credentials = Gcloud::Pubsub::Credentials.new keyfile, options
     end
     Gcloud::Pubsub::Project.new project, credentials
   end

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -31,6 +31,17 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/pubsub+
   #
   # === Returns
   #

--- a/lib/gcloud/pubsub/credentials.rb
+++ b/lib/gcloud/pubsub/credentials.rb
@@ -20,8 +20,7 @@ module Gcloud
     ##
     # Represents the OAuth 2.0 signing logic for Pub/Sub.
     class Credentials < Gcloud::Credentials #:nodoc:
-      SCOPE = ["https://www.googleapis.com/auth/pubsub",
-               "https://www.googleapis.com/auth/cloud-platform"]
+      SCOPE = ["https://www.googleapis.com/auth/pubsub"]
       PATH_ENV_VARS = %w(PUBSUB_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(PUBSUB_KEYFILE_JSON GOOGLE_CLOUD_KEYFILE_JSON)
     end

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -46,12 +46,12 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  def self.storage project = nil, keyfile = nil
+  def self.storage project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Storage::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Storage::Credentials.default
+      credentials = Gcloud::Storage::Credentials.default options
     else
-      credentials = Gcloud::Storage::Credentials.new keyfile
+      credentials = Gcloud::Storage::Credentials.new keyfile, options
     end
     Gcloud::Storage::Project.new project, credentials
   end

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -31,6 +31,17 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/devstorage.full_control+
   #
   # === Returns
   #

--- a/test/gcloud/credentials_test.rb
+++ b/test/gcloud/credentials_test.rb
@@ -1,0 +1,73 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+##
+# This test is testing the private class Gcloud::Credentials. We want to make
+# sure that the passed in scope propogates to the Signet object. This means
+# testing the private API, which is generally frowned on.
+describe Gcloud::Credentials, :private do
+  let(:default_keyfile_hash) do
+    {
+      "private_key_id"=>"testabc1234567890xyz",
+      "private_key"=>"-----BEGIN RSA PRIVATE KEY-----\nMIIBOwIBAAJBAOyi0Hy1l4Ym2m2o71Q0TF4O9E81isZEsX0bb+Bqz1SXEaSxLiXM\nUZE8wu0eEXivXuZg6QVCW/5l+f2+9UPrdNUCAwEAAQJAJkqubA/Chj3RSL92guy3\nktzeodarLyw8gF8pOmpuRGSiEo/OLTeRUMKKD1/kX4f9sxf3qDhB4e7dulXR1co/\nIQIhAPx8kMW4XTTL6lJYd2K5GrH8uBMp8qL5ya3/XHrBgw3dAiEA7+3Iw3ULTn2I\n1J34WlJ2D5fbzMzB4FAHUNEV7Ys3f1kCIQDtUahCMChrl7+H5t9QS+xrn77lRGhs\nB50pjvy95WXpgQIhAI2joW6JzTfz8fAapb+kiJ/h9Vcs1ZN3iyoRlNFb61JZAiA8\nNy5NyNrMVwtB/lfJf1dAK/p/Bwd8LZLtgM6PapRfgw==\n-----END RSA PRIVATE KEY-----\n",
+      "client_email"=>"credz-testabc1234567890xyz@developer.gserviceaccount.com",
+      "client_id"=>"credz-testabc1234567890xyz.apps.googleusercontent.com",
+      "type"=>"service_account"
+    }
+  end
+
+  it "uses a default scope" do
+    mocked_signet = MiniTest::Mock.new
+    mocked_signet.expect :fetch_access_token!, true
+
+    stubbed_signet = ->(options) {
+      options[:token_credential_uri].must_equal "https://accounts.google.com/o/oauth2/token"
+      options[:audience].must_equal "https://accounts.google.com/o/oauth2/token"
+      options[:scope].must_equal []
+      options[:issuer].must_equal default_keyfile_hash["client_email"]
+      options[:signing_key].must_be_kind_of OpenSSL::PKey::RSA
+
+      mocked_signet
+    }
+
+    Signet::OAuth2::Client.stub :new, stubbed_signet do
+      Gcloud::Credentials.new default_keyfile_hash
+    end
+
+    mocked_signet.verify
+  end
+
+  it "uses a custom scope" do
+    mocked_signet = MiniTest::Mock.new
+    mocked_signet.expect :fetch_access_token!, true
+
+    stubbed_signet = ->(options) {
+      options[:token_credential_uri].must_equal "https://accounts.google.com/o/oauth2/token"
+      options[:audience].must_equal "https://accounts.google.com/o/oauth2/token"
+      options[:scope].must_equal ["http://example.com/scope"]
+      options[:issuer].must_equal default_keyfile_hash["client_email"]
+      options[:signing_key].must_be_kind_of OpenSSL::PKey::RSA
+
+      mocked_signet
+    }
+
+    Signet::OAuth2::Client.stub :new, stubbed_signet do
+      Gcloud::Credentials.new default_keyfile_hash, scope: "http://example.com/scope"
+    end
+
+    mocked_signet.verify
+  end
+end

--- a/test/gcloud/gcloud_test.rb
+++ b/test/gcloud/gcloud_test.rb
@@ -20,49 +20,169 @@ require "gcloud/pubsub"
 describe Gcloud do
   it "calls out to Gcloud.datastore" do
     gcloud = Gcloud.new
-    Gcloud.stub :datastore, "datastore-project-object" do
+    stubbed_datastore = ->(project, keyfile, options) {
+      project.must_equal nil
+      keyfile.must_equal nil
+      options.must_equal({})
+      "datastore-project-object-empty"
+    }
+    Gcloud.stub :datastore, stubbed_datastore do
       dataset = gcloud.datastore
-      dataset.must_equal "datastore-project-object"
+      dataset.must_equal "datastore-project-object-empty"
     end
   end
 
   it "passes project and keyfile to Gcloud.datastore" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    Gcloud.stub :datastore, "datastore-project-object", ["project-id", "keyfile-path"] do
+    stubbed_datastore = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({})
+      "datastore-project-object"
+    }
+    Gcloud.stub :datastore, stubbed_datastore do
       dataset = gcloud.datastore
       dataset.must_equal "datastore-project-object"
     end
   end
 
+  it "passes project and keyfile and options to Gcloud.datastore" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    stubbed_datastore = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({scope: "http://example.com/scope"})
+      "datastore-project-object-scoped"
+    }
+    Gcloud.stub :datastore, stubbed_datastore do
+      dataset = gcloud.datastore scope: "http://example.com/scope"
+      dataset.must_equal "datastore-project-object-scoped"
+    end
+  end
+
   it "calls out to Gcloud.storage" do
     gcloud = Gcloud.new
-    Gcloud.stub :storage, "storage-project-object" do
+    stubbed_storage = ->(project, keyfile, options) {
+      project.must_equal nil
+      keyfile.must_equal nil
+      options.must_equal({})
+      "storage-project-object-empty"
+    }
+    Gcloud.stub :storage, stubbed_storage do
       dataset = gcloud.storage
-      dataset.must_equal "storage-project-object"
+      dataset.must_equal "storage-project-object-empty"
     end
   end
 
   it "passes project and keyfile to Gcloud.storage" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    Gcloud.stub :storage, "storage-project-object", ["project-id", "keyfile-path"] do
+    stubbed_storage = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({})
+      "storage-project-object"
+    }
+    Gcloud.stub :storage, stubbed_storage do
       dataset = gcloud.storage
       dataset.must_equal "storage-project-object"
     end
   end
 
+  it "passes project and keyfile and options to Gcloud.storage" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    stubbed_storage = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({scope: "http://example.com/scope"})
+      "storage-project-object-scoped"
+    }
+    Gcloud.stub :storage, stubbed_storage do
+      dataset = gcloud.storage scope: "http://example.com/scope"
+      dataset.must_equal "storage-project-object-scoped"
+    end
+  end
+
   it "calls out to Gcloud.pubsub" do
     gcloud = Gcloud.new
-    Gcloud.stub :pubsub, "pubsub-project-object" do
+    stubbed_pubsub = ->(project, keyfile, options) {
+      project.must_equal nil
+      keyfile.must_equal nil
+      options.must_equal({})
+      "pubsub-project-object-empty"
+    }
+    Gcloud.stub :pubsub, stubbed_pubsub do
       dataset = gcloud.pubsub
-      dataset.must_equal "pubsub-project-object"
+      dataset.must_equal "pubsub-project-object-empty"
     end
   end
 
   it "passes project and keyfile to Gcloud.pubsub" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    Gcloud.stub :pubsub, "pubsub-project-object", ["project-id", "keyfile-path"] do
+    stubbed_pubsub = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({})
+      "pubsub-project-object"
+    }
+    Gcloud.stub :pubsub, stubbed_pubsub do
       dataset = gcloud.pubsub
       dataset.must_equal "pubsub-project-object"
+    end
+  end
+
+  it "passes project and keyfile and options to Gcloud.pubsub" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    stubbed_pubsub = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({scope: "http://example.com/scope"})
+      "pubsub-project-object-scoped"
+    }
+    Gcloud.stub :pubsub, stubbed_pubsub do
+      dataset = gcloud.pubsub scope: "http://example.com/scope"
+      dataset.must_equal "pubsub-project-object-scoped"
+    end
+  end
+
+  it "calls out to Gcloud.bigquery" do
+    gcloud = Gcloud.new
+    stubbed_bigquery = ->(project, keyfile, options) {
+      project.must_equal nil
+      keyfile.must_equal nil
+      options.must_equal({})
+      "bigquery-project-object-empty"
+    }
+    Gcloud.stub :bigquery, stubbed_bigquery do
+      dataset = gcloud.bigquery
+      dataset.must_equal "bigquery-project-object-empty"
+    end
+  end
+
+  it "passes project and keyfile to Gcloud.bigquery" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    stubbed_bigquery = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({})
+      "bigquery-project-object"
+    }
+    Gcloud.stub :bigquery, stubbed_bigquery do
+      dataset = gcloud.bigquery
+      dataset.must_equal "bigquery-project-object"
+    end
+  end
+
+  it "passes project and keyfile and options to Gcloud.bigquery" do
+    gcloud = Gcloud.new "project-id", "keyfile-path"
+    stubbed_bigquery = ->(project, keyfile, options) {
+      project.must_equal "project-id"
+      keyfile.must_equal "keyfile-path"
+      options.must_equal({scope: "http://example.com/scope"})
+      "bigquery-project-object-scoped"
+    }
+    Gcloud.stub :bigquery, stubbed_bigquery do
+      dataset = gcloud.bigquery scope: "http://example.com/scope"
+      dataset.must_equal "bigquery-project-object-scoped"
     end
   end
 end


### PR DESCRIPTION
Allow users to assert a specific OAuth 2.0 scope when connecting to the API.