### PR TITLE
Invoke RDoc task in clean environment

### DIFF
--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 gem "rdoc"
+require "bundler"
 require "rdoc/task"
 require "fileutils"
 require "pathname"
@@ -101,9 +102,11 @@ namespace :pages do
     puts `git clone --quiet --branch=#{tag} --single-branch #{git_repo} #{repo} > /dev/null`
     # build the docs in the tag repo
     Dir.chdir repo do
-      # create the docs
-      puts `bundle install`
-      puts `bundle exec rake pages:rdoc`
+      Bundler.with_clean_env do
+        # create the docs
+        puts `bundle install --path .bundle`
+        puts `bundle exec rake pages:rdoc`
+      end
     end
 
     # checkout the gh-pages branch


### PR DESCRIPTION
The 0.1.0 tag has some old dependencies that were not installed when
running the rake pages:tag[v0.1.0] command using bundle exec.
This was due to Bundler being too clevar and applying the parent
scope to all sub shells. To resolve this call the commands using the
Bundler.with_clean_env method.

[closes #215]