### PR TITLE
Check Google Compute Engine for project_id

### DIFF
--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gcloud/gce"
 require "gcloud/bigquery/connection"
 require "gcloud/bigquery/credentials"
 require "gcloud/bigquery/errors"
@@ -77,7 +78,8 @@ module Gcloud
       def self.default_project #:nodoc:
         ENV["BIGQUERY_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
-          ENV["GOOGLE_CLOUD_PROJECT"]
+          ENV["GOOGLE_CLOUD_PROJECT"] ||
+          Gcloud::GCE.project_id
       end
 
       ##

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gcloud/gce"
 require "gcloud/datastore/connection"
 require "gcloud/datastore/credentials"
 require "gcloud/datastore/entity"
@@ -80,7 +81,8 @@ module Gcloud
         ENV["DATASTORE_DATASET"] ||
           ENV["DATASTORE_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
-          ENV["GOOGLE_CLOUD_PROJECT"]
+          ENV["GOOGLE_CLOUD_PROJECT"] ||
+          Gcloud::GCE.project_id
       end
 
       ##

--- a/lib/gcloud/gce.rb
+++ b/lib/gcloud/gce.rb
@@ -1,0 +1,62 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "faraday"
+
+#--
+# Google Cloud Compute Engine
+module Gcloud
+  ##
+  # Represents the Google Compute Engine environment.
+  module GCE #:nodoc:
+    CHECK_URI = "http://169.254.169.254"
+    PROJECT_URI = "#{CHECK_URI}/computeMetadata/v1/project/project-id"
+
+    # rubocop:disable all
+    # Disabled rubocop because this is private and we don't need more methods.
+
+    def self.gce? options = {}
+      conn = options[:connection] || Faraday.default_connection
+      resp = conn.get CHECK_URI do |req|
+        req.options.timeout = 0.1
+      end
+      return false unless resp.status == 200
+      return false unless resp.headers.key? "Metadata-Flavor"
+      return resp.headers["Metadata-Flavor"] == "Google"
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed
+      return false
+    end
+
+    def self.project_id options = {}
+      @gce ||= {}
+      return @gce[:project_id] if @gce.key? :project_id
+      conn = options[:connection] || Faraday.default_connection
+      conn.headers = { "Metadata-Flavor" => "Google" }
+      resp = conn.get PROJECT_URI do |req|
+        req.options.timeout = 0.1
+      end
+      if resp.status == 200
+        @gce[:project_id] = resp.body
+      else
+        @gce[:project_id] = nil
+      end
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed
+      @gce ||= {}
+      @gce[:project_id] = nil
+    end
+
+    # rubocop:enable all
+  end
+end

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gcloud/gce"
 require "gcloud/pubsub/connection"
 require "gcloud/pubsub/credentials"
 require "gcloud/pubsub/errors"
@@ -73,7 +74,8 @@ module Gcloud
       def self.default_project #:nodoc:
         ENV["PUBSUB_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
-          ENV["GOOGLE_CLOUD_PROJECT"]
+          ENV["GOOGLE_CLOUD_PROJECT"] ||
+          Gcloud::GCE.project_id
       end
 
       ##

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gcloud/gce"
 require "gcloud/storage/errors"
 require "gcloud/storage/connection"
 require "gcloud/storage/credentials"
@@ -79,7 +80,8 @@ module Gcloud
       def self.default_project #:nodoc:
         ENV["STORAGE_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
-          ENV["GOOGLE_CLOUD_PROJECT"]
+          ENV["GOOGLE_CLOUD_PROJECT"] ||
+          Gcloud::GCE.project_id
       end
 
       ##


### PR DESCRIPTION
The googleauth library detects when running on Google Compute Engine and
retrieves the authentication from the GCE environment.
Likewise, we should look to GCE to find the project_id.

[closes #211]