### PR TITLE
Add Change DSL

### DIFF
--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -1,0 +1,142 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gcloud
+  module Dns
+    class Zone
+      ##
+      # = DNS Zone Transaction
+      #
+      class Transaction
+        attr_reader :additions, :deletions #:nodoc:
+
+        ##
+        # Creates a new transaction.
+        def initialize zone #:nodoc:
+          @zone = zone
+          @additions = []
+          @deletions = []
+        end
+
+        ##
+        # Adds a record to the Zone.
+        #
+        # === Parameters
+        #
+        # +name+::
+        #   The owner of the record. For example: +example.com.+. (+String+)
+        # +type+::
+        #   The identifier of a {supported record
+        #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+        # +ttl+::
+        #   The number of seconds that the record can be cached by resolvers.
+        #   (+Integer+)
+        # +data+::
+        #   The resource record data, as determined by +type+ and defined in RFC
+        #   1035 (section 5) and RFC 1034 (section 3.6.1). For example:
+        #   +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of +String+)
+        #
+        # === Example
+        #
+        #   require "gcloud"
+        #
+        #   gcloud = Gcloud.new
+        #   dns = gcloud.dns
+        #   zone = dns.zone "example-zone"
+        #   zone.update do |tx|
+        #     tx.add     "example.com.", "A",  86400, "1.2.3.4"
+        #     tx.remove  "example.com.", "TXT"
+        #     tx.replace "example.com.", "MX", 86400, ["10 mail1.example.com.",
+        #                                              "20 mail2.example.com."]
+        #   end
+        #
+        def add name, type, ttl, data
+          @additions += Array(@zone.record(name, type, ttl, data))
+        end
+
+        ##
+        # Removes records from the Zone. The records are looked up before they
+        # are removed.
+        #
+        # === Parameters
+        #
+        # +name+::
+        #   The owner of the record. For example: +example.com.+. (+String+)
+        # +type+::
+        #   The identifier of a {supported record
+        #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+        #
+        # === Example
+        #
+        #   require "gcloud"
+        #
+        #   gcloud = Gcloud.new
+        #   dns = gcloud.dns
+        #   zone = dns.zone "example-zone"
+        #   zone.update do |tx|
+        #     tx.add     "example.com.", "A",  86400, "1.2.3.4"
+        #     tx.remove  "example.com.", "TXT"
+        #     tx.replace "example.com.", "MX", 86400, ["10 mail1.example.com.",
+        #                                              "20 mail2.example.com."]
+        #   end
+        #
+        def remove name, type
+          @deletions += @zone.records(name: name, type: type).all
+        end
+
+        ##
+        # Replaces existing records on the Zone. Records matching the +name+ and
+        # +type+ are replaced.
+        #
+        # === Parameters
+        #
+        # +name+::
+        #   The owner of the record. For example: +example.com.+. (+String+)
+        # +type+::
+        #   The identifier of a {supported record
+        #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+        # +ttl+::
+        #   The number of seconds that the record can be cached by resolvers.
+        #   (+Integer+)
+        # +data+::
+        #   The resource record data, as determined by +type+ and defined in RFC
+        #   1035 (section 5) and RFC 1034 (section 3.6.1). For example:
+        #   +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of +String+)
+        #
+        # === Example
+        #
+        #   require "gcloud"
+        #
+        #   gcloud = Gcloud.new
+        #   dns = gcloud.dns
+        #   zone = dns.zone "example-zone"
+        #   zone.update do |tx|
+        #     tx.add     "example.com.", "A",  86400, "1.2.3.4"
+        #     tx.remove  "example.com.", "TXT"
+        #     tx.replace "example.com.", "MX", 86400, ["10 mail1.example.com.",
+        #                                              "20 mail2.example.com."]
+        #   end
+        #
+        def replace name, type, ttl, data
+          remove name, type
+          add name, type, ttl, data
+        end
+      end
+    end
+  end
+end

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -429,7 +429,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
     change.deletions.first.data.must_equal to_remove.data
   end
 
-  it "removes records by name and type" do
+  it "replaces records by name and type" do
     to_add = zone.record "example.net.", "A", 18600, "example.com."
     to_remove = zone.record "example.net.", "A", 18600, "example.org."
 

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -465,6 +465,46 @@ describe Gcloud::Dns::Zone, :mock_dns do
     change.deletions.first.data.must_equal to_remove.data
   end
 
+  it "allows for multiple changes in one update using the DSL" do
+    a_to_add = zone.record "example.com.", "A", 18600, "127.0.0.1"
+    txt_to_remove = zone.record "example.com.", "TXT", 1, "Hello world!"
+    mx_to_add = zone.record "example.com.", "MX", 18600, ["mail1.example.com", "mail2.example.com"]
+    mx_to_remove = zone.record "example.com.", "MX", 18600, ["mail1.example.net", "mail2.example.net"]
+
+    # mock the lookup for TXT
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/rrsets" do |env|
+      env.params["name"].must_equal "example.com."
+      env.params["type"].must_equal "TXT"
+      [200, {"Content-Type" => "application/json"},
+       lookup_records_json(txt_to_remove)]
+    end
+    # mock the lookup for MX
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/rrsets" do |env|
+      env.params["name"].must_equal "example.com."
+      env.params["type"].must_equal "MX"
+      [200, {"Content-Type" => "application/json"},
+       lookup_records_json(mx_to_remove)]
+    end
+    # mock the update call, test that additions and deletions are correct
+    mock_connection.post "/dns/v1/projects/#{project}/managedZones/#{zone.id}/changes" do |env|
+      json = JSON.parse env.body
+      json["additions"].count.must_equal 2
+      json["deletions"].count.must_equal 2
+      json["additions"].must_include a_to_add.to_gapi
+      json["additions"].must_include mx_to_add.to_gapi
+      json["deletions"].must_include txt_to_remove.to_gapi
+      json["deletions"].must_include mx_to_remove.to_gapi
+      [200, {"Content-Type" => "application/json"},
+       create_change_json([a_to_add, mx_to_add], [txt_to_remove, mx_to_remove])]
+    end
+
+    zone.update do |tx|
+      tx.add "example.com.", "A", 18600, "127.0.0.1"
+      tx.remove "example.com.", "TXT"
+      tx.replace "example.com.", "MX", 18600, ["mail1.example.com", "mail2.example.com"]
+    end
+  end
+
   def lookup_records_json record
     hash = { "kind" => "dns#resourceRecordSet", "rrsets" => [record.to_gapi] }
     hash.to_json


### PR DESCRIPTION
Add mechanism for adding, removing, and replacing multiple records in the same API call.

```ruby
require "gcloud"

gcloud = Gcloud.new
dns = gcloud.dns
zone = dns.zone "example-zone"
change = zone.update do |tx|
  tx.add     "example.com.",     "A",  86400, "1.2.3.4"
  tx.add     "www.example.com.", "A",  86400, "1.2.3.4"
  tx.remove  "example.com.",     "TXT"
  tx.replace "example.com.",     "MX", 86400, ["10 mail1.example.com.",
                                               "20 mail2.example.com."]
end
```