### PR TITLE
Update Search Result#inspect

### DIFF
--- a/lib/gcloud/search/result.rb
+++ b/lib/gcloud/search/result.rb
@@ -167,7 +167,8 @@ module Gcloud
       def inspect #:nodoc:
         insp_token = ""
         if token
-          trunc_token = token[0...(token.index("_") || 24)].inspect
+          trunc_token = "#{token[0, 8]}...#{token[-5..-1]}"
+          trunc_token = token if token.length < 20
           insp_token = ", token: #{trunc_token}..."
         end
         insp_fields = ", fields: (#{fields.keys.join ', '})"


### PR DESCRIPTION
Use a different string truncation method for token.
This new method makes it a bit clearer that the token has been truncated.