### PR TITLE
Add DNS Change

### DIFF
--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gcloud/dns/change/list"
 require "time"
 
 module Gcloud

--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -117,6 +117,32 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
+      # Refreshes the change until the status is +done+.
+      # The delay between refreshes will incrementally increase.
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   change = zone.change 1234567890
+      #   change.done? #=> false
+      #   change.wait_until_done!
+      #   change.done? #=> true
+      #
+      def wait_until_done!
+        backoff = ->(retries) { sleep 2 * retries + 5 }
+        retries = 0
+        until done?
+          backoff.call retries
+          retries += 1
+          reload!
+        end
+      end
+
+      ##
       # New Change from a Google API Client object.
       def self.from_gapi gapi, zone #:nodoc:
         new.tap do |f|

--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -1,0 +1,123 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "time"
+
+module Gcloud
+  module Dns
+    ##
+    # = DNS Change
+    #
+    # Represents a request containing additions or deletions or records.
+    # Additions and deletions can be done in bulk, in a single atomic
+    # transaction, and take effect at the same time in each authoritative DNS
+    # server.
+    #
+    #   require "gcloud"
+    #
+    #   gcloud = Gcloud.new
+    #   dns = gcloud.dns
+    #   zone = dns.zone "example-zone"
+    #   zone.changes.each do |change|
+    #     puts "Change includes #{change.additions.count} additions " \
+    #          "and #{change.additions.count} deletions."
+    #   end
+    #
+    class Change
+      ##
+      # The Connection object.
+      attr_accessor :connection #:nodoc:
+
+      ##
+      # The Google API Client object.
+      attr_accessor :gapi #:nodoc:
+
+      ##
+      # Create an empty Change object.
+      def initialize #:nodoc:
+        @connection = nil
+        @gapi = {}
+      end
+
+      ##
+      # Unique identifier for the resource; defined by the server.
+      #
+      def id
+        @gapi["id"]
+      end
+
+      ##
+      # The records added in this change request.
+      #
+      def additions
+        Array @gapi["additions"]
+      end
+
+      ##
+      # The records removed in this change request.
+      #
+      def deletions
+        Array @gapi["deletions"]
+      end
+
+      ##
+      # Status of the operation. Values are +"done"+ and +"pending"+.
+      #
+      def status
+        @gapi["status"]
+      end
+
+      ##
+      # Checks if the status is +"done"+.
+      def done?
+        return false if status.nil?
+        "done".casecmp(status).zero?
+      end
+
+      ##
+      # Checks if the status is +"pending"+.
+      def pending?
+        return false if status.nil?
+        "pending".casecmp(status).zero?
+      end
+
+      ##
+      # The time that this operation was started by the server.
+      #
+      def started_at
+        Time.parse @gapi["startTime"]
+      rescue
+        nil
+      end
+
+      ##
+      # New Change from a Google API Client object.
+      def self.from_gapi gapi, conn #:nodoc:
+        new.tap do |f|
+          f.gapi = gapi
+          f.connection = conn
+        end
+      end
+
+      protected
+
+      ##
+      # Raise an error unless an active connection is available.
+      def ensure_connection!
+        fail "Must have active connection" unless connection
+      end
+    end
+  end
+end

--- a/lib/gcloud/dns/change/list.rb
+++ b/lib/gcloud/dns/change/list.rb
@@ -1,0 +1,70 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gcloud
+  module Dns
+    class Change
+      ##
+      # Change::List is a special case Array with additional values.
+      class List < DelegateClass(::Array)
+        ##
+        # If not empty, indicates that there are more records that match
+        # the request and this value should be passed to continue.
+        attr_accessor :token
+
+        ##
+        # Create a new Table::List with an array of jobs.
+        def initialize arr = []
+          super arr
+        end
+
+        ##
+        # Whether there a next page of zones.
+        def next?
+          !token.nil?
+        end
+
+        ##
+        # Retrieve the next page of zones.
+        def next
+          return nil unless next?
+          ensure_zone!
+          @zone.changes token: token
+        end
+
+        ##
+        # New Changes::List from a response object.
+        def self.from_response resp, zone #:nodoc:
+          changes = new(Array(resp.data["changes"]).map do |gapi_object|
+            Change.from_gapi gapi_object, zone.connection
+          end)
+          changes.instance_eval do
+            @token = resp.data["nextPageToken"]
+            @zone = zone
+          end
+          changes
+        end
+
+        protected
+
+        ##
+        # Raise an error unless an active connection is available.
+        def ensure_zone!
+          fail "Must have active connection" unless @zone
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/dns/change/list.rb
+++ b/lib/gcloud/dns/change/list.rb
@@ -48,7 +48,7 @@ module Gcloud
         # New Changes::List from a response object.
         def self.from_response resp, zone #:nodoc:
           changes = new(Array(resp.data["changes"]).map do |gapi_object|
-            Change.from_gapi gapi_object, zone.connection
+            Change.from_gapi gapi_object, zone
           end)
           changes.instance_eval do
             @token = resp.data["nextPageToken"]

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -96,7 +96,9 @@ module Gcloud
       def list_changes zone_id, options = {}
         params = { project: @project, managedZone: zone_id,
                    pageToken: options.delete(:token),
-                   maxResults: options.delete(:max)
+                   maxResults: options.delete(:max),
+                   sortBy: options.delete(:sort),
+                   sortOrder: options.delete(:order)
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -93,6 +93,18 @@ module Gcloud
         )
       end
 
+      def list_changes zone_id, options = {}
+        params = { project: @project, managedZone: zone_id,
+                   pageToken: options.delete(:token),
+                   maxResults: options.delete(:max)
+                 }.delete_if { |_, v| v.nil? }
+
+        @client.execute(
+          api_method: @dns.changes.list,
+          parameters: params
+        )
+      end
+
       def inspect #:nodoc:
         "#{self.class}(#{@project})"
       end

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -85,6 +85,14 @@ module Gcloud
         )
       end
 
+      def get_change zone_id, change_id
+        @client.execute(
+          api_method: @dns.changes.get,
+          parameters: { project: @project, managedZone: zone_id,
+                        changeId: change_id }
+        )
+      end
+
       def inspect #:nodoc:
         "#{self.class}(#{@project})"
       end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gcloud/dns/change"
 require "gcloud/dns/zone/list"
 require "time"
 
@@ -132,6 +133,41 @@ module Gcloud
           true
         else
           fail ApiError.from_response(resp)
+        end
+      end
+
+      ##
+      # Retrieves an existing change by id.
+      #
+      # === Parameters
+      #
+      # +change_id+::
+      #   The id of a change. (+String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Bigquery::Change or +nil+ if the change does not exist
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example.com."
+      #   change = zone.change "dns-change-1234567890"
+      #   if change
+      #     puts "Change includes #{change.additions.count} additions " \
+      #          "and #{change.additions.count} deletions."
+      #   end
+      #
+      def change change_id
+        ensure_connection!
+        resp = connection.get_change id, change_id
+        if resp.success?
+          Change.from_gapi resp.data, connection
+        else
+          nil
         end
       end
 

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -172,6 +172,62 @@ module Gcloud
       end
 
       ##
+      # Retrieves the list of changes belonging to the zone.
+      #
+      # === Parameters
+      #
+      # +options+::
+      #   An optional Hash for controlling additional behavior. (+Hash+)
+      # <code>options[:token]</code>::
+      #   A previously-returned page token representing part of the larger set
+      #   of results to view. (+String+)
+      # <code>options[:max]</code>::
+      #   Maximum number of changes to return. (+Integer+)
+      #
+      # === Returns
+      #
+      # Array of Gcloud::Bigquery::Change (Gcloud::Bigquery::Change::List)
+      #
+      # === Examples
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   changes = zone.changes
+      #   changes.each do |change|
+      #     puts change.name
+      #   end
+      #
+      # If you have a significant number of changes, you may need to paginate
+      # through them: (See Gcloud::Bigquery::Change::List)
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   changes = zone.changes
+      #   loop do
+      #     changes.each do |change|
+      #       puts change.name
+      #     end
+      #     break unless changes.next?
+      #     changes = changes.next
+      #   end
+      #
+      def changes options = {}
+        ensure_connection!
+        resp = connection.list_changes id, options
+        if resp.success?
+          Change::List.from_response resp, self
+        else
+          fail ApiError.from_response(resp)
+        end
+      end
+
+      ##
       # New Zone from a Google API Client object.
       def self.from_gapi gapi, conn #:nodoc:
         new.tap do |f|

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -165,7 +165,7 @@ module Gcloud
         ensure_connection!
         resp = connection.get_change id, change_id
         if resp.success?
-          Change.from_gapi resp.data, connection
+          Change.from_gapi resp.data, self
         else
           nil
         end

--- a/test/gcloud/dns/change_test.rb
+++ b/test/gcloud/dns/change_test.rb
@@ -81,6 +81,39 @@ describe Gcloud::Dns::Change, :mock_dns do
     change.must_be :done?
   end
 
+  it "can wait until done" do
+    pending_change = Gcloud::Dns::Change.from_gapi pending_change_hash, zone
+
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       pending_change_json(pending_change.id)]
+    end
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       pending_change_json(pending_change.id)]
+    end
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       pending_change_json(pending_change.id)]
+    end
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       pending_change_json(pending_change.id)]
+    end
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       done_change_json(pending_change.id)]
+    end
+
+    # mock out the sleep method so the test doesn't actually block
+    def pending_change.sleep *args
+    end
+
+    pending_change.must_be :pending?
+    pending_change.wait_until_done!
+    pending_change.must_be :done?
+  end
+
   def done_change_hash change_id = nil
     hash = random_change_hash
     hash["id"] = change_id if change_id

--- a/test/gcloud/dns/change_test.rb
+++ b/test/gcloud/dns/change_test.rb
@@ -15,7 +15,11 @@
 require "helper"
 
 describe Gcloud::Dns::Change, :mock_dns do
-  let(:change) { Gcloud::Dns::Change.from_gapi random_change_hash, dns.connection }
+  let(:zone_name) { "example-zone" }
+  let(:zone_dns) { "example.com." }
+  let(:zone_hash) { random_zone_hash zone_name, zone_dns }
+  let(:zone) { Gcloud::Dns::Zone.from_gapi zone_hash, dns.connection }
+  let(:change) { Gcloud::Dns::Change.from_gapi done_change_hash, zone }
 
   it "knows its attributes" do
     change.id.must_equal "dns-change-1234567890"
@@ -30,9 +34,7 @@ describe Gcloud::Dns::Change, :mock_dns do
   end
 
   it "can represent a pending change" do
-    pending_change_hash = random_change_hash
-    pending_change_hash["status"] = "pending"
-    pending_change = Gcloud::Dns::Change.from_gapi pending_change_hash, dns.connection
+    pending_change = Gcloud::Dns::Change.from_gapi pending_change_hash, zone
 
     pending_change.id.must_equal "dns-change-1234567890"
     pending_change.additions.must_be :empty?
@@ -43,5 +45,59 @@ describe Gcloud::Dns::Change, :mock_dns do
 
     start_time = Time.new 2015, 1, 1, 0, 0, 0, 0
     pending_change.started_at.must_equal start_time
+  end
+
+  it "can reload itself" do
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       pending_change_json(change.id)]
+    end
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       done_change_json(change.id)]
+    end
+
+    change.must_be :done?
+    change.reload!
+    change.must_be :pending?
+    change.reload!
+    change.must_be :done?
+  end
+
+  it "can reload itself with refresh alias" do
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       pending_change_json(change.id)]
+    end
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes/#{change.id}" do |env|
+      [200, {"Content-Type" => "application/json"},
+       done_change_json(change.id)]
+    end
+
+    change.must_be :done?
+    change.refresh!
+    change.must_be :pending?
+    change.refresh!
+    change.must_be :done?
+  end
+
+  def done_change_hash change_id = nil
+    hash = random_change_hash
+    hash["id"] = change_id if change_id
+    hash
+  end
+
+  def pending_change_hash change_id = nil
+    hash = done_change_hash change_id
+    hash["status"] = "pending"
+    hash
+  end
+
+  def done_change_json change_id = nil
+    done_change_hash(change_id).to_json
+  end
+
+  def pending_change_json change_id = nil
+    pending_change_hash(change_id).to_json
   end
 end

--- a/test/gcloud/dns/change_test.rb
+++ b/test/gcloud/dns/change_test.rb
@@ -1,0 +1,48 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "gcloud/dns/change"
+
+describe Gcloud::Dns::Change, :mock_dns do
+  let(:change) { Gcloud::Dns::Change.from_gapi random_change_hash, dns.connection }
+
+  it "knows its attributes" do
+    change.id.must_equal "dns-change-1234567890"
+    change.additions.must_be :empty?
+    change.deletions.must_be :empty?
+    change.status.must_equal "done"
+    change.must_be :done?
+    change.wont_be :pending?
+
+    start_time = Time.new 2015, 1, 1, 0, 0, 0, 0
+    change.started_at.must_equal start_time
+  end
+
+  it "can represent a pending change" do
+    pending_change_hash = random_change_hash
+    pending_change_hash["status"] = "pending"
+    pending_change = Gcloud::Dns::Change.from_gapi pending_change_hash, dns.connection
+
+    pending_change.id.must_equal "dns-change-1234567890"
+    pending_change.additions.must_be :empty?
+    pending_change.deletions.must_be :empty?
+    pending_change.status.must_equal "pending"
+    pending_change.wont_be :done?
+    pending_change.must_be :pending?
+
+    start_time = Time.new 2015, 1, 1, 0, 0, 0, 0
+    pending_change.started_at.must_equal start_time
+  end
+end

--- a/test/gcloud/dns/change_test.rb
+++ b/test/gcloud/dns/change_test.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require "helper"
-require "gcloud/dns/change"
 
 describe Gcloud::Dns::Change, :mock_dns do
   let(:change) { Gcloud::Dns::Change.from_gapi random_change_hash, dns.connection }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -614,6 +614,17 @@ class MockDns < Minitest::Spec
     }
   end
 
+  def random_change_hash
+    {
+      "kind" => "dns#change",
+      "id" => "dns-change-1234567890",
+      "additions" => [],
+      "deletions" => [],
+      "startTime" => "2015-01-01T00:00:00-00:00",
+      "status" => "done"
+    }
+  end
+
   # Register this spec type for when :storage is used.
   register_spec_type(self) do |desc, *addl|
     addl.include? :mock_dns


### PR DESCRIPTION
Add Change object, representing a change request. This PR doesn't cover creating DNS changes, only representing the Change resource in the Google Cloud DNS API.

A change object can be retrieved from a zone by providing the id value:

```ruby
require "gcloud"

gcloud = Gcloud.new
dns = gcloud.dns
zone = dns.zone "example-zone"
change = zone.change 1234567890
```

The change object knows what its status is:

```ruby
change.status #=> "pending"
change.done? #=> false
change.pending? #=> true
```

The change object can be refreshed to update the status

```ruby
change.done? #=> false
change.refresh!
change.done? #=> true
```

Or the change object can continually refresh until it is done:

```ruby
change.done? #=> false
change.wait_until_done!
change.done? #=> true
```

[refs #288, refs #289, refs #290, refs #296, refs #297]