### PR TITLE
Add and Remove Records

### DIFF
--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -63,14 +63,14 @@ module Gcloud
       # The records added in this change request.
       #
       def additions
-        Array @gapi["additions"]
+        Array(@gapi["additions"]).map { |gapi| Record.from_gapi gapi }
       end
 
       ##
       # The records removed in this change request.
       #
       def deletions
-        Array @gapi["deletions"]
+        Array(@gapi["deletions"]).map { |gapi| Record.from_gapi gapi }
       end
 
       ##

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -108,9 +108,9 @@ module Gcloud
       end
 
       def create_change zone_id, additions, deletions
-        change = { "kind" => "dns#change",
-          "additions" => Array(additions),
-          "deletions" => Array(deletions) }
+        change = { "kind"      => "dns#change",
+                   "additions" => Array(additions),
+                   "deletions" => Array(deletions) }
 
         @client.execute(
           api_method: @dns.changes.create,

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -107,6 +107,18 @@ module Gcloud
         )
       end
 
+      def create_change zone_id, additions, deletions
+        change = { "kind" => "dns#change",
+          "additions" => Array(additions),
+          "deletions" => Array(deletions) }
+
+        @client.execute(
+          api_method: @dns.changes.create,
+          parameters: { project: @project, managedZone: zone_id },
+          body_object: change
+        )
+      end
+
       def list_records zone_id, options = {}
         params = { project: @project, managedZone: zone_id,
                    pageToken: options.delete(:token),

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -87,7 +87,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Gcloud::Bigquery::Zone or +nil+ if the zone does not exist
+      # Gcloud::Dns::Zone or +nil+ if the zone does not exist
       #
       # === Example
       #
@@ -123,7 +123,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Array of Gcloud::Bigquery::Zone (Gcloud::Bigquery::Zone::List)
+      # Array of Gcloud::Dns::Zone (Gcloud::Dns::Zone::List)
       #
       # === Examples
       #
@@ -137,7 +137,7 @@ module Gcloud
       #   end
       #
       # If you have a significant number of zones, you may need to paginate
-      # through them: (See Gcloud::Bigquery::Zone::List)
+      # through them: (See Gcloud::Dns::Zone::List)
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -91,6 +91,10 @@ module Gcloud
       def self.from_gapi gapi #:nodoc:
         new gapi["name"], gapi["ttl"], gapi["type"], gapi["rrdatas"]
       end
+
+      def to_gapi
+        { "name" => name, "ttl" => ttl, "type" => type, "rrdatas" => data }
+      end
     end
   end
 end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -344,8 +344,8 @@ module Gcloud
       end
 
       def update records_to_add = [], records_to_remove = []
-        records_to_add = Array(records_to_add).map! &:to_gapi
-        records_to_remove = Array(records_to_remove).map! &:to_gapi
+        records_to_add = Array(records_to_add).map(&:to_gapi)
+        records_to_remove = Array(records_to_remove).map(&:to_gapi)
 
         ensure_connection!
         resp = connection.create_change id, records_to_add, records_to_remove
@@ -354,6 +354,14 @@ module Gcloud
         else
           fail ApiError.from_response(resp)
         end
+      end
+
+      def add *records
+        update Array(records).flatten, []
+      end
+
+      def remove *records
+        update [], Array(records).flatten
       end
 
       ##

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -343,6 +343,19 @@ module Gcloud
         Gcloud::Dns::Record.new name, ttl, type, data
       end
 
+      def update records_to_add = [], records_to_remove = []
+        records_to_add = Array(records_to_add).map! &:to_gapi
+        records_to_remove = Array(records_to_remove).map! &:to_gapi
+
+        ensure_connection!
+        resp = connection.create_change id, records_to_add, records_to_remove
+        if resp.success?
+          Change.from_gapi resp.data, self
+        else
+          fail ApiError.from_response(resp)
+        end
+      end
+
       ##
       # New Zone from a Google API Client object.
       def self.from_gapi gapi, conn #:nodoc:

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -147,7 +147,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Gcloud::Bigquery::Change or +nil+ if the change does not exist
+      # Gcloud::Dns::Change or +nil+ if the change does not exist
       #
       # === Example
       #
@@ -193,7 +193,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Array of Gcloud::Bigquery::Change (Gcloud::Bigquery::Change::List)
+      # Array of Gcloud::Dns::Change (Gcloud::Dns::Change::List)
       #
       # === Examples
       #
@@ -217,7 +217,7 @@ module Gcloud
       #   changes = zone.changes order: :desc
       #
       # If you have a significant number of changes, you may need to paginate
-      # through them: (See Gcloud::Bigquery::Change::List)
+      # through them: (See Gcloud::Dns::Change::List)
       #
       #   require "gcloud"
       #
@@ -247,8 +247,6 @@ module Gcloud
         end
       end
 
-      # rubocop:disable
-
       ##
       # Retrieves the list of records belonging to the zone.
       #
@@ -270,7 +268,7 @@ module Gcloud
       #
       # === Returns
       #
-      # Array of Gcloud::Bigquery::Record (Gcloud::Bigquery::Record::List)
+      # Array of Gcloud::Dns::Record (Gcloud::Dns::Record::List)
       #
       # === Examples
       #
@@ -294,7 +292,7 @@ module Gcloud
       #   records = zone.records name: "example.com.", type: "A"
       #
       # If you have a significant number of records, you may need to paginate
-      # through them: (See Gcloud::Bigquery::Record::List)
+      # through them: (See Gcloud::Dns::Record::List)
       #
       #   require "gcloud"
       #
@@ -320,14 +318,12 @@ module Gcloud
         end
       end
 
-      # rubocop:enable
-
       ##
       # Creates a new, unsaved Record that can be added to a Zone.
       #
       # === Returns
       #
-      # A new Record instance.
+      # Gcloud::Dns::Record
       #
       # === Example
       #
@@ -337,12 +333,31 @@ module Gcloud
       #   dns = gcloud.dns
       #   zone = dns.zone "example-zone"
       #   record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
-      #   zone.add_records [record_1]
+      #   zone.add record
       #
       def record name, ttl, type, data
         Gcloud::Dns::Record.new name, ttl, type, data
       end
 
+      ##
+      # Adds and removes Records from the Zone. All changes are made in a single
+      # API request.
+      #
+      # === Returns
+      #
+      # Gcloud::Dns::Change
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   new_record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   old_record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   zone.update [new_record], [old_record]
+      #
       def update records_to_add = [], records_to_remove = []
         records_to_add = Array(records_to_add).map(&:to_gapi)
         records_to_remove = Array(records_to_remove).map(&:to_gapi)
@@ -356,10 +371,46 @@ module Gcloud
         end
       end
 
+      ##
+      # Adds records to the Zone. In order to update existing records, or add
+      # and delete records in the same transaction, use #update.
+      #
+      # === Returns
+      #
+      # Gcloud::Dns::Change
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   zone.add record
+      #
       def add *records
         update Array(records).flatten, []
       end
 
+      ##
+      # Removes records from the Zone. In order to update existing records, or
+      # add and remove records in the same transaction, use #update.
+      #
+      # === Returns
+      #
+      # Gcloud::Dns::Change
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   zone.remove record
+      #
       def remove *records
         update [], Array(records).flatten
       end

--- a/test/gcloud/dns/change_test.rb
+++ b/test/gcloud/dns/change_test.rb
@@ -23,8 +23,10 @@ describe Gcloud::Dns::Change, :mock_dns do
 
   it "knows its attributes" do
     change.id.must_equal "dns-change-1234567890"
-    change.additions.must_be :empty?
-    change.deletions.must_be :empty?
+    change.additions.count.must_equal 1
+    change.additions.first.must_be_kind_of Gcloud::Dns::Record
+    change.deletions.count.must_equal 1
+    change.deletions.first.must_be_kind_of Gcloud::Dns::Record
     change.status.must_equal "done"
     change.must_be :done?
     change.wont_be :pending?
@@ -37,8 +39,10 @@ describe Gcloud::Dns::Change, :mock_dns do
     pending_change = Gcloud::Dns::Change.from_gapi pending_change_hash, zone
 
     pending_change.id.must_equal "dns-change-1234567890"
-    pending_change.additions.must_be :empty?
-    pending_change.deletions.must_be :empty?
+    pending_change.additions.count.must_equal 1
+    pending_change.additions.first.must_be_kind_of Gcloud::Dns::Record
+    pending_change.deletions.count.must_equal 1
+    pending_change.deletions.first.must_be_kind_of Gcloud::Dns::Record
     pending_change.status.must_equal "pending"
     pending_change.wont_be :done?
     pending_change.must_be :pending?
@@ -117,6 +121,8 @@ describe Gcloud::Dns::Change, :mock_dns do
   def done_change_hash change_id = nil
     hash = random_change_hash
     hash["id"] = change_id if change_id
+    hash["additions"] = [{ "name" => "example.net.", "ttl" => 18600, "type" => "A", "rrdatas" => ["example.com."] }]
+    hash["deletions"] = [{ "name" => "example.net.", "ttl" => 18600, "type" => "A", "rrdatas" => ["example.org."] }]
     hash
   end
 

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -347,6 +347,52 @@ describe Gcloud::Dns::Zone, :mock_dns do
     change.deletions.first.data.must_equal to_remove.data
   end
 
+  it "adds records" do
+    to_add = zone.record "example.net.", 18600, "A", "example.com."
+
+    mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
+      json = JSON.parse env.body
+      json["additions"].count.must_equal 1
+      json["deletions"].count.must_equal 0
+      json["additions"].first.must_equal to_add.to_gapi
+      json["deletions"].must_be :empty?
+      [200, {"Content-Type" => "application/json"},
+       create_change_json(to_add, [])]
+    end
+
+    change = zone.add to_add
+    change.must_be_kind_of Gcloud::Dns::Change
+    change.id.must_equal "dns-change-created"
+    change.additions.first.name.must_equal to_add.name
+    change.additions.first.ttl.must_equal  to_add.ttl
+    change.additions.first.type.must_equal to_add.type
+    change.additions.first.data.must_equal to_add.data
+    change.deletions.must_be :empty?
+  end
+
+  it "removes records" do
+    to_remove = zone.record "example.net.", 18600, "A", "example.org."
+
+    mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
+      json = JSON.parse env.body
+      json["additions"].count.must_equal 0
+      json["deletions"].count.must_equal 1
+      json["additions"].must_be :empty?
+      json["deletions"].first.must_equal to_remove.to_gapi
+      [200, {"Content-Type" => "application/json"},
+       create_change_json([], to_remove)]
+    end
+
+    change = zone.remove to_remove
+    change.must_be_kind_of Gcloud::Dns::Change
+    change.id.must_equal "dns-change-created"
+    change.additions.must_be :empty?
+    change.deletions.first.name.must_equal to_remove.name
+    change.deletions.first.ttl.must_equal  to_remove.ttl
+    change.deletions.first.type.must_equal to_remove.type
+    change.deletions.first.data.must_equal to_remove.data
+  end
+
   def create_change_json to_add, to_remove
     hash = random_change_hash
     hash["id"] = "dns-change-created"

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -320,6 +320,41 @@ describe Gcloud::Dns::Zone, :mock_dns do
     record.data.must_equal record_data
   end
 
+  it "adds and removes records with update" do
+    to_add = zone.record "example.net.", 18600, "A", "example.com."
+    to_remove = zone.record "example.net.", 18600, "A", "example.org."
+
+    mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
+      json = JSON.parse env.body
+      json["additions"].count.must_equal 1
+      json["deletions"].count.must_equal 1
+      json["additions"].first.must_equal to_add.to_gapi
+      json["deletions"].first.must_equal to_remove.to_gapi
+      [200, {"Content-Type" => "application/json"},
+       create_change_json(to_add, to_remove)]
+    end
+
+    change = zone.update to_add, to_remove
+    change.must_be_kind_of Gcloud::Dns::Change
+    change.id.must_equal "dns-change-created"
+    change.additions.first.name.must_equal to_add.name
+    change.additions.first.ttl.must_equal  to_add.ttl
+    change.additions.first.type.must_equal to_add.type
+    change.additions.first.data.must_equal to_add.data
+    change.deletions.first.name.must_equal to_remove.name
+    change.deletions.first.ttl.must_equal  to_remove.ttl
+    change.deletions.first.type.must_equal to_remove.type
+    change.deletions.first.data.must_equal to_remove.data
+  end
+
+  def create_change_json to_add, to_remove
+    hash = random_change_hash
+    hash["id"] = "dns-change-created"
+    hash["additions"] = Array(to_add).map &:to_gapi
+    hash["deletions"] = Array(to_remove).map &:to_gapi
+    hash.to_json
+  end
+
   def list_changes_json count = 2, token = nil
     changes = count.times.map do
       ch = random_change_hash


### PR DESCRIPTION
Adds `Zone#update`, `Zone#add`, and `Zone#remove`.

```ruby
require "gcloud"

gcloud = Gcloud.new
dns = gcloud.dns
zone = dns.zone "example-zone"
new_record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
old_record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
zone.update [new_record], [old_record]
```

[refs #293, refs #294, refs #295]