### PR TITLE
Change Table#schema option default

### DIFF
--- a/acceptance/bigquery/bigquery_test.rb
+++ b/acceptance/bigquery/bigquery_test.rb
@@ -38,7 +38,12 @@ describe Gcloud::Pubsub, :bigquery do
   let(:table) do
     t = dataset.table table_id
     if t.nil?
-      t = dataset.create_table table_id, schema: schema
+      t = dataset.create_table table_id do |schema|
+        schema.integer "id"
+        schema.string "breed"
+        schema.string "name"
+        schema.timestamp "dob"
+      end
     end
     t
   end
@@ -91,14 +96,7 @@ describe Gcloud::Pubsub, :bigquery do
     let(:local_file) { "acceptance/data/kitten-test-data.json" }
 
     it "has the correct schema" do
-      table.schema.must_equal({
-        "fields" => [
-          { "name" => "id",    "type" => "INTEGER" },
-          { "name" => "breed", "type" => "STRING" },
-          { "name" => "name",  "type" => "STRING" },
-          { "name" => "dob",   "type" => "TIMESTAMP" }
-        ]
-      })
+      table.schema.must_equal schema
     end
 
     it "gets and sets metadata" do

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -294,8 +294,8 @@ module Gcloud
       # Returns the table's schema as hash containing the keys and values
       # returned by the Google Cloud BigQuery {Rest API
       # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource].
-      # This method can also be used to replace or update the schema by passing
-      # a block. See Table::Schema for available methods. To replace the current
+      # This method can also be used to set, replace, or add to the schema by
+      # passing a block. See Table::Schema for available methods. To set the
       # schema by passing a hash instead, use #schema=.
       #
       # === Parameters
@@ -304,8 +304,10 @@ module Gcloud
       #   An optional Hash for controlling additional behavior. (+Hash+)
       # <code>options[:replace]</code>::
       #   Whether to replace the existing schema with the new schema. If
-      #   +false+, new fields will be added to the existing schema.  The default
-      #   value is +true+. (+Boolean+)
+      #   +true+, the fields will replace the existing schema. If
+      #   +false+, the fields will be added to the existing schema. When a table
+      #   already contains data, schema changes must be additive. Thus, the
+      #   default value is +false+. (+Boolean+)
       #
       # === Examples
       #
@@ -332,8 +334,8 @@ module Gcloud
         g = g.to_hash if g.respond_to? :to_hash
         s = g["schema"] ||= {}
         return s unless block_given?
-        old_schema = options[:replace] == false ? s : nil
-        schema_builder = Schema.new old_schema
+        s = nil if options[:replace]
+        schema_builder = Schema.new s
         yield schema_builder
         self.schema = schema_builder.schema if schema_builder.changed?
       end

--- a/test/gcloud/bigquery/table_schema_test.rb
+++ b/test/gcloud/bigquery/table_schema_test.rb
@@ -55,7 +55,7 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
     table.schema["fields"].first["name"].must_equal "moniker"
   end
 
-  it "sets a flat schema via a block" do
+  it "sets a flat schema via a block with replace option true" do
     new_table_data = new_table_hash
     new_table_data["schema"]["fields"] = [
       field_string_required,
@@ -70,7 +70,7 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
       [200, { "Content-Type" => "application/json" }, new_table_data.to_json]
     end
 
-    table.schema do |schema|
+    table.schema replace: true do |schema|
       schema.string "first_name", mode: :required
       schema.integer "rank", description: "An integer value from 1 to 100"
       schema.float "accuracy"
@@ -81,7 +81,7 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
     table.schema.must_equal new_table_data["schema"]
   end
 
-  it "adds to its existing schema with replace option false" do
+  it "adds to its existing schema with replace option default" do
     new_table_data = new_table_hash
     new_table_data["schema"]["fields"] << field_timestamp
     mock_connection.patch "/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" do |env|
@@ -90,7 +90,7 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
       [200, { "Content-Type" => "application/json" }, new_table_data.to_json]
     end
 
-    table.schema replace: false do |schema|
+    table.schema do |schema|
       schema.timestamp "start_date"
     end
 
@@ -109,7 +109,7 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
       [200, { "Content-Type" => "application/json" }, new_table_data.to_json]
     end
 
-    table.schema do |schema|
+    table.schema replace: true do |schema|
       schema.string "first_name", mode: :required
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"


### PR DESCRIPTION
It is more likely to add to a schema than to replace it, so default for the replace option should be false. Also, change acceptance test to use new schema builder.