### PR TITLE
Acceptance Retry

### DIFF
--- a/acceptance/bigquery_helper.rb
+++ b/acceptance/bigquery_helper.rb
@@ -63,6 +63,16 @@ module Acceptance
       addl.include? :bigquery
     end
   end
+
+  def self.run_one_method klass, method_name, reporter
+    result = nil
+    (1..3).each do |try|
+      result = Minitest.run_one_method(klass, method_name)
+      break if result.passed?
+      puts "Retrying #{klass}##{method_name} (#{try})"
+    end
+    reporter.record result
+  end
 end
 
 def clean_up_bigquery_datasets

--- a/acceptance/datastore_helper.rb
+++ b/acceptance/datastore_helper.rb
@@ -35,5 +35,15 @@ module Acceptance
     register_spec_type(self) do |desc, *addl|
       addl.include? :datastore
     end
+
+    def self.run_one_method klass, method_name, reporter
+      result = nil
+      (1..3).each do |try|
+        result = Minitest.run_one_method(klass, method_name)
+        break if result.passed?
+        puts "Retrying #{klass}##{method_name} (#{try})"
+      end
+      reporter.record result
+    end
   end
 end

--- a/acceptance/dns_helper.rb
+++ b/acceptance/dns_helper.rb
@@ -66,6 +66,16 @@ if ENV["GCLOUD_TEST_DNS_DOMAIN"]
         addl.include? :dns
       end
     end
+
+    def self.run_one_method klass, method_name, reporter
+      result = nil
+      (1..3).each do |try|
+        result = Minitest.run_one_method(klass, method_name)
+        break if result.passed?
+        puts "Retrying #{klass}##{method_name} (#{try})"
+      end
+      reporter.record result
+    end
   end
 
   def clean_up_dns_zones

--- a/acceptance/pubsub_helper.rb
+++ b/acceptance/pubsub_helper.rb
@@ -53,6 +53,16 @@ module Acceptance
     register_spec_type(self) do |desc, *addl|
       addl.include? :pubsub
     end
+
+    def self.run_one_method klass, method_name, reporter
+      result = nil
+      (1..3).each do |try|
+        result = Minitest.run_one_method(klass, method_name)
+        break if result.passed?
+        puts "Retrying #{klass}##{method_name} (#{try})"
+      end
+      reporter.record result
+    end
   end
 end
 

--- a/acceptance/storage_helper.rb
+++ b/acceptance/storage_helper.rb
@@ -66,6 +66,16 @@ module Acceptance
       addl.include? :storage
     end
   end
+
+  def self.run_one_method klass, method_name, reporter
+    result = nil
+    (1..3).each do |try|
+      result = Minitest.run_one_method(klass, method_name)
+      break if result.passed?
+      puts "Retrying #{klass}##{method_name} (#{try})"
+    end
+    reporter.record result
+  end
 end
 
 # Create buckets to be shared with all the tests


### PR DESCRIPTION
The acceptance tests work against the production services. Sometimes the
services present their eventually consistent nature and return results that
are not yet correct. Try rerunning failed tests instead of rerunning the
entire test suite.