### PR TITLE
Datastore Helpers

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -62,7 +62,7 @@ demo_task[:completed] = false
 dataset.save demo_task
 
 # Run a query for all completed tasks
-query = Gcloud::Datastore::Query.new.kind("Task").
+query = dataset.query("Task").
   where("completed", "=", true)
 completed_tasks = dataset.run query
 ```

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -53,10 +53,11 @@ gcloud = Gcloud.new
 dataset = gcloud.datastore
 
 # Create a new task to demo datastore
-demo_task = Gcloud::Datastore::Entity.new
-demo_task.key = dataset.key "Task", "datastore-demo"
-demo_task[:description] = "Demonstrate Datastore functionality"
-demo_task[:completed] = false
+demo_task = dataset.entity do |e|
+  e.key = dataset.key "Task", "datastore-demo"
+  e["description"] = "Demonstrate Datastore functionality"
+  e["completed"] = false
+end
 
 # Save the new task
 dataset.save demo_task

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -54,7 +54,7 @@ dataset = gcloud.datastore
 
 # Create a new task to demo datastore
 demo_task = Gcloud::Datastore::Entity.new
-demo_task.key = Gcloud::Datastore::Key.new "Task", "datastore-demo"
+demo_task.key = dataset.key "Task", "datastore-demo"
 demo_task[:description] = "Demonstrate Datastore functionality"
 demo_task[:completed] = false
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -53,10 +53,9 @@ gcloud = Gcloud.new
 dataset = gcloud.datastore
 
 # Create a new task to demo datastore
-demo_task = dataset.entity do |e|
-  e.key = dataset.key "Task", "datastore-demo"
-  e["description"] = "Demonstrate Datastore functionality"
-  e["completed"] = false
+demo_task = dataset.entity "Task", "datastore-demo" do |t|
+  t["description"] = "Demonstrate Datastore functionality"
+  t["completed"] = false
 end
 
 # Save the new task

--- a/README.md
+++ b/README.md
@@ -82,10 +82,9 @@ gcloud = Gcloud.new "my-todo-project-id",
 dataset = gcloud.datastore
 
 # Create a new task to demo datastore
-demo_task = dataset.entity do |e|
-  e.key = dataset.key "Task", "datastore-demo"
-  e["description"] = "Demonstrate Datastore functionality"
-  e["completed"] = false
+demo_task = dataset.entity "Task", "datastore-demo" do |t|
+  t["description"] = "Demonstrate Datastore functionality"
+  t["completed"] = false
 end
 
 # Save the new task

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ gcloud = Gcloud.new "my-todo-project-id",
 dataset = gcloud.datastore
 
 # Create a new task to demo datastore
-demo_task = Gcloud::Datastore::Entity.new
-demo_task.key = dataset.key "Task", "datastore-demo"
-demo_task[:description] = "Demonstrate Datastore functionality"
-demo_task[:completed] = false
+demo_task = dataset.entity do |e|
+  e.key = dataset.key "Task", "datastore-demo"
+  e["description"] = "Demonstrate Datastore functionality"
+  e["completed"] = false
+end
 
 # Save the new task
 dataset.save demo_task

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ dataset = gcloud.datastore
 
 # Create a new task to demo datastore
 demo_task = Gcloud::Datastore::Entity.new
-demo_task.key = Gcloud::Datastore::Key.new "Task", "datastore-demo"
+demo_task.key = dataset.key "Task", "datastore-demo"
 demo_task[:description] = "Demonstrate Datastore functionality"
 demo_task[:completed] = false
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ demo_task[:completed] = false
 dataset.save demo_task
 
 # Run a query for all completed tasks
-query = Gcloud::Datastore::Query.new.kind("Task").
+query = dataset.query("Task").
   where("completed", "=", true)
 completed_tasks = dataset.run query
 ```

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -96,7 +96,7 @@ module Gcloud
   #   gcloud  = Gcloud.new
   #   dataset = gcloud.datastore
   #
-  #   entity = Gcloud::Datastore::Entity.new
+  #   entity = dataset.entity
   #   entity.key = dataset.key "Task"
   #   entity["description"] = "Get started with Google Cloud"
   #   entity["completed"] = false

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -96,10 +96,10 @@ module Gcloud
   #   gcloud  = Gcloud.new
   #   dataset = gcloud.datastore
   #
-  #   entity = dataset.entity
-  #   entity.key = dataset.key "Task"
-  #   entity["description"] = "Get started with Google Cloud"
-  #   entity["completed"] = false
+  #   entity = dataset.entity "Task" do |t|
+  #     t["description"] = "Get started with Google Cloud"
+  #     t["completed"] = false
+  #   end
   #
   #   dataset.save entity
   #

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -97,7 +97,7 @@ module Gcloud
   #   dataset = gcloud.datastore
   #
   #   entity = Gcloud::Datastore::Entity.new
-  #   entity.key = Gcloud::Datastore::Key.new "Task"
+  #   entity.key = dataset.key "Task"
   #   entity["description"] = "Get started with Google Cloud"
   #   entity["completed"] = false
   #

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -58,7 +58,7 @@ module Gcloud
   #                              "/path/to/keyfile.json"
   #
   #   entity = Gcloud::Datastore::Entity.new
-  #   entity.key = Gcloud::Datastore::Key.new "Task"
+  #   entity.key = dataset.key "Task"
   #   entity["description"] = "Get started with Google Cloud"
   #   entity["completed"] = false
   #
@@ -125,7 +125,7 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   key = Gcloud::Datastore::Key.new "Task", 12345
+  #   key = dataset.key "Task", 12345
   #   entity = dataset.find key
   #
   # See Gcloud::Datastore::Dataset#find
@@ -224,7 +224,7 @@ module Gcloud
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
   #   entity = Gcloud::Datastore::Entity.new
-  #   entity.key = Gcloud::Datastore::Key.new "User"
+  #   entity.key = dataset.key "User"
   #   entity["name"] = "Heidi Henderson"
   #   entity.key.id #=> nil
   #   dataset.save entity
@@ -272,7 +272,7 @@ module Gcloud
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
   #
-  #   key = Gcloud::Datastore::Key.new "User", "heidi"
+  #   key = dataset.key "User", "heidi"
   #
   #   user = Gcloud::Datastore::Entity.new
   #   user.key = key
@@ -293,7 +293,7 @@ module Gcloud
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
   #
-  #   key = Gcloud::Datastore::Key.new "User", "heidi"
+  #   key = dataset.key "User", "heidi"
   #
   #   user = Gcloud::Datastore::Entity.new
   #   user.key = key

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -139,8 +139,7 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   query = Gcloud::Datastore::Query.new
-  #   query.kind("List").
+  #   query = dataset.query("List").
   #     where("active", "=", true)
   #   active_lists = dataset.run query
   #
@@ -150,8 +149,7 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   query = Gcloud::Datastore::Query.new
-  #   query.kind("List").
+  #   query = dataset.query("List").
   #     where("active", "=", true).
   #     order("name")
   #   active_lists = dataset.run query
@@ -163,8 +161,7 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   query = Gcloud::Datastore::Query.new
-  #   query.kind("List").
+  #   query = dataset.query("List").
   #     where("active", "=", true).
   #     order("name").
   #     limit(5)
@@ -179,8 +176,7 @@ module Gcloud
   #   dataset = gcloud.datastore
   #
   #   list = dataset.find "List", "todos"
-  #   query = Gcloud::Datastore::Query.new
-  #   query.kind("Task").
+  #   query = dataset.query("Task").
   #     ancestor(list.key)
   #   items = dataset.run query
   #
@@ -198,8 +194,7 @@ module Gcloud
   #   dataset = gcloud.datastore
   #
   #   list = dataset.find "List", "todos"
-  #   query = Gcloud::Datastore::Query.new
-  #   query.kind("Task").
+  #   query = dataset.query("Task").
   #     ancestor(list.key)
   #   all_tasks = []
   #   tmp_tasks = dataset.run query

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -57,7 +57,7 @@ module Gcloud
   #   dataset = Gcloud.datastore "my-todo-project",
   #                              "/path/to/keyfile.json"
   #
-  #   entity = Gcloud::Datastore::Entity.new
+  #   entity = dataset.entity
   #   entity.key = dataset.key "Task"
   #   entity["description"] = "Get started with Google Cloud"
   #   entity["completed"] = false
@@ -223,7 +223,7 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   entity = Gcloud::Datastore::Entity.new
+  #   entity = dataset.entity
   #   entity.key = dataset.key "User"
   #   entity["name"] = "Heidi Henderson"
   #   entity.key.id #=> nil
@@ -274,7 +274,7 @@ module Gcloud
   #
   #   key = dataset.key "User", "heidi"
   #
-  #   user = Gcloud::Datastore::Entity.new
+  #   user = dataset.entity
   #   user.key = key
   #   user["name"] = "Heidi Henderson"
   #   user["email"] = "heidi@example.net"
@@ -295,7 +295,7 @@ module Gcloud
   #
   #   key = dataset.key "User", "heidi"
   #
-  #   user = Gcloud::Datastore::Entity.new
+  #   user = dataset.entity
   #   user.key = key
   #   user["name"] = "Heidi Henderson"
   #   user["email"] = "heidi@example.net"

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -57,10 +57,10 @@ module Gcloud
   #   dataset = Gcloud.datastore "my-todo-project",
   #                              "/path/to/keyfile.json"
   #
-  #   entity = dataset.entity
-  #   entity.key = dataset.key "Task"
-  #   entity["description"] = "Get started with Google Cloud"
-  #   entity["completed"] = false
+  #   entity = dataset.entity "Task" do |t|
+  #     t["description"] = "Get started with Google Cloud"
+  #     t["completed"] = false
+  #   end
   #
   #   dataset.save entity
   #
@@ -223,9 +223,9 @@ module Gcloud
   #
   #   gcloud = Gcloud.new
   #   dataset = gcloud.datastore
-  #   entity = dataset.entity
-  #   entity.key = dataset.key "User"
-  #   entity["name"] = "Heidi Henderson"
+  #   entity = dataset.entity "User" do |e|
+  #     e["name"] = "Heidi Henderson"
+  #   end
   #   entity.key.id #=> nil
   #   dataset.save entity
   #   entity.key.id #=> 123456789
@@ -274,10 +274,10 @@ module Gcloud
   #
   #   key = dataset.key "User", "heidi"
   #
-  #   user = dataset.entity
-  #   user.key = key
-  #   user["name"] = "Heidi Henderson"
-  #   user["email"] = "heidi@example.net"
+  #   user = dataset.entity key do |u|
+  #     u["name"] = "Heidi Henderson"
+  #     u["email"] = "heidi@example.net"
+  #   end
   #
   #   dataset.transaction do |tx|
   #     if tx.find(user.key).nil?
@@ -295,10 +295,10 @@ module Gcloud
   #
   #   key = dataset.key "User", "heidi"
   #
-  #   user = dataset.entity
-  #   user.key = key
-  #   user["name"] = "Heidi Henderson"
-  #   user["email"] = "heidi@example.net"
+  #   user = dataset.entity key do |u|
+  #     u["name"] = "Heidi Henderson"
+  #     u["email"] = "heidi@example.net"
+  #   end
   #
   #   tx = dataset.transaction
   #   begin

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -39,7 +39,7 @@ module Gcloud
     #   gcloud = Gcloud.new
     #   dataset = gcloud.datastore
     #
-    #   query = Gcloud::Datastore::Query.new.kind("Task").
+    #   query = dataset.query("Task").
     #     where("completed", "=", true)
     #
     #   tasks = dataset.run query
@@ -246,7 +246,7 @@ module Gcloud
       #
       # === Example
       #
-      #   query = Gcloud::Datastore::Query.new.kind("Task").
+      #   query = dataset.query("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query
       #
@@ -319,6 +319,38 @@ module Gcloud
           tx.rollback
           raise TransactionError.new("Transaction failed to commit.", e)
         end
+      end
+
+      ##
+      # Create a new Query instance. This is a convenience method to make the
+      # creation of Query objects easier.
+      #
+      # === Parameters
+      #
+      # +kinds+::
+      #   The kind of entities to query. This is optional. (+String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Datastore::Query
+      #
+      # === Example
+      #
+      #   query = dataset.query("Task").
+      #     where("completed", "=", true)
+      #   tasks = dataset.run query
+      #
+      # This code is equivalent to the following:
+      #
+      #   query = Gcloud::Datastore::Query.new.
+      #     kind("Task").
+      #     where("completed", "=", true)
+      #   tasks = dataset.run query
+      #
+      def query *kinds
+        query = Query.new
+        query.kind(*kinds) unless kinds.empty?
+        query
       end
 
       protected

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -368,11 +368,11 @@ module Gcloud
       #
       # === Example
       #
-      #   key = dataset.key "User", "username"
+      #   key = dataset.key "User", "heidi@example.com"
       #
       # This code is equivalent to the following:
       #
-      #   key = Gcloud::Datastore::Key.new "User", "username"
+      #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
       def key kind = nil, id_or_name = nil
         Key.new kind, id_or_name
@@ -405,28 +405,28 @@ module Gcloud
       #
       # The key can also be passed in as an object:
       #
-      #   key = dataset.key "User", "username"
+      #   key = dataset.key "User", "heidi@example.com"
       #   entity = dataset.entity key
       #
       # Or the key values can be passed in as parameters:
       #
-      #   entity = dataset.entity "User", "username"
+      #   entity = dataset.entity "User", "heidi@example.com"
       #
       # This code is equivalent to the following:
       #
-      #   key = Gcloud::Datastore::Key.new "User", "username"
+      #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   entity = Gcloud::Datastore::Entity.new
       #   entity.key = key
       #
       # The newly created entity object can also be configured using a block:
       #
-      #   user = dataset.entity "User", "username" do |u|
+      #   user = dataset.entity "User", "heidi@example.com" do |u|
       #     u["name"] = "Heidi Henderson"
       #  end
       #
       # This code is equivalent to the following:
       #
-      #   key = Gcloud::Datastore::Key.new "User", "username"
+      #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   entity = Gcloud::Datastore::Entity.new
       #   entity.key = key
       #   entity["name"] = "Heidi Henderson"

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -273,7 +273,7 @@ module Gcloud
       #
       #   key = dataset.key "User", "heidi"
       #
-      #   user = Gcloud::Datastore::Entity.new
+      #   user = dataset.entity
       #   user.key = key
       #   user["name"] = "Heidi Henderson"
       #   user["email"] = "heidi@example.net"
@@ -293,7 +293,7 @@ module Gcloud
       #
       #   key = dataset.key "User", "heidi"
       #
-      #   user = Gcloud::Datastore::Entity.new
+      #   user = dataset.entity
       #   user.key = key
       #   user["name"] = "Heidi Henderson"
       #   user["email"] = "heidi@example.net"
@@ -378,6 +378,36 @@ module Gcloud
       #
       def key kind = nil, id_or_name = nil
         Key.new kind, id_or_name
+      end
+
+      ##
+      # Create a new empty Entity instance. This is a convenience method to make
+      # the creation of Entity objects easier.
+      #
+      # === Returns
+      #
+      # Gcloud::Datastore::Entity
+      #
+      # === Examples
+      #
+      #   entity = dataset.entity
+      #
+      # This code is equivalent to the following:
+      #
+      #   entity = Gcloud::Datastore::Entity.new
+      #
+      # The newly created entity object can be configured by passing a block:
+      #
+      #   demo_task = dataset.entity do |e|
+      #     e.key = dataset.key "Task", "datastore-demo"
+      #     e[:description] = "Demonstrate Datastore functionality"
+      #     e[:completed] = false
+      #  end
+      #
+      def entity
+        entity = Entity.new
+        yield entity if block_given?
+        entity
       end
 
       protected

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -101,7 +101,7 @@ module Gcloud
       #
       # === Example
       #
-      #   empty_key = Gcloud::Datastore::Key.new "Task"
+      #   empty_key = dataset.key "Task"
       #   task_keys = dataset.allocate_ids empty_key, 5
       #
       def allocate_ids incomplete_key, count = 1
@@ -160,7 +160,7 @@ module Gcloud
       #
       # Finding an entity with a key:
       #
-      #   key = Gcloud::Datastore::Key.new "Task", 123456
+      #   key = dataset.key "Task", 123456
       #   task = dataset.find key
       #
       # Finding an entity with a +kind+ and +id+/+name+:
@@ -190,8 +190,8 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   key1 = Gcloud::Datastore::Key.new "Task", 123456
-      #   key2 = Gcloud::Datastore::Key.new "Task", 987654
+      #   key1 = dataset.key "Task", 123456
+      #   key2 = dataset.key "Task", 987654
       #   tasks = dataset.find_all key1, key2
       #
       def find_all *keys
@@ -271,7 +271,7 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
       #
-      #   key = Gcloud::Datastore::Key.new "User", "heidi"
+      #   key = dataset.key "User", "heidi"
       #
       #   user = Gcloud::Datastore::Entity.new
       #   user.key = key
@@ -291,7 +291,7 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
       #
-      #   key = Gcloud::Datastore::Key.new "User", "heidi"
+      #   key = dataset.key "User", "heidi"
       #
       #   user = Gcloud::Datastore::Entity.new
       #   user.key = key
@@ -351,6 +351,33 @@ module Gcloud
         query = Query.new
         query.kind(*kinds) unless kinds.empty?
         query
+      end
+
+      ##
+      # Create a new Key instance. This is a convenience method to make the
+      # creation of Key objects easier.
+      #
+      # === Parameters
+      #
+      # +kind+::
+      #   The kind of the Key. This is optional. (+String+)
+      # +id_or_name+::
+      #   The id or name of the Key. This is optional. (+Integer+ or +String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Datastore::Key
+      #
+      # === Example
+      #
+      #   key = dataset.key "User", "username"
+      #
+      # This code is equivalent to the following:
+      #
+      #   key = dataset.key "User", "username"
+      #
+      def key kind = nil, id_or_name = nil
+        Key.new kind, id_or_name
       end
 
       protected

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -26,9 +26,9 @@ module Gcloud
     # Every Entity has a Key, and a list of properties.
     #
     #   entity = Gcloud::Datastore::Entity.new
-    #   entity.key = Gcloud::Datastore::Key.new "User", "username"
-    #   entity["name"] = "User McUser"
-    #   entity["email"] = "user@example.net"
+    #   entity.key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
+    #   entity["name"] = "Heidi Henderson"
+    #
     class Entity
       ##
       # The Key that identifies the entity.
@@ -62,7 +62,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = dataset.find "User", "heidi"
+      #   user = dataset.find "User", "heidi@example.com"
       #   user["name"] #=> "Heidi Henderson"
       #
       # Or with a symbol name:
@@ -71,7 +71,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = dataset.find "User", "heidi"
+      #   user = dataset.find "User", "heidi@example.com"
       #   user[:name] #=> "Heidi Henderson"
       #
       def [] prop_name
@@ -96,7 +96,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = dataset.find "User", "heidi"
+      #   user = dataset.find "User", "heidi@example.com"
       #   user["name"] = "Heidi H. Henderson"
       #
       # Or with a symbol name:
@@ -105,7 +105,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   user = dataset.find "User", "heidi"
+      #   user = dataset.find "User", "heidi@example.com"
       #   user[:name] = "Heidi H. Henderson"
       #
       def []= prop_name, prop_value
@@ -122,8 +122,8 @@ module Gcloud
       #
       # === Example
       #
-      #   entity.properties[:name] = "User McUser"
-      #   entity.properties["name"] #=> "User McUser"
+      #   entity.properties[:name] = "Heidi H. Henderson"
+      #   entity.properties["name"] #=> "Heidi H. Henderson"
       #
       #   entity.properties.each do |name, value|
       #     puts "property #{name} has a value of #{value}"
@@ -168,7 +168,7 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
-      #   entity = dataset.find "User", "heidi"
+      #   entity = dataset.find "User", "heidi@example.com"
       #   entity.persisted? #=> true
       #   entity.key = Gcloud::Datastore::Key.new "User" #=> RuntimeError
       #   entity.key.frozen? #=> true
@@ -192,7 +192,7 @@ module Gcloud
       #   new_entity = Gcloud::Datastore::Entity.new
       #   new_entity.persisted? #=> false
       #
-      #   found_entity = dataset.find "User", "heidi"
+      #   found_entity = dataset.find "User", "heidi@example.com"
       #   found_entity.persisted? #=> true
       #
       def persisted?

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -196,8 +196,7 @@ module Gcloud
       #   dataset = gcloud.datastore
       #
       #   user = dataset.find "User", "heidi"
-      #   query = Gcloud::Datastore::Query.new
-      #   query.kind("List").
+      #   query = dataset.query("List").
       #     ancestor(user.key)
       #   lists = dataset.run query
       #   lists.first.key.parent #=> Key("User", "heidi")

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -25,7 +25,7 @@ module Gcloud
     # name string, assigned explicitly by the application, or an integer numeric
     # ID, assigned automatically by Datastore.
     #
-    #   key = Gcloud::Datastore::Key.new "User", "username"
+    #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
     class Key
       ##
       # The kind of the Key.
@@ -57,7 +57,7 @@ module Gcloud
       #                       "/path/to/keyfile.json"
       #
       #   dataset = gcloud.datastore
-      #   entity = dataset.find "User", "heidi"
+      #   entity = dataset.find "User", "heidi@example.com"
       #   entity.key.dataset_id #=> "my-todo-project"
       #
       attr_accessor :dataset_id
@@ -77,7 +77,7 @@ module Gcloud
       #                       "/path/to/keyfile.json"
       #
       #   dataset = gcloud.datastore
-      #   entity = dataset.find "User", "heidi"
+      #   entity = dataset.find "User", "heidi@example.com"
       #   entity.key.namespace #=> "ns~todo-project"
       #
       attr_accessor :namespace
@@ -98,7 +98,7 @@ module Gcloud
       #
       # === Example
       #
-      #   key = Gcloud::Datastore::Key.new "User", "username"
+      #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
       def initialize kind = nil, id_or_name = nil
         @kind = kind
@@ -119,9 +119,9 @@ module Gcloud
       #
       # === Example
       #
-      #   key = Gcloud::Datastore::Key.new "User", "heidi"
+      #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   key.id #=> nil
-      #   key.name #=> "heidi"
+      #   key.name #=> "heidi@example.com"
       #   key.id = 654321
       #   key.id #=> 654321
       #   key.name #=> nil
@@ -158,9 +158,9 @@ module Gcloud
       #   key = Gcloud::Datastore::Key.new "User", 123456
       #   key.id #=> 123456
       #   key.name #=> nil
-      #   key.name = "heidi"
+      #   key.name = "heidi@example.com"
       #   key.id #=> nil
-      #   key.name #=> "heidi"
+      #   key.name #=> "heidi@example.com"
       #
       def name= new_name #:nodoc:
         @id = nil if new_name
@@ -176,8 +176,8 @@ module Gcloud
       #
       # === Example
       #
-      #   key = Gcloud::Datastore::Key.new "User", "heidi"
-      #   key.name #=> "heidi"
+      #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
+      #   key.name #=> "heidi@example.com"
       #
       attr_reader :name
 
@@ -191,7 +191,7 @@ module Gcloud
       # === Example
       #
       #   key = Gcloud::Datastore::Key.new "List", "todos"
-      #   key.parent = Gcloud::Datastore::Key.new "User", "heidi"
+      #   key.parent = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
       def parent= new_parent #:nodoc:
         # store key if given an entity
@@ -213,11 +213,11 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
       #
-      #   user = dataset.find "User", "heidi"
+      #   user = dataset.find "User", "heidi@example.com"
       #   query = dataset.query("List").
       #     ancestor(user.key)
       #   lists = dataset.run query
-      #   lists.first.key.parent #=> Key("User", "heidi")
+      #   lists.first.key.parent #=> Key("User", "heidi@example.com")
       #
       attr_reader :parent
 
@@ -233,8 +233,8 @@ module Gcloud
       # === Example
       #
       #   key = Gcloud::Datastore::Key.new "List", "todos"
-      #   key.parent = Gcloud::Datastore::Key.new "User", "heidi"
-      #   key.path #=> [["User", "heidi"], ["List", "todos"]]
+      #   key.parent = Gcloud::Datastore::Key.new "User", "heidi@example.com"
+      #   key.path #=> [["User", "heidi@example.com"], ["List", "todos"]]
       #
       def path
         new_path = parent ? parent.path : []

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -82,6 +82,24 @@ module Gcloud
       #
       attr_accessor :namespace
 
+      ##
+      # Create a new Key instance.
+      #
+      # === Parameters
+      #
+      # +kind+::
+      #   The kind of the Key. This is optional. (+String+)
+      # +id_or_name+::
+      #   The id or name of the Key. This is optional. (+Integer+ or +String+)
+      #
+      # === Returns
+      #
+      # Gcloud::Datastore::Dataset::Key
+      #
+      # === Example
+      #
+      #   key = Gcloud::Datastore::Key.new "User", "username"
+      #
       def initialize kind = nil, id_or_name = nil
         @kind = kind
         if id_or_name.is_a? Integer

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -347,13 +347,48 @@ describe Gcloud::Datastore::Dataset do
     entity.must_be_kind_of Gcloud::Datastore::Entity
   end
 
+  it "entity sets the Key's kind for the new Entity" do
+    entity = dataset.entity "User"
+    entity.must_be_kind_of Gcloud::Datastore::Entity
+    entity.key.kind.must_equal "User"
+    entity.key.id.must_be :nil?
+    entity.key.name.must_be :nil?
+  end
+
+  it "entity sets the Key's kind and id for the new Entity" do
+    entity = dataset.entity "User", 123
+    entity.must_be_kind_of Gcloud::Datastore::Entity
+    entity.key.kind.must_equal "User"
+    entity.key.id.must_equal 123
+    entity.key.name.must_be :nil?
+  end
+
+  it "entity sets the Key's kind and name for the new Entity" do
+    entity = dataset.entity "User", "username"
+    entity.must_be_kind_of Gcloud::Datastore::Entity
+    entity.key.kind.must_equal "User"
+    entity.key.id.must_be :nil?
+    entity.key.name.must_equal "username"
+  end
+
+  it "entity sets the Key object for the new Entity" do
+    key = dataset.key "User", "username"
+    entity = dataset.entity key
+    entity.must_be_kind_of Gcloud::Datastore::Entity
+    entity.key.kind.must_equal "User"
+    entity.key.id.must_be :nil?
+    entity.key.name.must_equal "username"
+  end
+
   it "entity can configure the new Entity using a block" do
-    entity = dataset.entity do |e|
-      e.key = dataset.key "User", "username"
+    entity = dataset.entity "User", "username" do |e|
       e["name"] = "User McUser"
       e["email"] = "user@example.net"
     end
     entity.must_be_kind_of Gcloud::Datastore::Entity
+    entity.key.kind.must_equal "User"
+    entity.key.id.must_be :nil?
+    entity.key.name.must_equal "username"
     entity.properties["name"].must_equal "User McUser"
     entity.properties["email"].must_equal "user@example.net"
   end

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -312,6 +312,21 @@ describe Gcloud::Datastore::Dataset do
     refute entities.no_more?
   end
 
+  it "query returns a Query instance" do
+    query = dataset.query "Task"
+    query.must_be_kind_of Gcloud::Datastore::Query
+
+    proto = query.to_proto
+    proto.kind.name.must_include "Task"
+    proto.kind.name.wont_include "User"
+
+    # Add a second kind to the query
+    query.kind "User"
+
+    proto = query.to_proto
+    proto.kind.name.must_include "Task"
+    proto.kind.name.must_include "User"
+  end
 
   describe "query result object" do
     let(:run_query_response_not_finished) do

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -342,6 +342,22 @@ describe Gcloud::Datastore::Dataset do
     key.name.must_equal "charlie"
   end
 
+  it "entity returns an Entity instance" do
+    entity = dataset.entity
+    entity.must_be_kind_of Gcloud::Datastore::Entity
+  end
+
+  it "entity can configure the new Entity using a block" do
+    entity = dataset.entity do |e|
+      e.key = dataset.key "User", "username"
+      e["name"] = "User McUser"
+      e["email"] = "user@example.net"
+    end
+    entity.must_be_kind_of Gcloud::Datastore::Entity
+    entity.properties["name"].must_equal "User McUser"
+    entity.properties["email"].must_equal "user@example.net"
+  end
+
   describe "query result object" do
     let(:run_query_response_not_finished) do
       run_query_response.tap do |response|

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -328,6 +328,20 @@ describe Gcloud::Datastore::Dataset do
     proto.kind.name.must_include "User"
   end
 
+  it "key returns a Key instance" do
+    key = dataset.key "ThisThing", 1234
+    key.must_be_kind_of Gcloud::Datastore::Key
+    key.kind.must_equal "ThisThing"
+    key.id.must_equal 1234
+    key.name.must_be :nil?
+
+    key = dataset.key "ThisThing", "charlie"
+    key.must_be_kind_of Gcloud::Datastore::Key
+    key.kind.must_equal "ThisThing"
+    key.id.must_be :nil?
+    key.name.must_equal "charlie"
+  end
+
   describe "query result object" do
     let(:run_query_response_not_finished) do
       run_query_response.tap do |response|


### PR DESCRIPTION
This change intends to make it easier to write (and maintain) Datastore code using gcloud. It adds three small convenience methods that will save on characters needed to be typed and read.

Before:

```ruby
dataset = gcloud.datastore

# Create a new task to demo datastore
demo_task = Gcloud::Datastore::Entity.new
demo_task.key = Gcloud::Datastore::Key.new "Task", "datastore-demo"
demo_task["description"] = "Demonstrate Datastore functionality"
demo_task["completed"] = false

# Save the new task
dataset.save demo_task
```

After:

```ruby
dataset = gcloud.datastore

# Create a new task to demo datastore
demo_task = dataset.entity "Task", "datastore-demo" do |t|
  t["description"] = "Demonstrate Datastore functionality"
  t["completed"] = false
end  

# Save the new task
dataset.save demo_task
```

Before:

```ruby
# Create a query for all completed tasks
query = Gcloud::Datastore::Query.new.
  kind("Task").
  where("completed", "=", true)

# Run the query
completed_tasks = dataset.run query
```

After:

```ruby
# Create a query for all completed tasks
query = dataset.query("Task").
  where("completed", "=", true)

# Run the query
completed_tasks = dataset.run query
```
