### PR TITLE
Fix missing Pathname require

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "pathname"
 require "gcloud/version"
 require "google/api_client"
 require "digest/md5"


### PR DESCRIPTION
The pathname library is part of the standard library, but needs to be required.
Other usages of pathname in gcloud have the require, but this one was missing.
Add the require to fix `undefined method 'Pathname'` errors.

[fixes #265]