### PR TITLE
Add Zone#replace

### DIFF
--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -32,7 +32,7 @@ module Gcloud
     #   record_1 = zone.record "example.com.", "A", 86400, "1.2.3.4"
     #   mx_data = ["10 mail.example.com.","20 mail2.example.com."]
     #   record_2 = zone.record "example.com.", "A", 86400, mx_data
-    #   zone.add_records [record_1, record_2]
+    #   zone.change [record_1, record_2], []
     #
     class Record
       ##

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -29,9 +29,9 @@ module Gcloud
     #   dns = gcloud.dns
     #   zone = dns.zone "example-zone"
     #
-    #   record_1 = zone.record "example.com.", 86400, "A", "1.2.3.4"
+    #   record_1 = zone.record "example.com.", "A", 86400, "1.2.3.4"
     #   mx_data = ["10 mail.example.com.","20 mail2.example.com."]
-    #   record_2 = zone.record "example.com.", 86400, "A", mx_data
+    #   record_2 = zone.record "example.com.", "A", 86400, mx_data
     #   zone.add_records [record_1, record_2]
     #
     class Record
@@ -63,19 +63,19 @@ module Gcloud
       #
       # +name+::
       #   The owner of the record. For example: +example.com.+. (+String+)
-      # +ttl+::
-      #   The number of seconds that the record can be cached by resolvers.
-      #   (+Integer+)
       # +type+::
       #   The identifier of a {supported record
       #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
       #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+      # +ttl+::
+      #   The number of seconds that the record can be cached by resolvers.
+      #   (+Integer+)
       # +data+::
       #   The resource record data, as determined by +type+ and defined in RFC
       #   1035 (section 5) and RFC 1034 (section 3.6.1). For example:
       #   +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of +String+)
       #
-      def initialize name, ttl, type, data
+      def initialize name, type, ttl, data
         fail ArgumentError, "name is required" unless name
         fail ArgumentError, "ttl is required" unless ttl
         fail ArgumentError, "type is required" unless type
@@ -89,11 +89,11 @@ module Gcloud
       ##
       # New Record from a Google API Client object.
       def self.from_gapi gapi #:nodoc:
-        new gapi["name"], gapi["ttl"], gapi["type"], gapi["rrdatas"]
+        new gapi["name"], gapi["type"], gapi["ttl"], gapi["rrdatas"]
       end
 
       def to_gapi
-        { "name" => name, "ttl" => ttl, "type" => type, "rrdatas" => data }
+        { "name" => name, "type" => type, "ttl" => ttl, "rrdatas" => data }
       end
     end
   end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -375,6 +375,22 @@ module Gcloud
       # Adds records to the Zone. In order to update existing records, or add
       # and delete records in the same transaction, use #update.
       #
+      # === Parameters
+      #
+      # +name+::
+      #   The owner of the record. For example: +example.com.+. (+String+)
+      # +type+::
+      #   The identifier of a {supported record
+      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+      # +ttl+::
+      #   The number of seconds that the record can be cached by resolvers.
+      #   (+Integer+)
+      # +data+::
+      #   The resource record data, as determined by +type+ and defined in RFC
+      #   1035 (section 5) and RFC 1034 (section 3.6.1). For example:
+      #   +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of +String+)
+      #
       # === Returns
       #
       # Gcloud::Dns::Change
@@ -386,11 +402,10 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dns = gcloud.dns
       #   zone = dns.zone "example-zone"
-      #   record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
-      #   zone.add record
+      #   change = zone.add "example.com.", "A", 86400, ["1.2.3.4"]
       #
-      def add *records
-        update Array(records).flatten, []
+      def add name, type, ttl, data
+        update [record(name, type, ttl, data)], []
       end
 
       ##

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -332,11 +332,11 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dns = gcloud.dns
       #   zone = dns.zone "example-zone"
-      #   record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
       #   zone.add record
       #
-      def record name, ttl, type, data
-        Gcloud::Dns::Record.new name, ttl, type, data
+      def record name, type, ttl, data
+        Gcloud::Dns::Record.new name, type, ttl, data
       end
 
       ##
@@ -354,8 +354,8 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dns = gcloud.dns
       #   zone = dns.zone "example-zone"
-      #   new_record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
-      #   old_record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   new_record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
+      #   old_record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
       #   zone.update [new_record], [old_record]
       #
       def update records_to_add = [], records_to_remove = []
@@ -386,7 +386,7 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dns = gcloud.dns
       #   zone = dns.zone "example-zone"
-      #   record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
       #   zone.add record
       #
       def add *records
@@ -408,7 +408,7 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dns = gcloud.dns
       #   zone = dns.zone "example-zone"
-      #   record = zone.record "example.com.", 86400, "A", ["1.2.3.4"]
+      #   record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
       #   zone.remove record
       #
       def remove *records

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -409,8 +409,18 @@ module Gcloud
       end
 
       ##
-      # Removes records from the Zone. In order to update existing records, or
-      # add and remove records in the same transaction, use #update.
+      # Removes records from the Zone. The records are looked up before they are
+      # removed. In order to update existing records, or add and remove records
+      # in the same transaction, use #update.
+      #
+      # === Parameters
+      #
+      # +name+::
+      #   The owner of the record. For example: +example.com.+. (+String+)
+      # +type+::
+      #   The identifier of a {supported record
+      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
       #
       # === Returns
       #
@@ -423,11 +433,10 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dns = gcloud.dns
       #   zone = dns.zone "example-zone"
-      #   record = zone.record "example.com.", "A", 86400, ["1.2.3.4"]
-      #   zone.remove record
+      #   change = zone.remove "example.com.", "A"
       #
-      def remove *records
-        update [], Array(records).flatten
+      def remove name, type
+        update [], records(name: name, type: type)
       end
 
       ##

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -436,7 +436,46 @@ module Gcloud
       #   change = zone.remove "example.com.", "A"
       #
       def remove name, type
-        update [], records(name: name, type: type)
+        update [], records(name: name, type: type).all.to_a
+      end
+
+      ##
+      # Replaces existing records on the Zone. Records matching the +name+ and
+      # +type+ are replaced. In order to update existing records, or add and
+      # delete records in the same transaction, use #update.
+      #
+      # === Parameters
+      #
+      # +name+::
+      #   The owner of the record. For example: +example.com.+. (+String+)
+      # +type+::
+      #   The identifier of a {supported record
+      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+      # +ttl+::
+      #   The number of seconds that the record can be cached by resolvers.
+      #   (+Integer+)
+      # +data+::
+      #   The resource record data, as determined by +type+ and defined in RFC
+      #   1035 (section 5) and RFC 1034 (section 3.6.1). For example:
+      #   +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of +String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Dns::Change
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   change = zone.replace "example.com.", "A", 86400, ["5.6.7.8"]
+      #
+      def replace name, type, ttl, data
+        update [record(name, type, ttl, data)],
+               records(name: name, type: type).all.to_a
       end
 
       ##

--- a/test/gcloud/dns/record_test.rb
+++ b/test/gcloud/dns/record_test.rb
@@ -20,7 +20,7 @@ describe Gcloud::Dns::Record, :mock_dns do
   let(:record_ttl)  { 86400 }
   let(:record_type) { "A" }
   let(:record_data) { ["1.2.3.4"] }
-  let(:record_hash) { random_record_hash record_name, record_ttl, record_type, record_data }
+  let(:record_hash) { random_record_hash record_name, record_type, record_ttl, record_data }
   let(:record) { Gcloud::Dns::Record.from_gapi record_hash }
 
   it "knows its attributes" do

--- a/test/gcloud/dns/record_test.rb
+++ b/test/gcloud/dns/record_test.rb
@@ -17,16 +17,16 @@ require "helper"
 describe Gcloud::Dns::Record, :mock_dns do
   # Create a record object with the project's mocked connection object
   let(:record_name) { "example.com." }
-  let(:record_ttl)  { 86400 }
   let(:record_type) { "A" }
+  let(:record_ttl)  { 86400 }
   let(:record_data) { ["1.2.3.4"] }
   let(:record_hash) { random_record_hash record_name, record_type, record_ttl, record_data }
   let(:record) { Gcloud::Dns::Record.from_gapi record_hash }
 
   it "knows its attributes" do
     record.name.must_equal record_name
-    record.ttl.must_equal  record_ttl
     record.type.must_equal record_type
+    record.ttl.must_equal  record_ttl
     record.data.must_equal record_data
   end
 end

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -374,7 +374,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
     change.deletions.first.data.must_equal to_remove.data
   end
 
-  it "adds records" do
+  it "adds a record" do
     to_add = zone.record "example.net.", "A", 18600, "example.com."
 
     mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
@@ -387,15 +387,15 @@ describe Gcloud::Dns::Zone, :mock_dns do
        create_change_json(to_add, [])]
     end
 
-    change = zone.add to_add
+    change = zone.add "example.net.", "A", 18600, "example.com."
     change.must_be_kind_of Gcloud::Dns::Change
     change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.data.must_equal to_add.data
+    change.additions.first.name.must_equal "example.net."
+    change.additions.first.type.must_equal "A"
+    change.additions.first.ttl.must_equal  18600
+    change.additions.first.data.must_equal ["example.com."]
     change.deletions.must_be :empty?
- end
+  end
 
   it "removes records" do
     to_remove = zone.record "example.net.", "A", 18600, "example.org."

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -339,7 +339,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
   end
 
   it "can create a record" do
-    record = zone.record record_name, record_ttl, record_type, record_data
+    record = zone.record record_name, record_type, record_ttl, record_data
 
     record.name.must_equal record_name
     record.ttl.must_equal  record_ttl
@@ -348,8 +348,8 @@ describe Gcloud::Dns::Zone, :mock_dns do
   end
 
   it "adds and removes records with update" do
-    to_add = zone.record "example.net.", 18600, "A", "example.com."
-    to_remove = zone.record "example.net.", 18600, "A", "example.org."
+    to_add = zone.record "example.net.", "A", 18600, "example.com."
+    to_remove = zone.record "example.net.", "A", 18600, "example.org."
 
     mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
       json = JSON.parse env.body
@@ -375,7 +375,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
   end
 
   it "adds records" do
-    to_add = zone.record "example.net.", 18600, "A", "example.com."
+    to_add = zone.record "example.net.", "A", 18600, "example.com."
 
     mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
       json = JSON.parse env.body
@@ -398,7 +398,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
   end
 
   it "removes records" do
-    to_remove = zone.record "example.net.", 18600, "A", "example.org."
+    to_remove = zone.record "example.net.", "A", 18600, "example.org."
 
     mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
       json = JSON.parse env.body
@@ -443,7 +443,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
     seed = rand 99999
     name = "example-#{seed}.com."
     records = count.times.map do
-      random_record_hash name, seed, "A", ["1.2.3.4"]
+      random_record_hash name, "A", seed, ["1.2.3.4"]
     end
     hash = { "kind" => "dns#resourceRecordSet", "rrsets" => records }
     hash["nextPageToken"] = token unless token.nil?

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -21,8 +21,8 @@ describe Gcloud::Dns::Zone, :mock_dns do
   let(:zone_hash) { random_zone_hash zone_name, zone_dns }
   let(:zone) { Gcloud::Dns::Zone.from_gapi zone_hash, dns.connection }
   let(:record_name) { "example.com." }
-  let(:record_ttl)  { 86400 }
   let(:record_type) { "A" }
+  let(:record_ttl)  { 86400 }
   let(:record_data) { ["1.2.3.4"] }
 
   it "knows its attributes" do
@@ -365,12 +365,12 @@ describe Gcloud::Dns::Zone, :mock_dns do
     change.must_be_kind_of Gcloud::Dns::Change
     change.id.must_equal "dns-change-created"
     change.additions.first.name.must_equal to_add.name
-    change.additions.first.ttl.must_equal  to_add.ttl
     change.additions.first.type.must_equal to_add.type
+    change.additions.first.ttl.must_equal  to_add.ttl
     change.additions.first.data.must_equal to_add.data
     change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.ttl.must_equal  to_remove.ttl
     change.deletions.first.type.must_equal to_remove.type
+    change.deletions.first.ttl.must_equal  to_remove.ttl
     change.deletions.first.data.must_equal to_remove.data
   end
 
@@ -395,7 +395,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
     change.additions.first.type.must_equal to_add.type
     change.additions.first.data.must_equal to_add.data
     change.deletions.must_be :empty?
-  end
+ end
 
   it "removes records" do
     to_remove = zone.record "example.net.", "A", 18600, "example.org."
@@ -415,8 +415,8 @@ describe Gcloud::Dns::Zone, :mock_dns do
     change.id.must_equal "dns-change-created"
     change.additions.must_be :empty?
     change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.ttl.must_equal  to_remove.ttl
     change.deletions.first.type.must_equal to_remove.type
+    change.deletions.first.ttl.must_equal  to_remove.ttl
     change.deletions.first.data.must_equal to_remove.data
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -625,7 +625,7 @@ class MockDns < Minitest::Spec
     }
   end
 
-  def random_record_hash name, ttl, type, data
+  def random_record_hash name, type, ttl, data
     {
       "kind" => "dns#resourceRecordSet",
       "name" => name,


### PR DESCRIPTION
Adds the ability to add updated record without first finding the existing record and deleting it.

```ruby
require "gcloud"

gcloud = Gcloud.new
dns = gcloud.dns
zone = dns.zone "example-zone"
change = zone.replace "example.com.", 86400, "A", ["1.2.3.4"]
```

Also update `Zone#add` and `Zone#remove` to be smarter about making changes.