### PR TITLE
Added option delimiter_field to Gcloud::Bigquery::Table#load method

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -547,7 +547,8 @@ module Gcloud
               "createDisposition" => create_disposition(options[:create]),
               "writeDisposition" => write_disposition(options[:write]),
               "sourceFormat" => source_format(path, options[:format]),
-              "projectionFields" => projection_fields(options[:projection_fields])
+              "projectionFields" => projection_fields(options[:projection_fields]),
+              "fieldDelimiter" => options[:delimiter]
             }.delete_if { |_, v| v.nil? },
             "dryRun" => options[:dryrun]
           }.delete_if { |_, v| v.nil? }

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -653,6 +653,10 @@ module Gcloud
       #   names are case sensitive and must be top-level properties. If not set,
       #   BigQuery loads all properties. If any named property isn't found in
       #   the Cloud Datastore backup, an invalid error is returned. (+Array+)
+      # <code>options[:delimiter]</code>::
+      #   Specifices the separator for fields in a CSV file. BigQuery converts
+      #   the string to ISO-8859-1 encoding, and then uses the first byte of
+      #   the encoded string to split the data in its raw, binary state.
       #
       # === Returns
       #

--- a/test/gcloud/bigquery/table_load_local_test.rb
+++ b/test/gcloud/bigquery/table_load_local_test.rb
@@ -36,13 +36,14 @@ describe Gcloud::Bigquery::Table, :load, :local, :mock_bigquery do
       json["configuration"]["load"].wont_include "createDisposition"
       json["configuration"]["load"].wont_include "writeDisposition"
       json["configuration"]["load"]["sourceFormat"].must_equal "CSV"
+      json["configuration"]["load"]["fieldDelimiter"].must_equal "\t"
       json["configuration"].wont_include "dryRun"
       [200, {"Content-Type"=>"application/json", Location: "/resumable/upload/bigquery/v2/projects/#{project}/jobs"},
        load_job_json(table, "some/file/path.csv")]
     end
 
     temp_csv do |file|
-      job = table.load file, format: :csv
+      job = table.load file, format: :csv, delimiter: "\t"
       job.must_be_kind_of Gcloud::Bigquery::LoadJob
     end
   end


### PR DESCRIPTION
The Bigquery Api supports two delimiters [ "," and "\t"] but currently is not possible to specify the delimiter in then Gcloud::Bigquery::Table#load method ( "," is supported by default )

So the proposed definition of the new option is:

```
table.load file,  delimiter_field: "\t" 
```
