### PR TITLE
Add FQDN Usage

### DIFF
--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -133,6 +133,26 @@ module Gcloud
         )
       end
 
+      ##
+      # Fully Qualified Domain Name
+      def self.fqdn name, origin_dns
+        name = name.to_s.strip
+        return name if self.ip_addr? name
+        name = origin_dns if name.empty?
+        name = origin_dns if name == "@"
+        name = "#{name}.#{origin_dns}" unless name.include? "."
+        name = "#{name}." unless name.end_with? "."
+        name
+      end
+
+      require "ipaddr"
+      def self.ip_addr? name
+        IPAddr.new name
+        true
+      rescue IPAddr::Error
+        false
+      end
+
       def inspect #:nodoc:
         "#{self.class}(#{@project})"
       end

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -146,6 +146,9 @@ module Gcloud
       end
 
       require "ipaddr"
+      # Fix to make ip_addr? work on ruby 1.9
+      IPAddr::Error = ArgumentError unless defined? IPAddr::Error
+
       def self.ip_addr? name
         IPAddr.new name
         true

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -95,8 +95,7 @@ module Gcloud
           type = r.first
           type = :aaaa if type == :a4
           r.last.each do |zf_record|
-            name = zf_record[:name]
-            name = @zonefile.origin if name.nil? || name == "@"
+            name = Connection.fqdn(zf_record[:name], @zonefile.origin)
             key = [name, type]
             (@merged_zf_records[key] ||= []) << zf_record
           end

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -377,14 +377,7 @@ module Gcloud
       #   zone.add record
       #
       def record name, type, ttl, data
-        name = name.to_s.strip
-        name = dns if name.empty?
-        name = dns if name == "@"
-        unless ["NAPTR"].include?(type.to_s.upcase)
-          name = "#{name}.#{dns}" unless name.include? "."
-          name = "#{name}." unless name.end_with? "."
-        end
-        Gcloud::Dns::Record.new name, type, ttl, data
+        Gcloud::Dns::Record.new fqdn(name), type, ttl, data
       end
 
       ##
@@ -756,6 +749,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
       #   change = zone.modify "example.com.", "MX" do |mx|
       #     mx.ttl = 3600 # change only the TTL
       #   end
@@ -765,6 +759,34 @@ module Gcloud
         updated = existing.map(&:dup)
         updated.each { |r| yield r }
         update updated, existing, options
+      end
+
+      ##
+      # Ensures the given domain name is a Fully Qualified Domain Name. A
+      # subdomain like "www" will be prepended to the zone's domain name.
+      #
+      # === Parameters
+      #
+      # +domain_name+::
+      #   The domain name to ensure is a fully qualified domain name. (+String+)
+      #
+      # === Returns
+      #
+      # A fully qualified domain name. (+String+)
+      #
+      # === Examples
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dns = gcloud.dns
+      #   zone = dns.zone "example-zone"
+      #   zone.fqdn "www" #=> "www.example.com."
+      #   zone.fqdn "@" #=> "example.com."
+      #   zone.fqdn "mail.example.com." #=> "mail.example.com."
+      #
+      def fqdn domain_name
+        Connection.fqdn domain_name, dns
       end
 
       ##

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -351,6 +351,8 @@ module Gcloud
       #
       def records options = {}
         ensure_connection!
+        # Ensure name is a FQDN
+        options[:name] = fqdn(options[:name]) if options[:name]
         resp = connection.list_records id, options
         if resp.success?
           Record::List.from_response resp, self

--- a/test/gcloud/dns/zone_fqdn_test.rb
+++ b/test/gcloud/dns/zone_fqdn_test.rb
@@ -1,0 +1,48 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Dns::Zone, :fqdn, :mock_dns do
+  let(:zone_name) { "example-zone" }
+  let(:zone_dns) { "example.com." }
+  let(:zone) { Gcloud::Dns::Zone.from_gapi random_zone_hash(zone_name, zone_dns), dns.connection }
+
+  it "knows a fully qualified domain name when given one" do
+    zone.fqdn("example.org.").must_equal "example.org."
+  end
+
+  it "creates a fully qualified domain name when not given one" do
+    zone.fqdn("example.net").must_equal "example.net."
+  end
+
+  it "uses the zone's fully qualified domain name when given nil" do
+    zone.fqdn(nil).must_equal "example.com."
+  end
+
+  it "uses the zone's fully qualified domain name when given empty string" do
+    zone.fqdn("").must_equal "example.com."
+    zone.fqdn("  ").must_equal "example.com." # spaces
+    zone.fqdn("\t").must_equal "example.com." # tab
+    zone.fqdn("\n").must_equal "example.com." # new lines
+  end
+
+  it "uses the zone's fully qualified domain name when given @" do
+    zone.fqdn("").must_equal "example.com."
+  end
+
+  it "prepends the zone's fully qualified domain name when given a subdomain" do
+    zone.fqdn("www").must_equal "www.example.com."
+  end
+end


### PR DESCRIPTION
Use shared FQDN logic between Zone and Importer. Add the option to search, add, remove, replace, and modify records using a subdomain. This makes the FQDN behavior more consistent.