### PR TITLE
Allow NULL values

### DIFF
--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -89,6 +89,7 @@ module Gcloud
         if Time                      === value ||
            Gcloud::Datastore::Key    === value ||
            Gcloud::Datastore::Entity === value ||
+           NilClass                  === value ||
            TrueClass                 === value ||
            FalseClass                === value ||
            Float                     === value ||

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 require "gcloud/proto/datastore_v1.pb"
+require "gcloud/datastore/errors"
 
 module Gcloud
   module Datastore
@@ -63,6 +64,8 @@ module Gcloud
           v.key_value = value.to_proto
         elsif Gcloud::Datastore::Entity === value
           v.entity_value = value.to_proto
+        elsif NilClass === value
+          # The correct behavior is to not set a value property
         elsif TrueClass === value
           v.boolean_value = true
         elsif FalseClass === value

--- a/test/gcloud/datastore/entity_test.rb
+++ b/test/gcloud/datastore/entity_test.rb
@@ -54,11 +54,14 @@ describe Gcloud::Datastore::Entity do
     proto.key.path_element.first.kind = "User"
     proto.key.path_element.first.id = 123456
     proto.property = [Gcloud::Datastore::Proto::Property.new,
+                      Gcloud::Datastore::Proto::Property.new,
                       Gcloud::Datastore::Proto::Property.new]
-    proto.property.first.name = "name"
-    proto.property.first.value = Gcloud::Datastore::Proto.to_proto_value "User McNumber"
-    proto.property.last.name = "email"
-    proto.property.last.value = Gcloud::Datastore::Proto.to_proto_value "number@example.net"
+    proto.property[0].name = "name"
+    proto.property[0].value = Gcloud::Datastore::Proto.to_proto_value "User McNumber"
+    proto.property[1].name = "email"
+    proto.property[1].value = Gcloud::Datastore::Proto.to_proto_value "number@example.net"
+    proto.property[2].name = "avatar"
+    proto.property[2].value = Gcloud::Datastore::Proto.to_proto_value nil
 
     entity_from_proto = Gcloud::Datastore::Entity.from_proto proto
 
@@ -67,6 +70,8 @@ describe Gcloud::Datastore::Entity do
     entity_from_proto.key.name.must_be :nil?
     entity_from_proto.properties["name"].must_equal "User McNumber"
     entity_from_proto.properties["email"].must_equal "number@example.net"
+    entity_from_proto.properties.exist?("avatar").must_equal true
+    entity_from_proto.properties["avatar"].must_equal nil
   end
 
   it "can store other entities as properties" do

--- a/test/gcloud/datastore/proto/value_test.rb
+++ b/test/gcloud/datastore/proto/value_test.rb
@@ -47,6 +47,24 @@ describe "Proto Value methods" do
     raw.must_equal str
   end
 
+  it "encodes nil" do
+    value = Gcloud::Datastore::Proto.to_proto_value nil
+    value.boolean_value.must_be :nil?
+    value.timestamp_microseconds_value.must_be :nil?
+    value.key_value.must_be :nil?
+    value.entity_value.must_be :nil?
+    value.double_value.must_be :nil?
+    value.integer_value.must_be :nil?
+    value.string_value.must_be :nil?
+    value.list_value.must_be :nil?
+  end
+
+  it "decodes NULL" do
+    value = Gcloud::Datastore::Proto::Value.new
+    raw = Gcloud::Datastore::Proto.from_proto_value value
+    raw.must_equal nil
+  end
+
   it "encodes true" do
     value = Gcloud::Datastore::Proto.to_proto_value true
     value.boolean_value.must_equal true


### PR DESCRIPTION
A Datastore Value is considered NULL if there is no typed value set.
It is possible to have NULL values in Datastore, but it hasn't been possible
to set NULL values from gcloud. Futher, a NULL property value in Datastore
will raise an error when creating an Entity object in gcloud.
Correct this oversight and allow nil to represent NULL in Datastore.

[fixes #259]