### PR TITLE
Allow BigQuery Table/View Representation as a String

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -315,6 +315,22 @@ module Gcloud
         result
       end
 
+      ##
+      # Extracts at least +tbl+ group, and possibly +dts+ and +prj+ groups,
+      # from strings in the formats: "my_table", "my_dataset.my_table", or
+      # "my-project:my_dataset.my_table". Then merges project_id and
+      # dataset_id from the default table if they are missing.
+      def table_ref_from_s str, default_table_ref
+        str = str.to_s
+        m = /\A(((?<prj>\S*):)?(?<dts>\S*)\.)?(?<tbl>\S*)\z/.match str
+        unless m
+          fail ArgumentError, "unable to identify table from #{str.inspect}"
+        end
+        default_table_ref.merge("projectId" => m["prj"],
+                                "datasetId" => m["dts"],
+                                "tableId" => m["tbl"])
+      end
+
       def inspect #:nodoc:
         "#{self.class}(#{@project})"
       end

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -461,16 +461,8 @@ module Gcloud
         {
           "configuration" => {
             "copy" => {
-              "sourceTable" => {
-                "projectId" => source["tableReference"]["projectId"],
-                "datasetId" => source["tableReference"]["datasetId"],
-                "tableId" => source["tableReference"]["tableId"]
-              }.delete_if { |_, v| v.nil? },
-              "destinationTable" => {
-                "projectId" => target["tableReference"]["projectId"],
-                "datasetId" => target["tableReference"]["datasetId"],
-                "tableId" => target["tableReference"]["tableId"]
-              }.delete_if { |_, v| v.nil? },
+              "sourceTable" => source,
+              "destinationTable" => target,
               "createDisposition" => create_disposition(options[:create]),
               "writeDisposition" => write_disposition(options[:write])
             }.delete_if { |_, v| v.nil? },
@@ -485,11 +477,7 @@ module Gcloud
           "configuration" => {
             "link" => {
               "sourceUri" => Array(urls),
-              "destinationTable" => {
-                "projectId" => table["tableReference"]["projectId"],
-                "datasetId" => table["tableReference"]["datasetId"],
-                "tableId" => table["tableReference"]["tableId"]
-              }.delete_if { |_, v| v.nil? },
+              "destinationTable" => table,
               "createDisposition" => create_disposition(options[:create]),
               "writeDisposition" => write_disposition(options[:write]),
               "sourceFormat" => source_format(path, options[:format])
@@ -508,11 +496,7 @@ module Gcloud
           "configuration" => {
             "extract" => {
               "destinationUris" => Array(storage_urls),
-              "sourceTable" => {
-                "projectId" => table["tableReference"]["projectId"],
-                "datasetId" => table["tableReference"]["datasetId"],
-                "tableId" => table["tableReference"]["tableId"]
-              }.delete_if { |_, v| v.nil? },
+              "sourceTable" => table,
               "destinationFormat" => dest_format
             }.delete_if { |_, v| v.nil? },
             "dryRun" => options[:dryrun]
@@ -527,11 +511,7 @@ module Gcloud
           "configuration" => {
             "load" => {
               "sourceUris" => Array(urls),
-              "destinationTable" => {
-                "projectId" => table["tableReference"]["projectId"],
-                "datasetId" => table["tableReference"]["datasetId"],
-                "tableId" => table["tableReference"]["tableId"]
-              }.delete_if { |_, v| v.nil? },
+              "destinationTable" => table,
               "createDisposition" => create_disposition(options[:create]),
               "writeDisposition" => write_disposition(options[:write]),
               "sourceFormat" => source_format(path, options[:format]),

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -127,6 +127,12 @@ module Gcloud
       end
 
       ##
+      # The Project ID, Dataset ID, and Table ID as a camel-cased hash.
+      def table_ref #:nodoc:
+        @gapi["tableReference"]
+      end
+
+      ##
       # The combined Project ID, Dataset ID, and Table ID for this table, in the
       # format specified by the {Query
       # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
@@ -461,7 +467,9 @@ module Gcloud
       #
       def copy destination_table, options = {}
         ensure_connection!
-        resp = connection.copy_table gapi, destination_table.gapi, options
+        resp = connection.copy_table table_ref,
+                                     destination_table.table_ref,
+                                     options
         if resp.success?
           Job.from_gapi resp.data, connection
         else
@@ -503,7 +511,7 @@ module Gcloud
       #
       def link source_url, options = {} #:nodoc:
         ensure_connection!
-        resp = connection.link_table gapi, source_url, options
+        resp = connection.link_table table_ref, source_url, options
         if resp.success?
           Job.from_gapi resp.data, connection
         else
@@ -552,7 +560,7 @@ module Gcloud
       #
       def extract extract_url, options = {}
         ensure_connection!
-        resp = connection.extract_table gapi, extract_url, options
+        resp = connection.extract_table table_ref, extract_url, options
         if resp.success?
           Job.from_gapi resp.data, connection
         else
@@ -796,7 +804,7 @@ module Gcloud
         # Convert to storage URL
         file = file.to_gs_url if file.respond_to? :to_gs_url
 
-        resp = connection.load_table gapi, file, options
+        resp = connection.load_table table_ref, file, options
         if resp.success?
           Job.from_gapi resp.data, connection
         else
@@ -814,7 +822,7 @@ module Gcloud
 
       def load_resumable file, options = {}
         chunk_size = verify_chunk_size! options[:chunk_size]
-        resp = connection.load_resumable gapi, file, chunk_size, options
+        resp = connection.load_resumable table_ref, file, chunk_size, options
         if resp.success?
           Job.from_gapi resp.data, connection
         else
@@ -823,7 +831,7 @@ module Gcloud
       end
 
       def load_multipart file, options = {}
-        resp = connection.load_multipart gapi, file, options
+        resp = connection.load_multipart table_ref, file, options
         if resp.success?
           Job.from_gapi resp.data, connection
         else

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -297,7 +297,7 @@ class MockBigquery < Minitest::Spec
     }
   end
 
-  def random_table_hash dataset, id = nil, name = nil, description = nil
+  def random_table_hash dataset, id = nil, name = nil, description = nil, project_id = nil
     id ||= "my_table"
     name ||= "Table Name"
 
@@ -307,7 +307,7 @@ class MockBigquery < Minitest::Spec
       "id" => "#{project}:#{dataset}.#{id}",
       "selfLink" => "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{id}",
       "tableReference" => {
-        "projectId" => project,
+        "projectId" => (project_id || project),
         "datasetId" => dataset,
         "tableId" => id
       },


### PR DESCRIPTION
Obtaining an object reference to a BigQuery table in a project other than the one loaded via auth credentials is not easy, so allowing string references to tables makes it easier to perform operations on tables in other projects.

[closes #258]