### PR TITLE
Fix search URL generation

### DIFF
--- a/lib/gcloud/search/connection.rb
+++ b/lib/gcloud/search/connection.rb
@@ -107,6 +107,13 @@ module Gcloud
       end
 
       def search index_id, query, options = {}
+        # Always encode expression hashes as JSON strings
+        if options[:expressions]
+          # Force to an array of hashes, this works with an array or a hash
+          tmp = [options[:expressions]].flatten.map { |ex| JSON.dump ex }
+          options[:expressions] = tmp
+        end
+
         @client.execute(
           api_method: @search.indexes.search,
           parameters: search_request(index_id, query, options)

--- a/test/gcloud/search/index_test.rb
+++ b/test/gcloud/search/index_test.rb
@@ -370,6 +370,19 @@ describe Gcloud::Search::Index, :mock_search do
     end
   end
 
+  it "searches one expression set" do
+    expression = { name: "TotalPrice", expression: "(Price+Tax)" }
+    expression_json = { "expression" => "(Price+Tax)", "name" => "TotalPrice" }
+
+    mock_connection.get "/v1/projects/#{project}/indexes/#{index.index_id}/search" do |env|
+      JSON.parse(env.params["fieldExpressions"]).must_equal expression_json
+      [200, {"Content-Type"=>"application/json"}, search_results_json(3)]
+    end
+
+    results = index.search query, expressions: expression
+    results.size.must_equal 3
+  end
+
   it "searches with expressions set" do
     expressions = [
       { name: "TotalPrice", expression: "(Price+Tax)" },
@@ -379,8 +392,9 @@ describe Gcloud::Search::Index, :mock_search do
       { "expression" => "(Price+Tax)", "name" => "TotalPrice" },
       { "expression" => "snippet('good times', content)", "name" => "snippet" }
     ]
+
     mock_connection.get "/v1/projects/#{project}/indexes/#{index.index_id}/search" do |env|
-      env.params["fieldExpressions"].must_equal expressions_json
+      env.params["fieldExpressions"].map { |v| JSON.parse v }.must_equal expressions_json
       [200, {"Content-Type"=>"application/json"}, search_results_json(3)]
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -759,7 +759,7 @@ class MockSearch < Minitest::Spec
   def setup
     @connection = Faraday::Adapter::Test::Stubs.new
     search.connection.client.connection = Faraday.new "https://cloudsearch.googleapis.com" do |builder|
-      # builder.options.params_encoder = Faraday::FlatParamsEncoder
+      builder.options.params_encoder = Faraday::FlatParamsEncoder
       builder.adapter :test, @connection
     end
   end


### PR DESCRIPTION
The search querystring was not being added when running authed requests.
Add query parameters to the URI to force both code paths to be the same.