### PR TITLE
Add DNS Modify

### DIFF
--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -111,19 +111,20 @@ module Gcloud
         [name, type, ttl, data].hash
       end
 
-      def eql?(other) #:nodoc:
+      def eql? other #:nodoc:
         return false unless other.is_a? self.class
         name == other.name && type == other.type &&
           ttl == other.ttl && data == other.data
       end
 
-      def ==(other) #:nodoc:
+      def == other #:nodoc:
         self.eql? other
       end
 
-      def <=>(other) #:nodoc:
+      def <=> other #:nodoc:
         return nil unless other.is_a? self.class
-        [name, type, ttl, data] <=> [other.name, other.type, other.ttl, other.data]
+        [name, type, ttl, data] <=>
+          [other.name, other.type, other.ttl, other.data]
       end
     end
   end

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -106,6 +106,25 @@ module Gcloud
       def to_gapi #:nodoc:
         { "name" => name, "type" => type, "ttl" => ttl, "rrdatas" => data }
       end
+
+      def hash #:nodoc:
+        [name, type, ttl, data].hash
+      end
+
+      def eql?(other) #:nodoc:
+        return false unless other.is_a? self.class
+        name == other.name && type == other.type &&
+          ttl == other.ttl && data == other.data
+      end
+
+      def ==(other) #:nodoc:
+        self.eql? other
+      end
+
+      def <=>(other) #:nodoc:
+        return nil unless other.is_a? self.class
+        [name, type, ttl, data] <=> [other.name, other.type, other.ttl, other.data]
+      end
     end
   end
 end

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -40,15 +40,15 @@ module Gcloud
       attr_accessor :name
 
       ##
-      # The number of seconds that the record can be cached by resolvers.
-      # (+Integer+)
-      attr_accessor :ttl
-
-      ##
       # The identifier of a {supported record type
       # }[https://cloud.google.com/dns/what-is-cloud-dns#supported_record_types]
       # . For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
       attr_accessor :type
+
+      ##
+      # The number of seconds that the record can be cached by resolvers.
+      # (+Integer+)
+      attr_accessor :ttl
 
       ##
       # The resource record data, as determined by +type+ and defined in RFC
@@ -77,12 +77,12 @@ module Gcloud
       #
       def initialize name, type, ttl, data
         fail ArgumentError, "name is required" unless name
-        fail ArgumentError, "ttl is required" unless ttl
         fail ArgumentError, "type is required" unless type
+        fail ArgumentError, "ttl is required" unless ttl
         fail ArgumentError, "data is required" unless data
         @name = name.to_s
-        @ttl = Integer(ttl)
         @type = type.to_s.upcase
+        @ttl = Integer(ttl)
         @data = Array(data)
       end
 

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -101,6 +101,8 @@ module Gcloud
         new gapi["name"], gapi["type"], gapi["ttl"], gapi["rrdatas"]
       end
 
+      ##
+      # Convert the record object to a Google API hash.
       def to_gapi #:nodoc:
         { "name" => name, "type" => type, "ttl" => ttl, "rrdatas" => data }
       end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -434,6 +434,9 @@ module Gcloud
         update Gcloud::Dns::Importer.new(path_or_io).records(options), []
       end
 
+      # rubocop:disable Metrics/MethodLength
+      # Disabled rubocop because the yield needs to happen in this method.
+
       ##
       # Adds and removes Records from the Zone. All changes are made in a single
       # API request.
@@ -481,8 +484,13 @@ module Gcloud
           deletions += updater.deletions
         end
 
-        create_change additions, deletions
+        to_add    = additions - deletions
+        to_remove = deletions - additions
+        return nil if to_add.empty? && to_remove.empty?
+        create_change to_add, to_remove
       end
+
+      # rubocop:enable Metrics/MethodLength
 
       ##
       # Adds a record to the Zone. In order to update existing records, or add
@@ -624,7 +632,7 @@ module Gcloud
       #
       def modify name, type
         existing = records(name: name, type: type).all.to_a
-        updated = existing.map &:dup
+        updated = existing.map(&:dup)
         updated.each { |r| yield r }
         update updated, existing
       end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -596,6 +596,40 @@ module Gcloud
       end
 
       ##
+      # Modifies records on the Zone. Records matching the +name+ and +type+ are
+      # yielded to the block where they can be modified.
+      #
+      # === Parameters
+      #
+      # +name+::
+      #   The owner of the record. For example: +example.com.+. (+String+)
+      # +type+::
+      #   The identifier of a {supported record
+      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Dns::Change
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   change = zone.modify "example.com.", "MX" do |mx|
+      #     mx.ttl = 3600 # change only the TTL
+      #   end
+      #
+      def modify name, type
+        existing = records(name: name, type: type).all.to_a
+        updated = existing.map &:dup
+        updated.each { |r| yield r }
+        update updated, existing
+      end
+
+      ##
       # New Zone from a Google API Client object.
       def self.from_gapi gapi, conn #:nodoc:
         new.tap do |f|

--- a/test/gcloud/dns/record_test.rb
+++ b/test/gcloud/dns/record_test.rb
@@ -48,7 +48,7 @@ describe Gcloud::Dns::Record, :mock_dns do
     original = [ Gcloud::Dns::Record.new("example.com.", "A", 86400, "localhost"),
                  Gcloud::Dns::Record.new("example.net.", "A", 86400, "localhost"),
                  Gcloud::Dns::Record.new("example.org.", "A", 86400, "localhost") ]
-    changed = original.map &:dup
+    changed = original.map(&:dup)
     changed.must_equal original
     changed.first.ttl = 18600
     changed.wont_equal original

--- a/test/gcloud/dns/record_test.rb
+++ b/test/gcloud/dns/record_test.rb
@@ -36,4 +36,28 @@ describe Gcloud::Dns::Record, :mock_dns do
     zonefile_records.first.must_equal "#{record_name} #{record_ttl} IN #{record_type} #{record_data.first}"
     zonefile_records.last.must_equal "#{record_name} #{record_ttl} IN #{record_type} #{record_data.last}"
   end
+
+  it "knows if it is equal to other records" do
+    dupe = record.dup
+    dupe.must_equal record
+    dupe.data = ["5.6.7.8"]
+    dupe.wont_equal record
+  end
+
+  it "is comparable in arrays" do
+    original = [ Gcloud::Dns::Record.new("example.com.", "A", 86400, "localhost"),
+                 Gcloud::Dns::Record.new("example.net.", "A", 86400, "localhost"),
+                 Gcloud::Dns::Record.new("example.org.", "A", 86400, "localhost") ]
+    changed = original.map &:dup
+    changed.must_equal original
+    changed.first.ttl = 18600
+    changed.wont_equal original
+
+    existing = original - changed
+    updated = changed - original
+    existing.count.must_equal 1
+    updated.count.must_equal 1
+    existing.first.must_equal original.first
+    updated.first.must_equal changed.first
+  end
 end

--- a/test/gcloud/dns/zone_import_export_test.rb
+++ b/test/gcloud/dns/zone_import_export_test.rb
@@ -148,8 +148,8 @@ EOS
   def create_change_json to_add, to_remove
     hash = random_change_hash
     hash["id"] = "dns-change-created"
-    hash["additions"] = Array(to_add).map &:to_gapi
-    hash["deletions"] = Array(to_remove).map &:to_gapi
+    hash["additions"] = Array(to_add).map(&:to_gapi)
+    hash["deletions"] = Array(to_remove).map(&:to_gapi)
     hash.to_json
   end
 

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -391,7 +391,7 @@ describe Gcloud::Dns::Zone, :mock_dns do
     mx_record = zone.record zone.dns, "MX", 86400, ["10 mail.#{zone.dns}",
                                                     "20 mail2.#{zone.dns}"]
     to_add = [a_record, cname_record, mx_record]
-    to_remove = to_add.map &:dup
+    to_remove = to_add.map(&:dup)
     to_remove.first.data = ["example.org."]
 
     # The request to add and remove the records.
@@ -609,8 +609,8 @@ describe Gcloud::Dns::Zone, :mock_dns do
   def create_change_json to_add, to_remove
     hash = random_change_hash
     hash["id"] = "dns-change-created"
-    hash["additions"] = Array(to_add).map &:to_gapi
-    hash["deletions"] = Array(to_remove).map &:to_gapi
+    hash["additions"] = Array(to_add).map(&:to_gapi)
+    hash["deletions"] = Array(to_remove).map(&:to_gapi)
     hash.to_json
   end
 


### PR DESCRIPTION
Enables the following syntax to update existing records:

```ruby
zone.modify "example.com.", "MX" do |mx|
 mx.ttl = 3600 # change the TTL
end
```

[closes #319]