### PR TITLE
Add helper methods for index schema

### DIFF
--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -122,6 +122,26 @@ module Gcloud
       end
 
       ##
+      # The names of all the fields that are stored on the index.
+      def field_names
+        (text_fields + html_fields + atom_fields + datetime_fields +
+          number_fields + geo_fields).uniq
+      end
+
+      ##
+      # The field value types that are stored on the field name.
+      def field_types_for name
+        {
+          text: text_fields.include?(name),
+          html: html_fields.include?(name),
+          atom: atom_fields.include?(name),
+          datetime: datetime_fields.include?(name),
+          number: number_fields.include?(name),
+          geo: geo_fields.include?(name)
+        }.delete_if { |_k, v| !v }.keys
+      end
+
+      ##
       # Retrieves an existing document by id.
       #
       # === Parameters

--- a/test/gcloud/search/index_test.rb
+++ b/test/gcloud/search/index_test.rb
@@ -38,6 +38,14 @@ describe Gcloud::Search::Index, :mock_search do
     index.datetime_fields.must_equal ["published"]
     index.number_fields.must_equal ["likes"]
     index.geo_fields.must_equal ["location"]
+
+    index.field_names.must_equal ["title", "body", "slug", "published", "likes", "location"]
+    index.field_types_for("title").must_equal [:text]
+    index.field_types_for("body").must_equal [:text, :html]
+    index.field_types_for("slug").must_equal [:atom]
+    index.field_types_for("published").must_equal [:datetime]
+    index.field_types_for("likes").must_equal [:number]
+    index.field_types_for("location").must_equal [:geo]
   end
 
   it "knows its attributes even when indexedField is missing" do
@@ -50,6 +58,9 @@ describe Gcloud::Search::Index, :mock_search do
     simple_index.datetime_fields.must_be :empty?
     simple_index.number_fields.must_be :empty?
     simple_index.geo_fields.must_be :empty?
+
+    simple_index.field_names.must_be :empty?
+    simple_index.field_types_for("title").must_be :empty?
   end
 
   it "deletes itself with the force option" do


### PR DESCRIPTION
These helper methods will make it easier to inspect the indexed fields on an index.

[refs #416]