### PR TITLE
Search Setup

### DIFF
--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -350,4 +350,35 @@ module Gcloud
   end
 
   # rubocop:enable Metrics/LineLength
+
+  ##
+  # Creates a new object for connecting to the Search service.
+  # Each call creates a new connection.
+  #
+  # === Parameters
+  #
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/cloudsearch+
+  #
+  # === Returns
+  #
+  # Gcloud::Search::Project
+  #
+  # === Examples
+  #
+  #   require "gcloud"
+  #
+  def search options = {}
+    require "gcloud/search"
+    Gcloud.search @project, @keyfile, options
+  end
 end

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -1,0 +1,63 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gcloud"
+require "gcloud/search/project"
+
+#--
+# Google Cloud Search
+module Gcloud
+  ##
+  # Creates a new +Project+ instance connected to the Search service.
+  # Each call creates a new connection.
+  #
+  # === Parameters
+  #
+  # +project+::
+  #   Identifier for a Search project. If not present, the default project for
+  #   the credentials is used. (+String+)
+  # +keyfile+::
+  #   Keyfile downloaded from Google Cloud. If file path the file must be
+  #   readable. (+String+ or +Hash+)
+  # +options+::
+  #   An optional Hash for controlling additional behavior. (+Hash+)
+  # <code>options[:scope]</code>::
+  #   The OAuth 2.0 scopes controlling the set of resources and operations that
+  #   the connection can access. See {Using OAuth 2.0 to Access Google
+  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   or +Array+)
+  #
+  #   The default scope is:
+  #
+  #   * +https://www.googleapis.com/auth/cloudsearch+
+  #
+  # === Returns
+  #
+  # Gcloud::Search::Project
+  def self.search project = nil, keyfile = nil, options = {}
+    project ||= Gcloud::Search::Project.default_project
+    if keyfile.nil?
+      credentials = Gcloud::Search::Credentials.default options
+    else
+      credentials = Gcloud::Search::Credentials.new keyfile, options
+    end
+    Gcloud::Search::Project.new project, credentials
+  end
+
+  ##
+  # = Google Cloud Search
+  #
+  module Search
+  end
+end

--- a/lib/gcloud/search/connection.rb
+++ b/lib/gcloud/search/connection.rb
@@ -1,0 +1,44 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gcloud/version"
+require "google/api_client"
+
+module Gcloud
+  module Search
+    ##
+    # Represents the connection to Search,
+    # as well as expose the API calls.
+    class Connection #:nodoc:
+      API_VERSION = "v1"
+
+      attr_accessor :project
+      attr_accessor :credentials #:nodoc:
+
+      ##
+      # Creates a new Connection instance.
+      def initialize project, credentials #:nodoc:
+        @project = project
+        @credentials = credentials
+        @client = @credentials.client
+        @connection = Faraday.default_connection
+      end
+
+      def inspect #:nodoc:
+        "#{self.class}(#{@project})"
+      end
+    end
+  end
+end

--- a/lib/gcloud/search/connection.rb
+++ b/lib/gcloud/search/connection.rb
@@ -39,10 +39,12 @@ module Gcloud
       end
 
       def list_indexes options = {}
-        if options[:prefix]
-          options[:params] ||= {}
-          options[:params]["indexNamePrefix"] = options.delete :prefix
-        end
+        options[:params] = {
+          "indexNamePrefix" => options.delete(:prefix),
+          "pageSize" => options.delete(:max),
+          "pageToken" => options.delete(:token)
+        }.delete_if { |_, v| v.nil? }
+
         run "indexes", options
       end
 

--- a/lib/gcloud/search/credentials.rb
+++ b/lib/gcloud/search/credentials.rb
@@ -1,0 +1,29 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gcloud/credentials"
+
+module Gcloud
+  module Search
+    ##
+    # Represents the Oauth2 signing logic for Search.
+    class Credentials < Gcloud::Credentials #:nodoc:
+      SCOPE = ["https://www.googleapis.com/auth/cloudsearch"]
+      PATH_ENV_VARS = %w(SEARCH_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
+      JSON_ENV_VARS = %w(SEARCH_KEYFILE_JSON GCLOUD_KEYFILE_JSON
+                         GOOGLE_CLOUD_KEYFILE_JSON)
+    end
+  end
+end

--- a/lib/gcloud/search/errors.rb
+++ b/lib/gcloud/search/errors.rb
@@ -1,0 +1,67 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gcloud/errors"
+
+module Gcloud
+  module Search
+    ##
+    # Base Search exception class.
+    class Error < Gcloud::Error
+    end
+
+    ##
+    # Raised when an API call is not successful.
+    class ApiError < Error
+      ##
+      # The code of the error.
+      attr_reader :code
+
+      ##
+      # The errors encountered.
+      attr_reader :errors
+
+      def initialize message, code, errors = [] #:nodoc:
+        super message
+        @code   = code
+        @errors = errors
+      end
+
+      def self.from_response resp #:nodoc:
+        data = JSON.parse resp.body
+        if data["error"]
+          from_response_data data["error"]
+        else
+          from_response_status resp
+        end
+      rescue JSON::ParserError
+        from_response_status resp
+      end
+
+      def self.from_response_data error #:nodoc:
+        new error["message"], error["code"], error["errors"]
+      end
+
+      def self.from_response_status resp #:nodoc:
+        if resp.status == 404
+          new "#{resp.body}: #{resp.request.uri.request_uri}",
+              resp.status
+        else
+          new resp.body, resp.status
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -1,0 +1,53 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gcloud
+  module Search
+    ##
+    # = Index
+    #
+    # See Gcloud#search
+    class Index
+      ##
+      # The Connection object.
+      attr_accessor :connection #:nodoc:
+
+      ##
+      # The raw data object.
+      attr_accessor :raw #:nodoc:
+
+      ##
+      # Creates a new Index instance.
+      #
+      def initialize #:nodoc:
+        @connection = nil
+        @raw = nil
+      end
+
+      def index_id
+        @raw["indexId"]
+      end
+
+      ##
+      # New Index from a raw data object.
+      def self.from_raw raw, conn #:nodoc:
+        new.tap do |f|
+          f.raw = raw
+          f.connection = conn
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "gcloud/search/index/list"
+
 module Gcloud
   module Search
     ##

--- a/lib/gcloud/search/index/list.rb
+++ b/lib/gcloud/search/index/list.rb
@@ -1,0 +1,78 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Gcloud
+  module Search
+    class Index
+      ##
+      # Index::List is a special case Array with additional values.
+      class List < DelegateClass(::Array)
+        ##
+        # If not empty, indicates that there are more records that match
+        # the request and this value should be passed to continue.
+        attr_accessor :token
+
+        ##
+        # Create a new Index::List with an array of Index instances.
+        def initialize arr = []
+          super arr
+        end
+
+        ##
+        # Whether there a next page of indexes.
+        def next?
+          !token.nil?
+        end
+
+        ##
+        # Retrieve the next page of indexes.
+        def next
+          return nil unless next?
+          ensure_connection!
+          resp = @connection.list_indexes token: token
+          if resp.success?
+            Index::List.from_response resp, @connection
+          else
+            fail ApiError.from_response(resp)
+          end
+        end
+
+        ##
+        # New Indexs::List from a response object.
+        def self.from_response resp, conn #:nodoc:
+          data = JSON.parse resp.body
+          indexes = new(Array(data["indexes"]).map do |raw_index|
+            Index.from_raw raw_index, conn
+          end)
+          indexes.instance_eval do
+            @token = data["nextPageToken"]
+            @connection = conn
+          end
+          indexes
+        rescue JSON::ParserError
+          ApiError.from_response_status resp
+        end
+
+        protected
+
+        ##
+        # Raise an error unless an active connection is available.
+        def ensure_connection!
+          fail "Must have active connection" unless @connection
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -1,0 +1,76 @@
+#--
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "gcloud/gce"
+require "gcloud/search/connection"
+require "gcloud/search/credentials"
+require "gcloud/search/errors"
+
+module Gcloud
+  module Search
+    ##
+    # = Project
+    #
+    # See Gcloud#search
+    class Project
+      ##
+      # The Connection object.
+      attr_accessor :connection #:nodoc:
+
+      ##
+      # Creates a new Connection instance.
+      #
+      # See Gcloud.search
+      def initialize project, credentials #:nodoc:
+        project = project.to_s # Always cast to a string
+        fail ArgumentError, "project is missing" if project.empty?
+        @connection = Connection.new project, credentials
+      end
+
+      ##
+      # The unique ID string for the current project.
+      #
+      # === Example
+      #
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new "my-todo-project", "/path/to/keyfile.json"
+      #   search = gcloud.search
+      #
+      #   search.project #=> "my-todo-project"
+      #
+      def project
+        connection.project
+      end
+
+      ##
+      # Default project.
+      def self.default_project #:nodoc:
+        ENV["SEARCH_PROJECT"] ||
+          ENV["GCLOUD_PROJECT"] ||
+          ENV["GOOGLE_CLOUD_PROJECT"] ||
+          Gcloud::GCE.project_id
+      end
+
+      protected
+
+      ##
+      # Raise an error unless an active connection is available.
+      def ensure_connection!
+        fail "Must have active connection" unless connection
+      end
+    end
+  end
+end

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -80,6 +80,16 @@ module Gcloud
         end
       end
 
+      def indexes options = {}
+        ensure_connection!
+        resp = connection.list_indexes options
+        if resp.success?
+          Index::List.from_response resp, connection
+        else
+          fail ApiError.from_response(resp)
+        end
+      end
+
       protected
 
       ##

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -52,6 +52,12 @@ namespace :test do
     Dir.glob("test/gcloud/resource_manager/**/*_test.rb").each { |file| require_relative "../#{file}"}
   end
 
+  desc "Runs search tests."
+  task :search do
+    $LOAD_PATH.unshift "lib", "test"
+    Dir.glob("test/gcloud/search/**/*_test.rb").each { |file| require_relative "../#{file}"}
+  end
+
   desc "Runs tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     project = args[:project]

--- a/test/gcloud/search/project_test.rb
+++ b/test/gcloud/search/project_test.rb
@@ -66,6 +66,84 @@ describe Gcloud::Search::Project, :mock_search do
     index.must_be :nil?
   end
 
+  it "lists indexes" do
+    num_indexes = 3
+    mock_connection.get "/v1/projects/#{project}/indexes" do |env|
+      env.params.wont_include "indexNamePrefix"
+      env.params.wont_include "pageSize"
+      env.params.wont_include "pageToken"
+      [200, {"Content-Type"=>"application/json"},
+       list_index_json(num_indexes)]
+    end
+
+    indexes = search.indexes
+    indexes.size.must_equal num_indexes
+    indexes.each { |ds| ds.must_be_kind_of Gcloud::Search::Index }
+  end
+
+  it "paginates indexes" do
+    mock_connection.get "/v1/projects/#{project}/indexes" do |env|
+      env.params.wont_include "indexNamePrefix"
+      env.params.wont_include "pageSize"
+      env.params.wont_include "pageToken"
+      [200, {"Content-Type"=>"application/json"},
+       list_index_json(3, "next_page_token")]
+    end
+    mock_connection.get "/v1/projects/#{project}/indexes" do |env|
+      env.params.wont_include "indexNamePrefix"
+      env.params.wont_include "pageSize"
+      env.params.must_include "pageToken"
+      env.params["pageToken"].must_equal "next_page_token"
+      [200, {"Content-Type"=>"application/json"},
+       list_index_json(2)]
+    end
+
+    first_indexes = search.indexes
+    first_indexes.count.must_equal 3
+    first_indexes.each { |ds| ds.must_be_kind_of Gcloud::Search::Index }
+    first_indexes.token.wont_be :nil?
+    first_indexes.token.must_equal "next_page_token"
+
+    second_indexes = search.indexes token: first_indexes.token
+    second_indexes.count.must_equal 2
+    second_indexes.each { |ds| ds.must_be_kind_of Gcloud::Search::Index }
+    second_indexes.token.must_be :nil?
+  end
+
+  it "paginates indexes with prefix set" do
+    mock_connection.get "/v1/projects/#{project}/indexes" do |env|
+      env.params.must_include "indexNamePrefix"
+      env.params.wont_include "pageSize"
+      env.params.wont_include "pageToken"
+      env.params["indexNamePrefix"].must_equal "store_"
+      [200, {"Content-Type"=>"application/json"},
+       list_index_json(3, "next_page_token")]
+    end
+
+    indexes = search.indexes prefix: "store_"
+    indexes.count.must_equal 3
+    indexes.each { |ds| ds.must_be_kind_of Gcloud::Search::Index }
+    indexes.token.wont_be :nil?
+    indexes.token.must_equal "next_page_token"
+  end
+
+  it "paginates indexes with max set" do
+    mock_connection.get "/v1/projects/#{project}/indexes" do |env|
+      env.params.wont_include "indexNamePrefix"
+      env.params.must_include "pageSize"
+      env.params.wont_include "pageToken"
+      env.params["pageSize"].must_equal "3"
+      [200, {"Content-Type"=>"application/json"},
+       list_index_json(3, "next_page_token")]
+    end
+
+    indexes = search.indexes max: 3
+    indexes.count.must_equal 3
+    indexes.each { |ds| ds.must_be_kind_of Gcloud::Search::Index }
+    indexes.token.wont_be :nil?
+    indexes.token.must_equal "next_page_token"
+  end
+
   def random_index_hash index_id = nil
     index_id ||= "rnd_index_#{rand 999999}"
     {

--- a/test/gcloud/search/project_test.rb
+++ b/test/gcloud/search/project_test.rb
@@ -1,0 +1,21 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Search::Project, :mock_search do
+  it "exists" do
+    search.must_be_kind_of Gcloud::Search::Project
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -758,10 +758,9 @@ class MockSearch < Minitest::Spec
 
   def setup
     @connection = Faraday::Adapter::Test::Stubs.new
-    connection = search.instance_variable_get "@connection"
-    connection.instance_variable_set "@connection", Faraday.new do |builder|
+    search.connection.connection = Faraday.new "https://cloudsearch.googleapis.com" do |builder|
       # builder.options.params_encoder = Faraday::FlatParamsEncoder
-      builder.adapter :test, Faraday.default_connection
+      builder.adapter :test, @connection
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ require "gcloud/pubsub"
 require "gcloud/bigquery"
 require "gcloud/dns"
 require "gcloud/resource_manager"
+require "gcloud/search"
 
 class MockStorage < Minitest::Spec
   let(:project) { storage.connection.project }
@@ -747,5 +748,33 @@ class MockResourceManager < Minitest::Spec
   # Register this spec type for when :storage is used.
   register_spec_type(self) do |desc, *addl|
     addl.include? :mock_res_man
+  end
+end
+
+class MockSearch < Minitest::Spec
+  let(:project) { "test" }
+  let(:credentials) { OpenStruct.new }
+  let(:search) { Gcloud::Search::Project.new project, credentials }
+
+  def setup
+    @connection = Faraday::Adapter::Test::Stubs.new
+    connection = search.instance_variable_get "@connection"
+    connection.instance_variable_set "@connection", Faraday.new do |builder|
+      # builder.options.params_encoder = Faraday::FlatParamsEncoder
+      builder.adapter :test, Faraday.default_connection
+    end
+  end
+
+  def teardown
+    @connection.verify_stubbed_calls
+  end
+
+  def mock_connection
+    @connection
+  end
+
+  # Register this spec type for when :storage is used.
+  register_spec_type(self) do |desc, *addl|
+    addl.include? :mock_search
   end
 end


### PR DESCRIPTION
Add basic boilerplate for Cloud Search. Because we are unable to use the Google API Client for this service, we have to call the API directly. The setup has changed to reflect this. The plumbing will change as we continue development, but for now this works.

This also includes preliminary implementations of the methods to return a list of all existing indexes, as well as mocking out a method to find an index by name, which the Cloud Search API does not yet allow.

[refs #414, refs #415]