### PR TITLE
Fix hash syntax in Table example

### DIFF
--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -70,12 +70,12 @@ module Gcloud
     #     "first_name" => "Alice",
     #     "cities_lived" => [
     #       {
-    #         "place": "Seattle",
-    #         "number_of_years": 5
+    #         "place" => "Seattle",
+    #         "number_of_years" => 5
     #       },
     #       {
-    #         "place": "Stockholm",
-    #         "number_of_years": 6
+    #         "place" => "Stockholm",
+    #         "number_of_years" => 6
     #       }
     #     ]
     #   }


### PR DESCRIPTION
The invalid, JSON-style syntax can prevent proper Ruby syntax highlighting in some generated documentation.