### PR TITLE
Add DATASTORE_DATASET environment variable

### DIFF
--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -77,7 +77,8 @@ module Gcloud
       ##
       # Default project.
       def self.default_project #:nodoc:
-        ENV["DATASTORE_PROJECT"] ||
+        ENV["DATASTORE_DATASET"] ||
+          ENV["DATASTORE_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"]
       end


### PR DESCRIPTION
Currently, it seems that the Google Cloud Project ID and the Datastore Dataset ID are the same, so this change just adds the new environment variable to the front to the list used to detect Project ID.

[closes #237]