### PR TITLE
Make delegate dependency explicit

### DIFF
--- a/lib/gcloud/bigquery/data.rb
+++ b/lib/gcloud/bigquery/data.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Bigquery
     ##

--- a/lib/gcloud/bigquery/dataset/list.rb
+++ b/lib/gcloud/bigquery/dataset/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Bigquery
     class Dataset

--- a/lib/gcloud/bigquery/job/list.rb
+++ b/lib/gcloud/bigquery/job/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Bigquery
     class Job

--- a/lib/gcloud/bigquery/table/list.rb
+++ b/lib/gcloud/bigquery/table/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Bigquery
     class Table

--- a/lib/gcloud/datastore/dataset/lookup_results.rb
+++ b/lib/gcloud/datastore/dataset/lookup_results.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Datastore
     class Dataset

--- a/lib/gcloud/datastore/dataset/query_results.rb
+++ b/lib/gcloud/datastore/dataset/query_results.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Datastore
     class Dataset

--- a/lib/gcloud/dns/change/list.rb
+++ b/lib/gcloud/dns/change/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Dns
     class Change

--- a/lib/gcloud/dns/record/list.rb
+++ b/lib/gcloud/dns/record/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Dns
     class Record

--- a/lib/gcloud/dns/zone/list.rb
+++ b/lib/gcloud/dns/zone/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Dns
     class Zone

--- a/lib/gcloud/pubsub/subscription/list.rb
+++ b/lib/gcloud/pubsub/subscription/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Pubsub
     class Subscription

--- a/lib/gcloud/pubsub/topic/list.rb
+++ b/lib/gcloud/pubsub/topic/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Pubsub
     class Topic

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Storage
     class Bucket

--- a/lib/gcloud/storage/bucket/list.rb
+++ b/lib/gcloud/storage/bucket/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Storage
     class Bucket

--- a/lib/gcloud/storage/file/list.rb
+++ b/lib/gcloud/storage/file/list.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "delegate"
+
 module Gcloud
   module Storage
     class File


### PR DESCRIPTION
The class DelegateClass was being used without the delegate lib being required.
The lib was being required by a dependency, but the dependency should be explicit
in the code. Add the missing require.

[closed #403]