### PR TITLE
Rubocop Cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,7 @@ Metrics/ClassLength:
   Enabled: false
 Style/EmptyElse:
   Enabled: false
+Metrics/AbcSize:
+  Max: 20
+Metrics/MethodLength:
+  Max: 15

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -266,10 +266,6 @@ module Gcloud
         end
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
-      # Disabled rubocop because the level of abstraction is not violated here
-
       ##
       # Creates a new dataset.
       #
@@ -356,9 +352,6 @@ module Gcloud
           fail ApiError.from_response(resp)
         end
       end
-
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
 
       ##
       # Retrieves the list of datasets belonging to the project.

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -234,9 +234,6 @@ module Gcloud
         true
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # Disabled rubocop because the level of abstraction is not violated here
-
       ##
       # Retrieve entities specified by a Query.
       #
@@ -275,8 +272,6 @@ module Gcloud
         QueryResults.new entities, cursor, more_results
       end
       alias_method :run_query, :run
-
-      # rubocop:enable Metrics/AbcSize
 
       ##
       # Creates a Datastore Transaction.

--- a/lib/gcloud/gce.rb
+++ b/lib/gcloud/gce.rb
@@ -24,9 +24,6 @@ module Gcloud
     CHECK_URI = "http://169.254.169.254"
     PROJECT_URI = "#{CHECK_URI}/computeMetadata/v1/project/project-id"
 
-    # rubocop:disable all
-    # Disabled rubocop because this is private and we don't need more methods.
-
     def self.gce? options = {}
       conn = options[:connection] || Faraday.default_connection
       resp = conn.get CHECK_URI do |req|
@@ -56,7 +53,5 @@ module Gcloud
       @gce ||= {}
       @gce[:project_id] = nil
     end
-
-    # rubocop:enable all
   end
 end

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -78,10 +78,6 @@ module Gcloud
           Gcloud::GCE.project_id
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
-      # Disabled rubocop because there isn't much benefit to adding indirection
-
       ##
       # Retrieves topic by name.
       #
@@ -169,9 +165,6 @@ module Gcloud
       end
       alias_method :get_topic, :topic
       alias_method :find_topic, :topic
-
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
 
       ##
       # Creates a new topic.
@@ -347,9 +340,6 @@ module Gcloud
         publish_batch_messages topic_name, batch, autocreate
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # Disabling because this is very close to the limit.
-
       ##
       # Creates a new Subscription object for the provided topic.
       #
@@ -435,8 +425,6 @@ module Gcloud
       end
       alias_method :create_subscription, :subscribe
       alias_method :new_subscription, :subscribe
-
-      # rubocop:enable Metrics/AbcSize
 
       ##
       # Retrieves subscription by name.

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -191,9 +191,6 @@ module Gcloud
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
-      # Disabled rubocop because these lines are needed.
-
       ##
       # Pulls messages from the server. Returns an empty list if there are no
       # messages available in the backlog. Raises an ApiError with status
@@ -268,8 +265,6 @@ module Gcloud
       rescue Faraday::TimeoutError
         []
       end
-
-      # rubocop:enable Metrics/MethodLength
 
       ##
       # Pulls from the server while waiting for messages to become available.


### PR DESCRIPTION
Update Rubocop configuration to set slightly higher levels for method complexity and line length.
Many of the methods connecting to Google Cloud services are complex because
the Google Cloud service is complex. Relax these metrics to ease development.

[refs #408]