### PR TITLE
Add Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ coverage
 doc
 pkg
 
+# Ignore vagrant directory
+.vagrant
+
 # directories left by gh-pages
 _site
 html

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - "rakelib/**/*"
     - "acceptance/**/*"
     - "test/**/*"
+    - "Vagrantfile"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$grpc = <<SCRIPT
+# Install grps
+echo "deb http://http.debian.net/debian jessie-backports main" | sudo tee -a /etc/apt/sources.list
+sudo apt-get update -y
+sudo apt-get install libgrpc-dev -y --force-yes
+SCRIPT
+
+$gcloud = <<SCRIPT
+sudo apt-get install curl -y
+curl https://sdk.cloud.google.com | bash
+SCRIPT
+
+$rvm = <<SCRIPT
+# Install RVM and ruby 2.2
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+\\curl -sSL https://get.rvm.io | bash -s stable
+source ~/.rvm/scripts/rvm
+rvm install ruby-2.2
+rvm --default use 2.2
+
+# Install git and bundler and grpc gem
+sudo apt-get install git -y
+gem install bundler grpc
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "helderco/trusty64"
+
+  config.ssh.forward_agent = true
+
+  config.vm.provision "shell", inline: $grpc
+  config.vm.provision "shell", inline: $gcloud, privileged: false
+  config.vm.provision "shell", inline: $rvm, privileged: false
+end


### PR DESCRIPTION
Using vagrant is optional, but it will allow an easier way to get the
gcloud SDK and GRPC installed on the development environment.