### PR TITLE
Storage URL

### DIFF
--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -117,7 +117,7 @@ module Gcloud
       #
       # :category: Attributes
       #
-      def url
+      def api_url
         ensure_full_data!
         @gapi["selfLink"]
       end

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -184,7 +184,7 @@ module Gcloud
       #
       # :category: Attributes
       #
-      def url
+      def api_url
         ensure_full_data!
         @gapi["selfLink"]
       end

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -125,7 +125,7 @@ module Gcloud
       #
       # :category: Attributes
       #
-      def url
+      def api_url
         ensure_full_data!
         @gapi["selfLink"]
       end

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -70,8 +70,8 @@ module Gcloud
       end
 
       ##
-      # The URI of this bucket.
-      def url
+      # A URL that can be used to access the bucket using the REST API.
+      def api_url
         @gapi["selfLink"]
       end
 

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -101,8 +101,8 @@ module Gcloud
       end
 
       ##
-      # The url to the file.
-      def url
+      # A URL that can be used to access the file using the REST API.
+      def api_url
         @gapi["selfLink"]
       end
 

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -107,6 +107,12 @@ module Gcloud
       end
 
       ##
+      # A URL that can be used to download the file using the REST API.
+      def media_url
+        @gapi["mediaLink"]
+      end
+
+      ##
       # Content-Length of the data in bytes.
       def size
         @gapi["size"]

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -483,6 +483,13 @@ module Gcloud
       #
       # To share a file that is not public see #signed_url.
       #
+      # === Parameters
+      #
+      # +options+::
+      #   An optional Hash for controlling additional behavior. (+Hash+)
+      # <code>options[:protocol]</code>::
+      #   The protocol to use for the URL. Default is +HTTPS+. (+String+)
+      #
       # === Examples
       #
       #   require "gcloud"
@@ -494,8 +501,21 @@ module Gcloud
       #   file = bucket.file "avatars/heidi/400x400.png"
       #   public_url = file.public_url
       #
-      def public_url
-        "https://storage.googleapis.com/#{bucket}/#{name}"
+      # To generate the URL with a protocol other than HTTPS, use the +protocol+
+      # option:
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
+      #
+      #   bucket = storage.bucket "my-todo-app"
+      #   file = bucket.file "avatars/heidi/400x400.png"
+      #   public_url = file.public_url protocol: "http"
+      #
+      def public_url options = {}
+        protocol = options[:protocol] || :https
+        "#{protocol}://storage.googleapis.com/#{bucket}/#{name}"
       end
       alias_method :url, :public_url
 

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -476,6 +476,30 @@ module Gcloud
       end
 
       ##
+      # Public URL to access the file. If the file is not public, requests to
+      # the URL will return an error. (See File::Acl#public! and
+      # Bucket::DefaultAcl#public!) For more information, read [Accessing Public
+      # Data]{https://cloud.google.com/storage/docs/access-public-data}.
+      #
+      # To share a file that is not public see #signed_url.
+      #
+      # === Examples
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   storage = gcloud.storage
+      #
+      #   bucket = storage.bucket "my-todo-app"
+      #   file = bucket.file "avatars/heidi/400x400.png"
+      #   public_url = file.public_url
+      #
+      def public_url
+        "https://storage.googleapis.com/#{bucket}/#{name}"
+      end
+      alias_method :url, :public_url
+
+      ##
       # Access without authentication can be granted to a File for a specified
       # period of time. This URL uses a cryptographic signature
       # of your credentials to access the file. See the

--- a/test/gcloud/bigquery/dataset_attributes_test.rb
+++ b/test/gcloud/bigquery/dataset_attributes_test.rb
@@ -68,7 +68,7 @@ describe Gcloud::Bigquery::Dataset, :attributes, :mock_bigquery do
   attr_test :description, "This is my dataset"
   attr_test :default_expiration, 999
   attr_test :etag, "etag123456789"
-  attr_test :url, "http://googleapi/bigquery/v2/projects/test-project/datasets/my_dataset"
+  attr_test :api_url, "http://googleapi/bigquery/v2/projects/test-project/datasets/my_dataset"
   attr_test :location, "US"
 
 end

--- a/test/gcloud/bigquery/dataset_test.rb
+++ b/test/gcloud/bigquery/dataset_test.rb
@@ -55,7 +55,7 @@ describe Gcloud::Bigquery::Dataset, :mock_bigquery do
   let(:default_expiration) { 999 }
   let(:etag) { "etag123456789" }
   let(:location_code) { "US" }
-  let(:url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset_id}" }
+  let(:api_url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset_id}" }
   let(:dataset_hash) { random_dataset_hash dataset_id, dataset_name, dataset_description, default_expiration }
   let(:dataset) { Gcloud::Bigquery::Dataset.from_gapi dataset_hash,
                                                       bigquery.connection }
@@ -65,7 +65,7 @@ describe Gcloud::Bigquery::Dataset, :mock_bigquery do
     dataset.description.must_equal dataset_description
     dataset.default_expiration.must_equal default_expiration
     dataset.etag.must_equal etag
-    dataset.url.must_equal url
+    dataset.api_url.must_equal api_url
     dataset.location.must_equal location_code
   end
 

--- a/test/gcloud/bigquery/table_attributes_test.rb
+++ b/test/gcloud/bigquery/table_attributes_test.rb
@@ -93,7 +93,7 @@ describe Gcloud::Bigquery::Table, :attributes, :mock_bigquery do
 
   attr_test :description, "This is my table"
   attr_test :etag, "etag123456789"
-  attr_test :url, "http://googleapi/bigquery/v2/projects/test-project/datasets/my_table/tables/my_table"
+  attr_test :api_url, "http://googleapi/bigquery/v2/projects/test-project/datasets/my_table/tables/my_table"
   attr_test :bytes_count, 1000
   attr_test :rows_count, 100
   attr_test :location, "US"

--- a/test/gcloud/bigquery/table_extract_test.rb
+++ b/test/gcloud/bigquery/table_extract_test.rb
@@ -238,7 +238,7 @@ describe Gcloud::Bigquery::Table, :extract, :mock_bigquery do
   def extract_job_json table, extract_file
     hash = random_job_hash
     hash["configuration"]["extract"] = {
-      "destinationUris" => [extract_file.url],
+      "destinationUris" => [extract_file.api_url],
       "sourceTable" => {
         "projectId" => table.project_id,
         "datasetId" => table.dataset_id,

--- a/test/gcloud/bigquery/table_test.rb
+++ b/test/gcloud/bigquery/table_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
   let(:description) { "This is my table" }
   let(:etag) { "etag123456789" }
   let(:location_code) { "US" }
-  let(:url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
+  let(:api_url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
   let(:table) { Gcloud::Bigquery::Table.from_gapi table_hash,
                                                   bigquery.connection }
@@ -33,7 +33,7 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
     table.name.must_equal table_name
     table.description.must_equal description
     table.etag.must_equal etag
-    table.url.must_equal url
+    table.api_url.must_equal api_url
     table.bytes_count.must_equal 1000
     table.rows_count.must_equal 100
     table.table?.must_equal true

--- a/test/gcloud/bigquery/view_attributes_test.rb
+++ b/test/gcloud/bigquery/view_attributes_test.rb
@@ -93,7 +93,7 @@ describe Gcloud::Bigquery::View, :attributes, :mock_bigquery do
 
   attr_test :description, "This is my view"
   attr_test :etag, "etag123456789"
-  attr_test :url, "http://googleapi/bigquery/v2/projects/test-project/datasets/my_view/tables/my_view"
+  attr_test :api_url, "http://googleapi/bigquery/v2/projects/test-project/datasets/my_view/tables/my_view"
   attr_test :location, "US"
 
 end

--- a/test/gcloud/bigquery/view_test.rb
+++ b/test/gcloud/bigquery/view_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Bigquery::View, :mock_bigquery do
   let(:description) { "This is my view" }
   let(:etag) { "etag123456789" }
   let(:location_code) { "US" }
-  let(:url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
+  let(:api_url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
   let(:view_hash) { random_view_hash dataset, table_id, table_name, description }
   let(:view) { Gcloud::Bigquery::View.from_gapi view_hash,
                                                 bigquery.connection }
@@ -33,7 +33,7 @@ describe Gcloud::Bigquery::View, :mock_bigquery do
     view.name.must_equal table_name
     view.description.must_equal description
     view.etag.must_equal etag
-    view.url.must_equal url
+    view.api_url.must_equal api_url
     view.view?.must_equal true
     view.table?.must_equal false
     view.location.must_equal location_code

--- a/test/gcloud/storage/bucket_test.rb
+++ b/test/gcloud/storage/bucket_test.rb
@@ -45,7 +45,7 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     bucket_complete.id.must_equal bucket_hash_complete["id"]
     bucket_complete.name.must_equal bucket_name
     bucket_complete.created_at.must_equal bucket_hash_complete["timeCreated"]
-    bucket_complete.url.must_equal bucket_url
+    bucket_complete.api_url.must_equal bucket_url
     bucket_complete.location.must_equal bucket_location
     bucket_complete.logging_bucket.must_equal bucket_logging_bucket
     bucket_complete.logging_prefix.must_equal bucket_logging_prefix
@@ -469,12 +469,11 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     end
 
     bucket = storage.bucket bucket_name
-    bucket.url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
+    bucket.api_url.must_equal "https://www.googleapis.com/storage/v1/b/#{bucket_name}"
 
     bucket.reload!
 
-    # replace url with a legitimately mutable attribute when issue #91 is closed.
-    bucket.url.must_equal "#{new_url_root}/b/#{bucket_name}"
+    bucket.api_url.must_equal "#{new_url_root}/b/#{bucket_name}"
   end
 
   def create_file_json bucket=nil, name = nil

--- a/test/gcloud/storage/file_test.rb
+++ b/test/gcloud/storage/file_test.rb
@@ -30,6 +30,7 @@ describe Gcloud::Storage::File, :mock_storage do
     file.name.must_equal file_hash["name"]
     file.created_at.must_equal file_hash["timeCreated"]
     file.api_url.must_equal file_hash["selfLink"]
+    file.media_url.must_equal file_hash["mediaLink"]
 
     file.md5.must_equal file_hash["md5Hash"]
     file.crc32c.must_equal file_hash["crc32c"]

--- a/test/gcloud/storage/file_test.rb
+++ b/test/gcloud/storage/file_test.rb
@@ -32,6 +32,7 @@ describe Gcloud::Storage::File, :mock_storage do
     file.api_url.must_equal file_hash["selfLink"]
     file.media_url.must_equal file_hash["mediaLink"]
     file.public_url.must_equal "https://storage.googleapis.com/#{file.bucket}/#{file.name}"
+    file.public_url(protocol: :http).must_equal "http://storage.googleapis.com/#{file.bucket}/#{file.name}"
     file.url.must_equal file.public_url
 
     file.md5.must_equal file_hash["md5Hash"]

--- a/test/gcloud/storage/file_test.rb
+++ b/test/gcloud/storage/file_test.rb
@@ -29,7 +29,7 @@ describe Gcloud::Storage::File, :mock_storage do
     file.id.must_equal file_hash["id"]
     file.name.must_equal file_hash["name"]
     file.created_at.must_equal file_hash["timeCreated"]
-    file.url.must_equal file_hash["selfLink"]
+    file.api_url.must_equal file_hash["selfLink"]
 
     file.md5.must_equal file_hash["md5Hash"]
     file.crc32c.must_equal file_hash["crc32c"]

--- a/test/gcloud/storage/file_test.rb
+++ b/test/gcloud/storage/file_test.rb
@@ -31,6 +31,8 @@ describe Gcloud::Storage::File, :mock_storage do
     file.created_at.must_equal file_hash["timeCreated"]
     file.api_url.must_equal file_hash["selfLink"]
     file.media_url.must_equal file_hash["mediaLink"]
+    file.public_url.must_equal "https://storage.googleapis.com/#{file.bucket}/#{file.name}"
+    file.url.must_equal file.public_url
 
     file.md5.must_equal file_hash["md5Hash"]
     file.crc32c.must_equal file_hash["crc32c"]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -46,7 +46,6 @@ class MockStorage < Minitest::Spec
     @connection
   end
 
-
   def random_bucket_hash(name=random_bucket_name,
     url_root="https://www.googleapis.com/storage/v1", location="US",
     storage_class="STANDARD", versioning=nil, logging_bucket=nil,


### PR DESCRIPTION
The attribute `selfLink` in the Storage and BigQuery APIs is the location of the resource in the API. We don't want to confuse this with a URL that is meant to be accessed by public users, so rename to make clear this URL is for the API only. Add a new method `public_url` to offer the public URL as described in the [storage documentation](https://cloud.google.com/storage/docs/access-public-data).

[refs #377]