### PR TITLE
Fix bug with string table names

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -332,9 +332,10 @@ module Gcloud
         unless m
           fail ArgumentError, "unable to identify table from #{str.inspect}"
         end
-        default_table_ref.merge("projectId" => m["prj"],
-                                "datasetId" => m["dts"],
-                                "tableId" => m["tbl"])
+        str_table_ref = { "projectId" => m["prj"],
+                          "datasetId" => m["dts"],
+                          "tableId"   => m["tbl"] }.delete_if { |_, v| v.nil? }
+        default_table_ref.merge str_table_ref
       end
 
       def inspect #:nodoc:

--- a/test/gcloud/bigquery/table_copy_test.rb
+++ b/test/gcloud/bigquery/table_copy_test.rb
@@ -64,21 +64,38 @@ describe Gcloud::Bigquery::Table, :copy, :mock_bigquery do
   end
 
   it "can copy to a table identified by a string" do
-      mock_connection.post "/bigquery/v2/projects/#{project}/jobs" do |env|
-        json = JSON.parse(env.body)
-        json["configuration"]["copy"]["sourceTable"]["projectId"].must_equal source_table.project_id
-        json["configuration"]["copy"]["sourceTable"]["datasetId"].must_equal source_table.dataset_id
-        json["configuration"]["copy"]["sourceTable"]["tableId"].must_equal source_table.table_id
-        json["configuration"]["copy"]["destinationTable"]["projectId"].must_equal target_table_other_proj.project_id
-        json["configuration"]["copy"]["destinationTable"]["datasetId"].must_equal target_table_other_proj.dataset_id
-        json["configuration"]["copy"]["destinationTable"]["tableId"].must_equal target_table_other_proj.table_id
-        [200, {"Content-Type"=>"application/json"},
-         copy_job_json(source_table, target_table_other_proj)]
-      end
-
-      job = source_table.copy "target-project:target_dataset.target_table_id"
-      job.must_be_kind_of Gcloud::Bigquery::CopyJob
+    mock_connection.post "/bigquery/v2/projects/#{project}/jobs" do |env|
+      json = JSON.parse(env.body)
+      json["configuration"]["copy"]["sourceTable"]["projectId"].must_equal source_table.project_id
+      json["configuration"]["copy"]["sourceTable"]["datasetId"].must_equal source_table.dataset_id
+      json["configuration"]["copy"]["sourceTable"]["tableId"].must_equal   source_table.table_id
+      json["configuration"]["copy"]["destinationTable"]["projectId"].must_equal target_table_other_proj.project_id
+      json["configuration"]["copy"]["destinationTable"]["datasetId"].must_equal target_table_other_proj.dataset_id
+      json["configuration"]["copy"]["destinationTable"]["tableId"].must_equal   target_table_other_proj.table_id
+      [200, {"Content-Type"=>"application/json"},
+       copy_job_json(source_table, target_table_other_proj)]
     end
+
+    job = source_table.copy "target-project:target_dataset.target_table_id"
+    job.must_be_kind_of Gcloud::Bigquery::CopyJob
+  end
+
+  it "can copy to a table name string only" do
+    mock_connection.post "/bigquery/v2/projects/#{project}/jobs" do |env|
+      json = JSON.parse(env.body)
+      json["configuration"]["copy"]["sourceTable"]["projectId"].must_equal source_table.project_id
+      json["configuration"]["copy"]["sourceTable"]["datasetId"].must_equal source_table.dataset_id
+      json["configuration"]["copy"]["sourceTable"]["tableId"].must_equal   source_table.table_id
+      json["configuration"]["copy"]["destinationTable"]["projectId"].must_equal source_table.project_id
+      json["configuration"]["copy"]["destinationTable"]["datasetId"].must_equal source_table.dataset_id
+      json["configuration"]["copy"]["destinationTable"]["tableId"].must_equal   "new_target_table_id"
+      [200, {"Content-Type"=>"application/json"},
+       copy_job_json(source_table, target_table_other_proj)]
+    end
+
+    job = source_table.copy "new_target_table_id"
+    job.must_be_kind_of Gcloud::Bigquery::CopyJob
+  end
 
   it "can copy itself as a dryrun" do
     mock_connection.post "/bigquery/v2/projects/#{project}/jobs" do |env|


### PR DESCRIPTION
The intent is that the current project and dataset values are used when copying
to a table identified by a string if the string does not contain them.
The bug here is that the nil values were kept when merged.
Removing the keys with nil values before the merge corrects the behavior.

[fixes #326]