### PR TITLE
Fully Qualified Domain Names

### DIFF
--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -46,7 +46,8 @@ module Gcloud
       #   The path to a zone file on the filesystem, or an IO instance from
       #   which zone file data can be read. (+String+ or +IO+)
       #
-      def initialize path_or_io
+      def initialize zone, path_or_io
+        @zone = zone
         @grouped_zf_records = {}
         @records = []
         @zonefile = if path_or_io.respond_to? :read
@@ -114,7 +115,7 @@ module Gcloud
           data = zf_records.map do |zf_record|
             data_from_zonefile_record(key[1], zf_record)
           end
-          Gcloud::Dns::Record.new key[0], key[1], ttl, data
+          @zone.record key[0], key[1], ttl, data
         end
       end
 
@@ -122,7 +123,7 @@ module Gcloud
         zf_soa = @zonefile.soa
         ttl = ttl_to_i(zf_soa[:ttl]) || ttl_to_i(@zonefile.ttl)
         data = data_from_zonefile_record :soa, zf_soa
-        Gcloud::Dns::Record.new zf_soa[:origin], "SOA", ttl, data
+        @zone.record zf_soa[:origin], "SOA", ttl, data
       end
 
       ##

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -50,11 +50,7 @@ module Gcloud
         @zone = zone
         @grouped_zf_records = {}
         @records = []
-        @zonefile = if path_or_io.respond_to? :read
-                      Zonefile.new path_or_io.read
-                    else
-                      Zonefile.from_file path_or_io
-                    end
+        @zonefile = create_zonefile path_or_io
         sort_zonefile_records
         from_zonefile_records
         @records.unshift soa_record
@@ -185,6 +181,14 @@ module Gcloud
           return m[1].to_i * MULTIPLIER[m[2]].to_i
         end
         nil
+      end
+
+      def create_zonefile path_or_io # :nodoc:
+        if path_or_io.respond_to? :read
+          Zonefile.new path_or_io.read
+        else
+          Zonefile.from_file path_or_io
+        end
       end
     end
   end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -339,6 +339,7 @@ module Gcloud
       #
       def record name, type, ttl, data
         name = dns if name.to_s == "@"
+        name = "#{name}.#{dns}" if subdomain? name
         Gcloud::Dns::Record.new name, type, ttl, data
       end
 
@@ -430,7 +431,7 @@ module Gcloud
       def import path_or_io, options = {}
         options[:except] = Array(options[:except]).map(&:to_s).map(&:upcase)
         options[:except] = (options[:except] + %w(SOA NS)).uniq
-        additions = Gcloud::Dns::Importer.new(path_or_io).records(options)
+        additions = Gcloud::Dns::Importer.new(self, path_or_io).records(options)
         update additions, []
       end
 
@@ -784,6 +785,10 @@ module Gcloud
         else
           "ascending"
         end
+      end
+
+      def subdomain? name
+        name.to_s.strip =~ /\A[^\d]*[^\.]\z/
       end
     end
   end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -338,11 +338,12 @@ module Gcloud
       #   zone.add record
       #
       def record name, type, ttl, data
-        # if modify_name?
+        name = name.to_s.strip
+        name = dns if name.empty?
+        name = dns if name == "@"
         unless ["NAPTR"].include?(type.to_s.upcase)
-          name = dns if name.to_s == "@"
-          # if partial_domain?
-          name = "#{name}.#{dns}" unless name.to_s.strip.end_with?(".")
+          name = "#{name}.#{dns}" unless name.include? "."
+          name = "#{name}." unless name.end_with? "."
         end
         Gcloud::Dns::Record.new name, type, ttl, data
       end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -338,8 +338,12 @@ module Gcloud
       #   zone.add record
       #
       def record name, type, ttl, data
-        name = dns if name.to_s == "@"
-        name = "#{name}.#{dns}" if subdomain? name
+        # if modify_name?
+        unless ["NAPTR"].include?(type.to_s.upcase)
+          name = dns if name.to_s == "@"
+          # if partial_domain?
+          name = "#{name}.#{dns}" unless name.to_s.strip.end_with?(".")
+        end
         Gcloud::Dns::Record.new name, type, ttl, data
       end
 
@@ -785,10 +789,6 @@ module Gcloud
         else
           "ascending"
         end
-      end
-
-      def subdomain? name
-        name.to_s.strip =~ /\A[^\d]*[^\.]\z/
       end
     end
   end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -338,6 +338,7 @@ module Gcloud
       #   zone.add record
       #
       def record name, type, ttl, data
+        name = dns if name.to_s == "@"
         Gcloud::Dns::Record.new name, type, ttl, data
       end
 

--- a/test/gcloud/dns/importer_test.rb
+++ b/test/gcloud/dns/importer_test.rb
@@ -15,7 +15,10 @@
 require "helper"
 
 describe Gcloud::Dns::Importer, :mock_dns do
-
+  let(:zone_name) { "example-zone" }
+  let(:zone_dns) { "example.com." }
+  let(:zone_hash) { random_zone_hash zone_name, zone_dns }
+  let(:zone) { Gcloud::Dns::Zone.from_gapi zone_hash, dns.connection }
   # Zone file example from https://en.wikipedia.org/wiki/Zone_file
   let(:zonefile_path) { "acceptance/data/db.example.com" }
 
@@ -54,7 +57,7 @@ EOS
     records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
     record_must_be records[0], "example.com.", "SOA", 3600, ["ns.example.com. username.example.com. 2007120710 1d 2h 4w 1h"]
     record_must_be records[1], "example.com.", "MX", 3600, ["10 mail.example.com."]
-    record_must_be records[2], "@", "MX", 3600, ["20 mail2.example.com.","50 mail3"]
+    record_must_be records[2], "example.com.", "MX", 3600, ["20 mail2.example.com.","50 mail3"]
     record_must_be records[3], "example.com.", "A", 3600, ["192.0.2.1"]
     record_must_be records[4], "ns", "A", 3600, ["192.0.2.2"]
     record_must_be records[5], "mail", "A", 3600, ["192.0.2.3"]
@@ -72,11 +75,11 @@ EOS
   end
 
   it "imports records from zonefile IO instance" do
-    importer = Gcloud::Dns::Importer.new zonefile_io
+    importer = Gcloud::Dns::Importer.new zone, zonefile_io
     records = importer.records
     records.size.must_equal 8
     records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
-    record_must_be records[0], "@", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
+    record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
     record_must_be records[2], "ns1", "A", 86400, ["192.168.0.1"]
     record_must_be records[3], "www", "A", 3600, ["192.168.0.2"]
@@ -87,7 +90,7 @@ EOS
   end
 
   it "accepts an only option string" do
-    importer = Gcloud::Dns::Importer.new zonefile_io
+    importer = Gcloud::Dns::Importer.new zone, zonefile_io
     records = importer.records only: "A"
     records.size.must_equal 4
     record_must_be records[0], "ns1", "A", 86400, ["192.168.0.1"]
@@ -97,7 +100,7 @@ EOS
   end
 
   it "accepts an only option array" do
-    importer = Gcloud::Dns::Importer.new zonefile_io
+    importer = Gcloud::Dns::Importer.new zone, zonefile_io
     records = importer.records only: ["A","NS"]
     records.size.must_equal 5
     record_must_be records[0], "ns1", "A", 86400, ["192.168.0.1"]
@@ -108,20 +111,20 @@ EOS
   end
 
   it "accepts an except option string" do
-    importer = Gcloud::Dns::Importer.new zonefile_io
+    importer = Gcloud::Dns::Importer.new zone, zonefile_io
     records = importer.records except: "A"
     records.size.must_equal 4
-    record_must_be records[0], "@", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
+    record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
     record_must_be records[2], "example.com.", "NS", 86400, ["ns1.example.com.", "ns2.smokeyjoe.com."]
     record_must_be records[3], "ftp", "CNAME", 86400, ["www.example.com."]
   end
 
   it "accepts an except option array" do
-    importer = Gcloud::Dns::Importer.new zonefile_io
+    importer = Gcloud::Dns::Importer.new zone, zonefile_io
     records = importer.records except: ["A","CNAME"]
     records.size.must_equal 3
-    record_must_be records[0], "@", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
+    record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
     record_must_be records[2], "example.com.", "NS", 86400, ["ns1.example.com.", "ns2.smokeyjoe.com."]
   end

--- a/test/gcloud/dns/importer_test.rb
+++ b/test/gcloud/dns/importer_test.rb
@@ -51,7 +51,7 @@ EOS
   let(:zonefile_io) { StringIO.new zonefile }
 
   it "imports records from zonefile file path" do
-    importer = Gcloud::Dns::Importer.new zonefile_path
+    importer = Gcloud::Dns::Importer.new zone, zonefile_path
     records = importer.records
     records.size.must_equal 17
     records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
@@ -59,15 +59,15 @@ EOS
     record_must_be records[1], "example.com.", "MX", 3600, ["10 mail.example.com."]
     record_must_be records[2], "example.com.", "MX", 3600, ["20 mail2.example.com.","50 mail3"]
     record_must_be records[3], "example.com.", "A", 3600, ["192.0.2.1"]
-    record_must_be records[4], "ns", "A", 3600, ["192.0.2.2"]
-    record_must_be records[5], "mail", "A", 3600, ["192.0.2.3"]
-    record_must_be records[6], "mail2", "A", 3600, ["192.0.2.4"]
-    record_must_be records[7], "mail3", "A", 3600, ["192.0.2.5"]
+    record_must_be records[4], "ns.example.com.", "A", 3600, ["192.0.2.2"]
+    record_must_be records[5], "mail.example.com.", "A", 3600, ["192.0.2.3"]
+    record_must_be records[6], "mail2.example.com.", "A", 3600, ["192.0.2.4"]
+    record_must_be records[7], "mail3.example.com.", "A", 3600, ["192.0.2.5"]
     record_must_be records[8], "example.com.", "AAAA", 3600, ["2001:db8:10::1"]
-    record_must_be records[9], "ns", "AAAA", 3600, ["2001:db8:10::2"]
+    record_must_be records[9], "ns.example.com.", "AAAA", 3600, ["2001:db8:10::2"]
     record_must_be records[10], "example.com.", "NS", 3600, ["ns","ns.somewhere.example."]
-    record_must_be records[11], "www", "CNAME", 3600, ["example.com."]
-    record_must_be records[12], "wwwtest", "CNAME", 3600, ["www"]
+    record_must_be records[11], "www.example.com.", "CNAME", 3600, ["example.com."]
+    record_must_be records[12], "wwwtest.example.com.", "CNAME", 3600, ["www"]
     record_must_be records[13], "sip.example.com.", "TXT", 3600, ["\"text; containing ; spaces; and; semicolons ;\""]
     record_must_be records[14], "2.1.0.10.in-addr.arpa.", "PTR", 3600, ["server.example.com."]
     record_must_be records[15], "sip.example.com.", "SRV", 3600, ["0 5 5060 sip.example.com."]
@@ -81,32 +81,32 @@ EOS
     records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
     record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
-    record_must_be records[2], "ns1", "A", 86400, ["192.168.0.1"]
-    record_must_be records[3], "www", "A", 3600, ["192.168.0.2"]
-    record_must_be records[4], "bill", "A", 86400, ["192.168.0.3"]
-    record_must_be records[5], "fred", "A", 86400, ["192.168.0.4"]
+    record_must_be records[2], "ns1.example.com.", "A", 86400, ["192.168.0.1"]
+    record_must_be records[3], "www.example.com.", "A", 3600, ["192.168.0.2"]
+    record_must_be records[4], "bill.example.com.", "A", 86400, ["192.168.0.3"]
+    record_must_be records[5], "fred.example.com.", "A", 86400, ["192.168.0.4"]
     record_must_be records[6], "example.com.", "NS", 86400, ["ns1.example.com.", "ns2.smokeyjoe.com."]
-    record_must_be records[7], "ftp", "CNAME", 86400, ["www.example.com."]
+    record_must_be records[7], "ftp.example.com.", "CNAME", 86400, ["www.example.com."]
   end
 
   it "accepts an only option string" do
     importer = Gcloud::Dns::Importer.new zone, zonefile_io
     records = importer.records only: "A"
     records.size.must_equal 4
-    record_must_be records[0], "ns1", "A", 86400, ["192.168.0.1"]
-    record_must_be records[1], "www", "A", 3600, ["192.168.0.2"]
-    record_must_be records[2], "bill", "A", 86400, ["192.168.0.3"]
-    record_must_be records[3], "fred", "A", 86400, ["192.168.0.4"]
+    record_must_be records[0], "ns1.example.com.", "A", 86400, ["192.168.0.1"]
+    record_must_be records[1], "www.example.com.", "A", 3600, ["192.168.0.2"]
+    record_must_be records[2], "bill.example.com.", "A", 86400, ["192.168.0.3"]
+    record_must_be records[3], "fred.example.com.", "A", 86400, ["192.168.0.4"]
   end
 
   it "accepts an only option array" do
     importer = Gcloud::Dns::Importer.new zone, zonefile_io
     records = importer.records only: ["A","NS"]
     records.size.must_equal 5
-    record_must_be records[0], "ns1", "A", 86400, ["192.168.0.1"]
-    record_must_be records[1], "www", "A", 3600, ["192.168.0.2"]
-    record_must_be records[2], "bill", "A", 86400, ["192.168.0.3"]
-    record_must_be records[3], "fred", "A", 86400, ["192.168.0.4"]
+    record_must_be records[0], "ns1.example.com.", "A", 86400, ["192.168.0.1"]
+    record_must_be records[1], "www.example.com.", "A", 3600, ["192.168.0.2"]
+    record_must_be records[2], "bill.example.com.", "A", 86400, ["192.168.0.3"]
+    record_must_be records[3], "fred.example.com.", "A", 86400, ["192.168.0.4"]
     record_must_be records[4], "example.com.", "NS", 86400, ["ns1.example.com.", "ns2.smokeyjoe.com."]
   end
 
@@ -117,7 +117,7 @@ EOS
     record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
     record_must_be records[2], "example.com.", "NS", 86400, ["ns1.example.com.", "ns2.smokeyjoe.com."]
-    record_must_be records[3], "ftp", "CNAME", 86400, ["www.example.com."]
+    record_must_be records[3], "ftp.example.com.", "CNAME", 86400, ["www.example.com."]
   end
 
   it "accepts an except option array" do

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -358,6 +358,24 @@ describe Gcloud::Dns::Zone, :mock_dns do
     record.data.must_equal record_data
   end
 
+  it "creates a record with a qualified name when given only a subdomain" do
+    record = zone.record "www", record_type, record_ttl, record_data
+
+    record.name.must_equal "www.example.com."
+    record.ttl.must_equal  record_ttl
+    record.type.must_equal record_type
+    record.data.must_equal record_data
+  end
+
+  it "creates a record without changing name when given an IP address" do
+    record = zone.record "1.2.3.4", record_type, record_ttl, record_data
+
+    record.name.must_equal "1.2.3.4"
+    record.ttl.must_equal  record_ttl
+    record.type.must_equal record_type
+    record.data.must_equal record_data
+  end
+
   it "adds and removes records with update" do
     to_add = zone.record "example.net.", "A", 18600, "example.com."
     to_remove = zone.record "example.net.", "A", 18600, "example.org."

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -344,8 +344,8 @@ describe Gcloud::Dns::Zone, :mock_dns do
     record = zone.record record_name, record_type, record_ttl, record_data
 
     record.name.must_equal record_name
-    record.ttl.must_equal  record_ttl
     record.type.must_equal record_type
+    record.ttl.must_equal  record_ttl
     record.data.must_equal record_data
   end
 
@@ -353,8 +353,8 @@ describe Gcloud::Dns::Zone, :mock_dns do
     record = zone.record "@", record_type, record_ttl, record_data
 
     record.name.must_equal "example.com."
-    record.ttl.must_equal  record_ttl
     record.type.must_equal record_type
+    record.ttl.must_equal  record_ttl
     record.data.must_equal record_data
   end
 
@@ -362,18 +362,18 @@ describe Gcloud::Dns::Zone, :mock_dns do
     record = zone.record "www", record_type, record_ttl, record_data
 
     record.name.must_equal "www.example.com."
-    record.ttl.must_equal  record_ttl
     record.type.must_equal record_type
+    record.ttl.must_equal  record_ttl
     record.data.must_equal record_data
   end
 
-  it "creates a record without changing name when given an IP address" do
-    record = zone.record "1.2.3.4", record_type, record_ttl, record_data
+  it "creates a record without changing name when it is a NAPTR record" do
+    record = zone.record "1.2.3.4", "NAPTR", 3600, "10 100 \"U\" \"E2U+sip\" \"!^\\+44111555(.+)$!sip:7\\1@sip.example.com!\" ."
 
     record.name.must_equal "1.2.3.4"
-    record.ttl.must_equal  record_ttl
-    record.type.must_equal record_type
-    record.data.must_equal record_data
+    record.type.must_equal "NAPTR"
+    record.ttl.must_equal  3600
+    record.data.must_equal ["10 100 \"U\" \"E2U+sip\" \"!^\\+44111555(.+)$!sip:7\\1@sip.example.com!\" ."]
   end
 
   it "adds and removes records with update" do

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -349,6 +349,33 @@ describe Gcloud::Dns::Zone, :mock_dns do
     record.data.must_equal record_data
   end
 
+  it "creates a record with a fully domain name when not given one" do
+    record = zone.record "example.com", record_type, record_ttl, record_data
+
+    record.name.must_equal "example.com." # it appends "."
+    record.type.must_equal record_type
+    record.ttl.must_equal  record_ttl
+    record.data.must_equal record_data
+  end
+
+  it "creates a record when given nil for the domain name" do
+    record = zone.record nil, record_type, record_ttl, record_data
+
+    record.name.must_equal "example.com."
+    record.type.must_equal record_type
+    record.ttl.must_equal  record_ttl
+    record.data.must_equal record_data
+  end
+
+  it "creates a record when given an empty string for the domain name" do
+    record = zone.record "", record_type, record_ttl, record_data
+
+    record.name.must_equal "example.com."
+    record.type.must_equal record_type
+    record.ttl.must_equal  record_ttl
+    record.data.must_equal record_data
+  end
+
   it "creates a record when given '@' for the domain name" do
     record = zone.record "@", record_type, record_ttl, record_data
 

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -349,6 +349,15 @@ describe Gcloud::Dns::Zone, :mock_dns do
     record.data.must_equal record_data
   end
 
+  it "creates a record when given '@' for the domain name" do
+    record = zone.record "@", record_type, record_ttl, record_data
+
+    record.name.must_equal "example.com."
+    record.ttl.must_equal  record_ttl
+    record.type.must_equal record_type
+    record.data.must_equal record_data
+  end
+
   it "adds and removes records with update" do
     to_add = zone.record "example.net.", "A", 18600, "example.com."
     to_remove = zone.record "example.net.", "A", 18600, "example.org."


### PR DESCRIPTION
This change allows you to use "@" and "www" names when creating records. So this:

```ruby
zone.record "@", "A", 18600, "1.2.3.4"
```

Is equivalent to this:

```ruby
zone.record "example.net.", "A", 18600, "1.2.3.4"
```

And this:

```ruby
zone.record "www", "A", 18600, "1.2.3.4"
```

Is equivalent to this:

```ruby
zone.record "www.example.net.", "A", 18600, "1.2.3.4"
```