### PR TITLE
Add Datastore backup format option to Table#load

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -530,7 +530,8 @@ module Gcloud
               }.delete_if { |_, v| v.nil? },
               "createDisposition" => create_disposition(options[:create]),
               "writeDisposition" => write_disposition(options[:write]),
-              "sourceFormat" => source_format(path, options[:format])
+              "sourceFormat" => source_format(path, options[:format]),
+              "projectionFields" => projection_fields(options[:projection_fields])
             }.delete_if { |_, v| v.nil? },
             "dryRun" => options[:dryrun]
           }.delete_if { |_, v| v.nil? }
@@ -568,13 +569,20 @@ module Gcloud
         val = { "csv" => "CSV",
                 "json" => "NEWLINE_DELIMITED_JSON",
                 "newline_delimited_json" => "NEWLINE_DELIMITED_JSON",
-                "avro" => "AVRO" }[format.to_s.downcase]
+                "avro" => "AVRO",
+                "datastore" => "DATASTORE_BACKUP",
+                "datastore_backup" => "DATASTORE_BACKUP"}[format.to_s.downcase]
         return val unless val.nil?
         return nil if path.nil?
         return "CSV" if path.end_with? ".csv"
         return "NEWLINE_DELIMITED_JSON" if path.end_with? ".json"
         return "AVRO" if path.end_with? ".avro"
+        return "DATASTORE_BACKUP" if path.end_with? ".backup_info"
         nil
+      end
+
+      def projection_fields array_or_str
+        Array(array_or_str) unless array_or_str.nil?
       end
 
       # rubocop:enable all

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -542,6 +542,7 @@ module Gcloud
       #   * +csv+ - CSV
       #   * +json+ - {Newline-delimited JSON}[http://jsonlines.org/]
       #   * +avro+ - {Avro}[http://avro.apache.org/]
+      #   * +datastore_backup+ - Cloud Datastore backup
       # <code>options[:create]</code>::
       #   Specifies whether the job is allowed to create new tables. (+String+)
       #
@@ -558,6 +559,12 @@ module Gcloud
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - An error will be returned if the table already contains
       #     data.
+      # <code>options[:projection_fields]</code>::
+      #   If the +format+ option is set to +datastore_backup+, indicates which
+      #   entity properties to load from a Cloud Datastore backup. Property
+      #   names are case sensitive and must be top-level properties. If not set,
+      #   BigQuery loads all properties. If any named property isn't found in
+      #   the Cloud Datastore backup, an invalid error is returned. (+Array+)
       #
       # === Returns
       #


### PR DESCRIPTION
This includes adding the `projection_fields` option to Table#load
for specifying which entity fields to load from the backup, as
well as detection of format from the file extention `.backup_info`.

[closes #205]