### PR TITLE
Fix Datastore::Transaction unit tests

### DIFF
--- a/test/gcloud/datastore/transaction_test.rb
+++ b/test/gcloud/datastore/transaction_test.rb
@@ -93,8 +93,6 @@ describe Gcloud::Datastore::Transaction do
     end
 
     it "commit will raise if transaction is not open" do
-      transaction.connection.expect :begin_transaction, begin_transaction_response
-
       transaction.id.wont_be :nil?
       transaction.reset!
       transaction.id.must_be :nil?
@@ -106,8 +104,6 @@ describe Gcloud::Datastore::Transaction do
     end
 
     it "transaction will raise if transaction is not open" do
-      transaction.connection.expect :begin_transaction, begin_transaction_response
-
       transaction.id.wont_be :nil?
       transaction.reset!
       transaction.id.must_be :nil?


### PR DESCRIPTION
A change in minitest exposed what appears to be redundant mock setup. This setup is already made in lines 21-5:

```ruby
let(:connection)  do
   mock = Minitest::Mock.new
   mock.expect :begin_transaction, begin_transaction_response
   mock
end
```