### PR TITLE
Add mechanism to block on a job until it is done

### DIFF
--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -171,11 +171,7 @@ module Gcloud
   #         "FROM publicdata:samples.shakespeare"
   #   job = bigquery.query_job sql
   #
-  #   loop do
-  #     break if job.done?
-  #     sleep 1
-  #     job.refresh!
-  #   end
+  #   job.wait_until_done!
   #   if !job.failed?
   #     job.query_results.each do |row|
   #       puts row["word"]
@@ -362,11 +358,7 @@ module Gcloud
   #         "ORDER BY count DESC"
   #   query_job = dataset.query_job sql, table: result_table
   #
-  #   loop do
-  #     break if query_job.done?
-  #     sleep 1
-  #     query_job.refresh!
-  #   end
+  #   query_job.wait_until_done!
   #
   #   if !query_job.failed?
   #
@@ -377,11 +369,7 @@ module Gcloud
   #
   #     extract_job = result_table.extract extract_url
   #
-  #     loop do
-  #       break if extract_job.done?
-  #       sleep 1
-  #       extract_job.refresh!
-  #     end
+  #     extract_job.wait_until_done!
   #
   #     # Download to local filesystem
   #     bucket.files.first.download "baby-names-sam.csv"

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -516,11 +516,7 @@ module Gcloud
       #
       #   job = bigquery.query_job "SELECT name FROM my_table"
       #
-      #   loop do
-      #     break if job.done?
-      #     sleep 1
-      #     job.refresh!
-      #   end
+      #   job.wait_until_done!
       #   if !job.failed?
       #     job.query_results.each do |row|
       #       puts row["name"]

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -143,11 +143,7 @@ module Gcloud
       #
       #   job = bigquery.query_job "SELECT name FROM [my_proj:my_data.my_table]"
       #
-      #   loop do
-      #     break if job.done?
-      #     sleep 1
-      #     job.refresh!
-      #   end
+      #   job.wait_until_done!
       #   if !job.failed?
       #     job.query_results.each do |row|
       #       puts row["name"]

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -126,11 +126,7 @@ module Gcloud
       #   q = "SELECT word FROM publicdata:samples.shakespeare"
       #   job = bigquery.query_job q
       #
-      #   loop do
-      #     break if job.done?
-      #     sleep 1
-      #     job.refresh!
-      #   end
+      #   job.wait_until_done!
       #   data = job.query_results
       #   data.each do |row|
       #     puts row["word"]


### PR DESCRIPTION
The common idiom is to refresh a job as it cycles from pending to running to done.
The `Job#wait_until_done!` convenience method implements this logic.

[closed #228]