### PR TITLE
Remove Gzip middleware

### DIFF
--- a/acceptance/storage_helper.rb
+++ b/acceptance/storage_helper.rb
@@ -20,6 +20,8 @@ require "gcloud/storage"
 # and https://github.com/google/google-api-ruby-client/issues/69
 # and https://github.com/google/google-api-ruby-client/issues/106
 Faraday.default_adapter = :httpclient
+# Remove Google API Client Gzip middleware
+Faraday::Response.register_middleware :gzip => Faraday::Response::Middleware
 
 # Increase the number of retries because we run so many tests in parallel
 require "gcloud/backoff"


### PR DESCRIPTION
The Google API Client adds a gzip middleware. This conflicts with the HTTPClient's
transparent_gzip_decompression setting that was enabled in Faraday 0.9.2.
Remove the middleware until a new version of Google API Client is released
that fixes this.

[refs #367]