### PR TITLE
Fix Storage ACL Helpers

### DIFF
--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -477,7 +477,8 @@ module Gcloud
 
         def update_predefined_acl! acl_role
           resp = @connection.patch_bucket @bucket,
-                                          acl: acl_role
+                                          predefined_acl: acl_role,
+                                          acl: []
 
           return clear! if resp.success?
           fail Gcloud::Storage::ApiError.from_response(resp)
@@ -974,7 +975,8 @@ module Gcloud
 
         def update_predefined_default_acl! acl_role
           resp = @connection.patch_bucket @bucket,
-                                          default_acl: acl_role
+                                          predefined_default_acl: acl_role,
+                                          default_acl: []
 
           return clear! if resp.success?
           fail Gcloud::Storage::ApiError.from_response(resp)

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -468,11 +468,19 @@ module Gcloud
 
         protected
 
+        def clear!
+          @owners  = nil
+          @writers = nil
+          @readers = nil
+          self
+        end
+
         def update_predefined_acl! acl_role
           resp = @connection.patch_bucket @bucket,
                                           acl: acl_role
 
-          resp.success?
+          return clear! if resp.success?
+          fail Gcloud::Storage::ApiError.from_response(resp)
         end
 
         def entities_from_acls acls, role
@@ -957,11 +965,19 @@ module Gcloud
 
         protected
 
+        def clear!
+          @owners  = nil
+          @writers = nil
+          @readers = nil
+          self
+        end
+
         def update_predefined_default_acl! acl_role
           resp = @connection.patch_bucket @bucket,
                                           default_acl: acl_role
 
-          resp.success?
+          return clear! if resp.success?
+          fail Gcloud::Storage::ApiError.from_response(resp)
         end
 
         def entities_from_acls acls, role

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -240,7 +240,7 @@ module Gcloud
       def patch_file bucket_name, file_path, options = {}
         params = { bucket: bucket_name,
                    object: file_path,
-                   predefinedAcl: options[:acl]
+                   predefinedAcl: options[:predefined_acl]
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(
@@ -395,7 +395,8 @@ module Gcloud
           "contentEncoding" => options[:content_encoding],
           "contentLanguage" => options[:content_language],
           "contentType" => options[:content_type],
-          "metadata" => options[:metadata]
+          "metadata" => options[:metadata],
+          "acl" => options[:acl]
         }.delete_if { |_, v| v.nil? }
       end
 

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -84,8 +84,8 @@ module Gcloud
       # Updates a bucket, including its ACL metadata.
       def patch_bucket bucket_name, options = {}
         params = { bucket: bucket_name,
-                   predefinedAcl: options[:acl],
-                   predefinedDefaultObjectAcl: options[:default_acl]
+                   predefinedAcl: options[:predefined_acl],
+                   predefinedDefaultObjectAcl: options[:predefined_default_acl]
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(
@@ -324,7 +324,9 @@ module Gcloud
           "cors" => options[:cors],
           "logging" => logging_config(options),
           "versioning" => versioning_config(options[:versioning]),
-          "website" => website_config(options)
+          "website" => website_config(options),
+          "acl" => options[:acl],
+          "defaultObjectAcl" => options[:default_acl]
         }.delete_if { |_, v| v.nil? }
       end
 

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -545,7 +545,8 @@ module Gcloud
 
         def update_predefined_acl! acl_role
           resp = @connection.patch_file @bucket, @file,
-                                        acl: acl_role
+                                        predefined_acl: acl_role,
+                                        acl: []
 
           return clear! if resp.success?
           fail Gcloud::Storage::ApiError.from_response(resp)

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -536,11 +536,19 @@ module Gcloud
 
         protected
 
+        def clear!
+          @owners  = nil
+          @writers = nil
+          @readers = nil
+          self
+        end
+
         def update_predefined_acl! acl_role
           resp = @connection.patch_file @bucket, @file,
                                         acl: acl_role
 
-          resp.success?
+          return clear! if resp.success?
+          fail Gcloud::Storage::ApiError.from_response(resp)
         end
 
         def entities_from_acls acls, role

--- a/test/gcloud/storage/bucket_acl_test.rb
+++ b/test/gcloud/storage/bucket_acl_test.rb
@@ -275,6 +275,7 @@ describe Gcloud::Storage::Bucket, :acl, :mock_storage do
   def predefined_acl_update acl_role
     mock_connection.patch "/storage/v1/b/#{bucket.name}" do |env|
       env.params["predefinedAcl"].must_equal acl_role
+      JSON.parse(env.body)["acl"].must_equal []
       [200, {"Content-Type"=>"application/json"},
        random_bucket_hash(bucket.name).to_json]
     end

--- a/test/gcloud/storage/bucket_acl_test.rb
+++ b/test/gcloud/storage/bucket_acl_test.rb
@@ -194,6 +194,84 @@ describe Gcloud::Storage::Bucket, :acl, :mock_storage do
     end
   end
 
+  it "raises when the predefined ACL rule authenticatedRead returns an error" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticatedRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule auth returns an error" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.auth!
+    end
+  end
+
+  it "raises when the predefined ACL rule auth_read returns an error" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.auth_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule authenticated returns an error" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticated!
+    end
+  end
+
+  it "raises when the predefined ACL rule authenticated_read returns an error" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticated_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule private returns an error" do
+    predefined_acl_update_with_error "private" do |acl|
+      acl.private!
+    end
+  end
+
+  it "raises when the predefined ACL rule projectPrivate returns an error" do
+    predefined_acl_update_with_error "projectPrivate" do |acl|
+      acl.projectPrivate!
+    end
+  end
+
+  it "raises when the predefined ACL rule project_private returns an error" do
+    predefined_acl_update_with_error "projectPrivate" do |acl|
+      acl.project_private!
+    end
+  end
+
+  it "raises when the predefined ACL rule publicRead returns an error" do
+    predefined_acl_update_with_error "publicRead" do |acl|
+      acl.publicRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule public returns an error" do
+    predefined_acl_update_with_error "publicRead" do |acl|
+      acl.public!
+    end
+  end
+
+  it "raises when the predefined ACL rule public_read returns an error" do
+    predefined_acl_update_with_error "publicRead" do |acl|
+      acl.public_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule publicReadWrite returns an error" do
+    predefined_acl_update_with_error "publicReadWrite" do |acl|
+      acl.publicReadWrite!
+    end
+  end
+
+  it "raises when the predefined ACL rule public_write returns an error" do
+    predefined_acl_update_with_error "publicReadWrite" do |acl|
+      acl.public_write!
+    end
+  end
+
   def predefined_acl_update acl_role
     mock_connection.patch "/storage/v1/b/#{bucket.name}" do |env|
       env.params["predefinedAcl"].must_equal acl_role
@@ -202,6 +280,16 @@ describe Gcloud::Storage::Bucket, :acl, :mock_storage do
     end
 
     yield bucket.acl
+  end
+
+  def predefined_acl_update_with_error acl_role
+    mock_connection.patch "/storage/v1/b/#{bucket.name}" do |env|
+      env.params["predefinedAcl"].must_equal acl_role
+      [409, {"Content-Type"=>"application/json"},
+       acl_error_json]
+    end
+
+    expect { yield bucket.acl }.must_raise Gcloud::Storage::ApiError
   end
 
   def random_bucket_acl_hash bucket_name
@@ -249,5 +337,19 @@ describe Gcloud::Storage::Bucket, :acl, :mock_storage do
       }
      ]
     }
+  end
+
+  def acl_error_json
+    {
+      "error" => {
+        "errors" => [ {
+          "domain" => "global",
+          "reason" => "conflict",
+          "message" => "Cannot provide both a predefinedAcl and access controls."
+        } ],
+        "code" => 409,
+        "message" => "Cannot provide both a predefinedAcl and access controls."
+      }
+    }.to_json
   end
 end

--- a/test/gcloud/storage/default_acl_test.rb
+++ b/test/gcloud/storage/default_acl_test.rb
@@ -299,6 +299,7 @@ describe Gcloud::Storage::Bucket, :default_acl, :mock_storage do
   def predefined_default_acl_update acl_role
     mock_connection.patch "/storage/v1/b/#{bucket.name}" do |env|
       env.params["predefinedDefaultObjectAcl"].must_equal acl_role
+      JSON.parse(env.body)["defaultObjectAcl"].must_equal []
       [200, {"Content-Type"=>"application/json"},
        random_bucket_hash(bucket.name).to_json]
     end

--- a/test/gcloud/storage/default_acl_test.rb
+++ b/test/gcloud/storage/default_acl_test.rb
@@ -206,6 +206,96 @@ describe Gcloud::Storage::Bucket, :default_acl, :mock_storage do
     end
   end
 
+  it "raises when the predefined ACL rule authenticatedRead returns an error" do
+    predefined_default_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticatedRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule auth returns an error" do
+    predefined_default_acl_update_with_error "authenticatedRead" do |acl|
+      acl.auth!
+    end
+  end
+
+  it "raises when the predefined ACL rule auth_read returns an error" do
+    predefined_default_acl_update_with_error "authenticatedRead" do |acl|
+      acl.auth_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule authenticated returns an error" do
+    predefined_default_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticated!
+    end
+  end
+
+  it "raises when the predefined ACL rule authenticated_read returns an error" do
+    predefined_default_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticated_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule bucketOwnerFullControl returns an error" do
+    predefined_default_acl_update_with_error "bucketOwnerFullControl" do |acl|
+      acl.bucketOwnerFullControl!
+    end
+  end
+
+  it "raises when the predefined ACL rule owner_full returns an error" do
+    predefined_default_acl_update_with_error "bucketOwnerFullControl" do |acl|
+      acl.owner_full!
+    end
+  end
+
+  it "raises when the predefined ACL rule bucketOwnerRead returns an error" do
+    predefined_default_acl_update_with_error "bucketOwnerRead" do |acl|
+      acl.bucketOwnerRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule owner_read returns an error" do
+    predefined_default_acl_update_with_error "bucketOwnerRead" do |acl|
+      acl.owner_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule private returns an error" do
+    predefined_default_acl_update_with_error "private" do |acl|
+      acl.private!
+    end
+  end
+
+  it "raises when the predefined ACL rule projectPrivate returns an error" do
+    predefined_default_acl_update_with_error "projectPrivate" do |acl|
+      acl.projectPrivate!
+    end
+  end
+
+  it "raises when the predefined ACL rule project_private returns an error" do
+    predefined_default_acl_update_with_error "projectPrivate" do |acl|
+      acl.project_private!
+    end
+  end
+
+  it "raises when the predefined ACL rule publicRead returns an error" do
+    predefined_default_acl_update_with_error "publicRead" do |acl|
+      acl.publicRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule public returns an error" do
+    predefined_default_acl_update_with_error "publicRead" do |acl|
+      acl.public!
+    end
+  end
+
+  it "raises when the predefined ACL rule public_read returns an error" do
+    predefined_default_acl_update_with_error "publicRead" do |acl|
+      acl.public_read!
+    end
+  end
+
   def predefined_default_acl_update acl_role
     mock_connection.patch "/storage/v1/b/#{bucket.name}" do |env|
       env.params["predefinedDefaultObjectAcl"].must_equal acl_role
@@ -214,6 +304,16 @@ describe Gcloud::Storage::Bucket, :default_acl, :mock_storage do
     end
 
     yield bucket.default_acl
+  end
+
+  def predefined_default_acl_update_with_error acl_role
+    mock_connection.patch "/storage/v1/b/#{bucket.name}" do |env|
+      env.params["predefinedDefaultObjectAcl"].must_equal acl_role
+      [409, {"Content-Type"=>"application/json"},
+       acl_error_json]
+    end
+
+    expect { yield bucket.default_acl }.must_raise Gcloud::Storage::ApiError
   end
 
   def random_default_acl_hash bucket_name
@@ -252,5 +352,19 @@ describe Gcloud::Storage::Bucket, :default_acl, :mock_storage do
       }
      ]
     }
+  end
+
+  def acl_error_json
+    {
+      "error" => {
+        "errors" => [ {
+          "domain" => "global",
+          "reason" => "conflict",
+          "message" => "Cannot provide both a predefinedAcl and access controls."
+        } ],
+        "code" => 409,
+        "message" => "Cannot provide both a predefinedAcl and access controls."
+      }
+    }.to_json
   end
 end

--- a/test/gcloud/storage/file_acl_test.rb
+++ b/test/gcloud/storage/file_acl_test.rb
@@ -290,6 +290,96 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
     end
   end
 
+  it "raises when the predefined ACL rule authenticatedRead returns an error" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticatedRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule auth" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.auth!
+    end
+  end
+
+  it "raises when the predefined ACL rule auth_read" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.auth_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule authenticated" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticated!
+    end
+  end
+
+  it "raises when the predefined ACL rule authenticated_read" do
+    predefined_acl_update_with_error "authenticatedRead" do |acl|
+      acl.authenticated_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule bucketOwnerFullControl" do
+    predefined_acl_update_with_error "bucketOwnerFullControl" do |acl|
+      acl.bucketOwnerFullControl!
+    end
+  end
+
+  it "raises when the predefined ACL rule owner_full" do
+    predefined_acl_update_with_error "bucketOwnerFullControl" do |acl|
+      acl.owner_full!
+    end
+  end
+
+  it "raises when the predefined ACL rule bucketOwnerRead" do
+    predefined_acl_update_with_error "bucketOwnerRead" do |acl|
+      acl.bucketOwnerRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule owner_read" do
+    predefined_acl_update_with_error "bucketOwnerRead" do |acl|
+      acl.owner_read!
+    end
+  end
+
+  it "raises when the predefined ACL rule private" do
+    predefined_acl_update_with_error "private" do |acl|
+      acl.private!
+    end
+  end
+
+  it "raises when the predefined ACL rule projectPrivate" do
+    predefined_acl_update_with_error "projectPrivate" do |acl|
+      acl.projectPrivate!
+    end
+  end
+
+  it "raises when the predefined ACL rule project_private" do
+    predefined_acl_update_with_error "projectPrivate" do |acl|
+      acl.project_private!
+    end
+  end
+
+  it "raises when the predefined ACL rule publicRead" do
+    predefined_acl_update_with_error "publicRead" do |acl|
+      acl.publicRead!
+    end
+  end
+
+  it "raises when the predefined ACL rule public" do
+    predefined_acl_update_with_error "publicRead" do |acl|
+      acl.public!
+    end
+  end
+
+  it "raises when the predefined ACL rule public_read" do
+    predefined_acl_update_with_error "publicRead" do |acl|
+      acl.public_read!
+    end
+  end
+
   def predefined_acl_update acl_role
     mock_connection.patch "/storage/v1/b/#{bucket_name}/o/#{file_name}" do |env|
       env.params["predefinedAcl"].must_equal acl_role
@@ -298,6 +388,16 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
     end
 
     yield file.acl
+  end
+
+  def predefined_acl_update_with_error acl_role
+    mock_connection.patch "/storage/v1/b/#{bucket_name}/o/#{file_name}" do |env|
+      env.params["predefinedAcl"].must_equal acl_role
+      [409, {"Content-Type"=>"application/json"},
+       acl_error_json]
+    end
+
+    expect { yield file.acl }.must_raise Gcloud::Storage::ApiError
   end
 
   def random_file_acl_hash bucket_name, file_name
@@ -363,5 +463,19 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
       }
      ]
     }
+  end
+
+  def acl_error_json
+    {
+      "error" => {
+        "errors" => [ {
+          "domain" => "global",
+          "reason" => "conflict",
+          "message" => "Cannot provide both a predefinedAcl and access controls."
+        } ],
+        "code" => 409,
+        "message" => "Cannot provide both a predefinedAcl and access controls."
+      }
+    }.to_json
   end
 end

--- a/test/gcloud/storage/file_acl_test.rb
+++ b/test/gcloud/storage/file_acl_test.rb
@@ -383,6 +383,7 @@ describe Gcloud::Storage::File, :acl, :mock_storage do
   def predefined_acl_update acl_role
     mock_connection.patch "/storage/v1/b/#{bucket_name}/o/#{file_name}" do |env|
       env.params["predefinedAcl"].must_equal acl_role
+      JSON.parse(env.body)["acl"].must_equal []
       [200, {"Content-Type"=>"application/json"},
        random_file_hash(bucket_name, file_name).to_json]
     end


### PR DESCRIPTION
The ACL helpers were not working and returning the following error:

> `Cannot provide both a predefinedAcl and access controls.`

This is because the `predefinedAcl` rule was being set and the existing acl rules were not being overridden. The fix is to provide empty rules so the `predefinedAcl` rule can be applied. This has been done for Bucket ACL, Bucket Default ACL, and File ACL.

[closes #381]