### PR TITLE
Add inspect override to Connection

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -315,6 +315,10 @@ module Gcloud
         result
       end
 
+      def inspect
+        "#{self.class}(#{@project})"
+      end
+
       protected
 
       ##

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -315,7 +315,7 @@ module Gcloud
         result
       end
 
-      def inspect
+      def inspect #:nodoc:
         "#{self.class}(#{@project})"
       end
 

--- a/lib/gcloud/datastore/connection.rb
+++ b/lib/gcloud/datastore/connection.rb
@@ -144,7 +144,7 @@ module Gcloud
         @http_host = new_http_host
       end
 
-      def inspect
+      def inspect #:nodoc:
         "#{self.class}(#{@dataset_id})"
       end
 

--- a/lib/gcloud/datastore/connection.rb
+++ b/lib/gcloud/datastore/connection.rb
@@ -144,6 +144,10 @@ module Gcloud
         @http_host = new_http_host
       end
 
+      def inspect
+        "#{self.class}(#{@dataset_id})"
+      end
+
       protected
 
       ##

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -253,6 +253,10 @@ module Gcloud
         "#{project_path(options)}/subscriptions/#{subscription_name}"
       end
 
+      def inspect
+        "#{self.class}(#{@project})"
+      end
+
       protected
 
       def subscription_data topic, options = {}

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -253,7 +253,7 @@ module Gcloud
         "#{project_path(options)}/subscriptions/#{subscription_name}"
       end
 
-      def inspect
+      def inspect #:nodoc:
         "#{self.class}(#{@project})"
       end
 

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -347,7 +347,7 @@ module Gcloud
         MIME::Types.of(path).first.to_s
       end
 
-      def inspect
+      def inspect #:nodoc:
         "#{self.class}(#{@project})"
       end
 

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -347,6 +347,10 @@ module Gcloud
         MIME::Types.of(path).first.to_s
       end
 
+      def inspect
+        "#{self.class}(#{@project})"
+      end
+
       protected
 
       def incremental_backoff options = {}


### PR DESCRIPTION
Improve user experience in IRB and elsewhere by hiding the details of Google API Client, the inspect output of which is incredibly verbose.

[closes #208]