### PR TITLE
Add forceful deletion of Zone

### DIFF
--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -121,9 +121,9 @@ module Gcloud
       # +options+::
       #   An optional Hash for controlling additional behavior. (+Hash+)
       # <code>options[:force]</code>::
-      #   If +true+, forces the deletion of the zone by delete all records. If
-      #   +false+ and the zone contains non-essential records, the request will
-      #   fail. Default is +false+. (+Boolean+)
+      #   If +true+, ensures the deletion of the zone by first deleting all
+      #   records. If +false+ and the zone contains non-essential records, the
+      #   request will fail. Default is +false+. (+Boolean+)
       #
       # === Returns
       #
@@ -160,8 +160,8 @@ module Gcloud
       end
 
       ##
-      # Removes non-essential records the zone. Only NS and SOA records will be
-      # kept.
+      # Removes non-essential records from the zone. Only NS and SOA records
+      # will be kept.
       #
       # === Examples
       #

--- a/test/gcloud/dns/change_test.rb
+++ b/test/gcloud/dns/change_test.rb
@@ -117,26 +117,4 @@ describe Gcloud::Dns::Change, :mock_dns do
     pending_change.wait_until_done!
     pending_change.must_be :done?
   end
-
-  def done_change_hash change_id = nil
-    hash = random_change_hash
-    hash["id"] = change_id if change_id
-    hash["additions"] = [{ "name" => "example.net.", "ttl" => 18600, "type" => "A", "rrdatas" => ["example.com."] }]
-    hash["deletions"] = [{ "name" => "example.net.", "ttl" => 18600, "type" => "A", "rrdatas" => ["example.org."] }]
-    hash
-  end
-
-  def pending_change_hash change_id = nil
-    hash = done_change_hash change_id
-    hash["status"] = "pending"
-    hash
-  end
-
-  def done_change_json change_id = nil
-    done_change_hash(change_id).to_json
-  end
-
-  def pending_change_json change_id = nil
-    pending_change_hash(change_id).to_json
-  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -635,6 +635,28 @@ class MockDns < Minitest::Spec
     }
   end
 
+  def done_change_hash change_id = nil
+    hash = random_change_hash
+    hash["id"] = change_id if change_id
+    hash["additions"] = [{ "name" => "example.net.", "ttl" => 18600, "type" => "A", "rrdatas" => ["example.com."] }]
+    hash["deletions"] = [{ "name" => "example.net.", "ttl" => 18600, "type" => "A", "rrdatas" => ["example.org."] }]
+    hash
+  end
+
+  def pending_change_hash change_id = nil
+    hash = done_change_hash change_id
+    hash["status"] = "pending"
+    hash
+  end
+
+  def done_change_json change_id = nil
+    done_change_hash(change_id).to_json
+  end
+
+  def pending_change_json change_id = nil
+    pending_change_hash(change_id).to_json
+  end
+
   # Register this spec type for when :storage is used.
   register_spec_type(self) do |desc, *addl|
     addl.include? :mock_dns


### PR DESCRIPTION
A zone cannot be deleted while there are non-essential records on it. This option will forcefully delete a zone by removing those records. Also includes the clear! method to remove all non-essential records.