### PR TITLE
Drop Ruby 1.9.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,5 @@ Metrics/AbcSize:
   Max: 20
 Metrics/MethodLength:
   Max: 15
+Metrics/ParameterLists:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
 - 2.1
 - 2.0
-- 1.9
 script:
 - bundle exec rake travis
 after_success:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ file.copy backup, file.name
 
 ## Supported Ruby Versions
 
-gcloud is supported on Ruby 1.9.3+.
+gcloud is supported on Ruby 2.0+.
 
 ## Versioning
 

--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |gem|
   gem.name          = "gcloud"
   gem.version       = Gcloud::VERSION
 
-  gem.authors       = ["Silvano Luciani", "Mike Moore"]
-  gem.email         = ["silvano@google.com", "mike@blowmage.com"]
+  gem.authors       = ["Silvano Luciani", "Mike Moore", "Chris Smith"]
+  gem.email         = ["silvano@google.com", "mike@blowmage.com", "quartzmo@gmail.com"]
   gem.description   = "Gcloud is the official library for interacting with Google Cloud."
   gem.summary       = "API Client library for Google Cloud"
   gem.homepage      = "http://googlecloudplatform.github.io/gcloud-ruby/"

--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
                       `git ls-files -- docs/*`.split("\n")
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 1.9.3"
+  gem.required_ruby_version = ">= 2.0.0"
 
   gem.extra_rdoc_files = ["OVERVIEW.md", "AUTHENTICATION.md", "CHANGELOG.md"]
   gem.rdoc_options     = ["--main", "OVERVIEW.md",
@@ -38,6 +38,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      "httpclient", "~> 2.5"
   gem.add_development_dependency      "simplecov", "~> 0.9"
   gem.add_development_dependency      "coveralls", "~> 0.7"
-  # Cap tins at 1.6.0 for compatibility with Ruby 1.9
-  gem.add_development_dependency      "tins", "<= 1.6.0"
 end

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -72,9 +72,7 @@ module Gcloud
   #
   # === Parameters
   #
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -112,9 +110,9 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   dataset = gcloud.datastore scope: platform_scope
   #
-  def datastore options = {}
+  def datastore scope: nil
     require "gcloud/datastore"
-    Gcloud.datastore @project, @keyfile, options
+    Gcloud.datastore @project, @keyfile, scope: scope
   end
 
   ##
@@ -123,9 +121,7 @@ module Gcloud
   #
   # === Parameters
   #
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -158,9 +154,9 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/devstorage.read_only"
   #   readonly_storage = gcloud.storage scope: readonly_scope
   #
-  def storage options = {}
+  def storage scope: nil
     require "gcloud/storage"
-    Gcloud.storage @project, @keyfile, options
+    Gcloud.storage @project, @keyfile, scope: scope
   end
 
   ##
@@ -169,9 +165,7 @@ module Gcloud
   #
   # === Parameters
   #
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -202,9 +196,9 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   pubsub = gcloud.pubsub scope: platform_scope
   #
-  def pubsub options = {}
+  def pubsub scope: nil
     require "gcloud/pubsub"
-    Gcloud.pubsub @project, @keyfile, options
+    Gcloud.pubsub @project, @keyfile, scope: scope
   end
 
   ##
@@ -213,9 +207,7 @@ module Gcloud
   #
   # === Parameters
   #
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -249,9 +241,9 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   bigquery = gcloud.bigquery scope: platform_scope
   #
-  def bigquery options = {}
+  def bigquery scope: nil
     require "gcloud/bigquery"
-    Gcloud.bigquery @project, @keyfile, options
+    Gcloud.bigquery @project, @keyfile, scope: scope
   end
 
   ##
@@ -260,9 +252,7 @@ module Gcloud
   #
   # === Parameters
   #
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -295,9 +285,9 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/ndev.clouddns.readonly"
   #   dns = gcloud.dns scope: readonly_scope
   #
-  def dns options = {}
+  def dns scope: nil
     require "gcloud/dns"
-    Gcloud.dns @project, @keyfile, options
+    Gcloud.dns @project, @keyfile, scope: scope
   end
 
   # rubocop:disable Metrics/LineLength
@@ -310,9 +300,7 @@ module Gcloud
   #
   # === Parameters
   #
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -344,9 +332,9 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/cloudresourcemanager.readonly"
   #   resource_manager = gcloud.resource_manager scope: readonly_scope
   #
-  def resource_manager options = {}
+  def resource_manager scope: nil
     require "gcloud/resource_manager"
-    Gcloud.resource_manager @keyfile, options
+    Gcloud.resource_manager @keyfile, scope: scope
   end
 
   # rubocop:enable Metrics/LineLength

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -57,9 +57,10 @@ module Gcloud
   def self.bigquery project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Bigquery::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Bigquery::Credentials.default options
+      credentials = Gcloud::Bigquery::Credentials.default scope: options[:scope]
     else
-      credentials = Gcloud::Bigquery::Credentials.new keyfile, options
+      credentials = Gcloud::Bigquery::Credentials.new keyfile,
+                                                      scope: options[:scope]
     end
     Gcloud::Bigquery::Project.new project, credentials
   end

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -30,9 +30,7 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -54,13 +52,12 @@ module Gcloud
   #   dataset = bigquery.dataset "my_dataset"
   #   table = dataset.table "my_table"
   #
-  def self.bigquery project = nil, keyfile = nil, options = {}
+  def self.bigquery project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Bigquery::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Bigquery::Credentials.default scope: options[:scope]
+      credentials = Gcloud::Bigquery::Credentials.default scope: scope
     else
-      credentials = Gcloud::Bigquery::Credentials.new keyfile,
-                                                      scope: options[:scope]
+      credentials = Gcloud::Bigquery::Credentials.new keyfile, scope: scope
     end
     Gcloud::Bigquery::Project.new project, credentials
   end

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -345,17 +345,6 @@ module Gcloud
       protected
 
       ##
-      # Make sure the object is converted to a hash
-      # Ruby 1.9.3 doesn't support to_h, so here we are.
-      def hashify hash
-        if hash.respond_to? :to_h
-          hash.to_h
-        else
-          Hash.try_convert(hash) || {}
-        end
-      end
-
-      ##
       # Create the HTTP body for insert dataset
       def insert_dataset_request dataset_id, options = {}
         {

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -471,7 +471,6 @@ module Gcloud
           "defaultDataset" => dataset_config,
           "timeoutMs" => options[:timeout],
           "dryRun" => options[:dryrun],
-          "preserveNulls" => options[:preserve_nulls],
           "useQueryCache" => options[:cache]
         }.delete_if { |_, v| v.nil? }
       end

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -94,11 +94,11 @@ module Gcloud
       # either manually or by specifying force: true in options.
       # Immediately after deletion, you can create another dataset with
       # the same name.
-      def delete_dataset dataset_id, options = {}
+      def delete_dataset dataset_id, force = nil
         @client.execute(
           api_method: @bigquery.datasets.delete,
           parameters: { projectId: @project, datasetId: dataset_id,
-                        deleteContents: options[:force]
+                        deleteContents: force
                       }.delete_if { |_, v| v.nil? }
         )
       end

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -614,12 +614,12 @@ module Gcloud
       #     table exists and contains data.
       # +large_results+::
       #   If +true+, allows the query to produce arbitrarily large result tables
-      #   at a slight cost in performance. Requires <code>options[:table]</code>
-      #   to be set. (+Boolean+)
+      #   at a slight cost in performance. Requires +table+ parameter to be set.
+      #   (+Boolean+)
       # +flatten+::
       #   Flattens all nested and repeated fields in the query results. The
-      #   default value is +true+. <code>options[:large_results]</code> must be
-      #   +true+ if this is set to +false+. (+Boolean+)
+      #   default value is +true+. +large_results+ parameter must be +true+ if
+      #   this is set to +false+. (+Boolean+)
       #
       # === Returns
       #

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -122,12 +122,12 @@ module Gcloud
       #     table exists and contains data.
       # +large_results+::
       #   If +true+, allows the query to produce arbitrarily large result tables
-      #   at a slight cost in performance. Requires <code>options[:table]</code>
-      #   to be set. (+Boolean+)
+      #   at a slight cost in performance. Requires +table+ parameter to be set.
+      #   (+Boolean+)
       # +flatten+::
       #   Flattens all nested and repeated fields in the query results. The
-      #   default value is +true+. <code>options[:large_results]</code> must be
-      #   +true+ if this is set to +false+. (+Boolean+)
+      #   default value is +true+. +large_results+ parameter must be +true+ if
+      #   this is set to +false+. (+Boolean+)
       # +dataset+::
       #   Specifies the default dataset to use for unqualified table names in
       #   the query. (+Dataset+ or +String+)

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -93,25 +93,25 @@ module Gcloud
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # <code>options[:priority]</code>::
+      # +priority+::
       #   Specifies a priority for the query. Possible values include
       #   +INTERACTIVE+ and +BATCH+. The default value is +INTERACTIVE+.
       #   (+String+)
-      # <code>options[:cache]</code>::
+      # +cache+::
       #   Whether to look for the result in the query cache. The query cache is
       #   a best-effort cache that will be flushed whenever tables in the query
       #   are modified. The default value is +true+. (+Boolean+)
-      # <code>options[:table]</code>::
+      # +table+::
       #   The destination table where the query results should be stored. If not
       #   present, a new table will be created to store the results. (+Table+)
-      # <code>options[:create]</code>::
+      # +create+::
       #   Specifies whether the job is allowed to create new tables. (+String+)
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # <code>options[:write]</code>::
+      # +write+::
       #   Specifies the action that occurs if the destination table already
       #   exists. (+String+)
       #
@@ -120,15 +120,15 @@ module Gcloud
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - A 'duplicate' error is returned in the job result if the
       #     table exists and contains data.
-      # <code>options[:large_results]</code>::
+      # +large_results+::
       #   If +true+, allows the query to produce arbitrarily large result tables
       #   at a slight cost in performance. Requires <code>options[:table]</code>
       #   to be set. (+Boolean+)
-      # <code>options[:flatten]</code>::
+      # +flatten+::
       #   Flattens all nested and repeated fields in the query results. The
       #   default value is +true+. <code>options[:large_results]</code> must be
       #   +true+ if this is set to +false+. (+Boolean+)
-      # <code>options[:dataset]</code>::
+      # +dataset+::
       #   Specifies the default dataset to use for unqualified table names in
       #   the query. (+Dataset+ or +String+)
       #
@@ -152,8 +152,13 @@ module Gcloud
       #     end
       #   end
       #
-      def query_job query, options = {}
+      def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
+                    create: nil, write: nil, large_results: nil, flatten: nil,
+                    dataset: nil
         ensure_connection!
+        options = { priority: priority, cache: cache, table: table,
+                    create: create, write: write, large_results: large_results,
+                    flatten: flatten, dataset: dataset }
         resp = connection.query_job query, options
         if resp.success?
           Job.from_gapi resp.data, connection
@@ -173,37 +178,37 @@ module Gcloud
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   The maximum number of rows of data to return per page of results.
       #   Setting this flag to a small value such as 1000 and then paging
       #   through results might improve reliability when the query result set is
       #   large. In addition to this limit, responses are also limited to 10 MB.
       #   By default, there is no maximum row count, and only the byte limit
       #   applies. (+Integer+)
-      # <code>options[:timeout]</code>::
+      # +timeout+::
       #   How long to wait for the query to complete, in milliseconds, before
       #   the request times out and returns. Note that this is only a timeout
       #   for the request, not the query. If the query takes longer to run than
       #   the timeout value, the call returns without any results and with
       #   QueryData#complete? set to false. The default value is 10000
       #   milliseconds (10 seconds). (+Integer+)
-      # <code>options[:dryrun]</code>::
+      # +dryrun+::
       #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
       #   is valid, BigQuery returns statistics about the job such as how many
       #   bytes would be processed. If the query is invalid, an error returns.
       #   The default value is +false+. (+Boolean+)
-      # <code>options[:cache]</code>::
+      # +cache+::
       #   Whether to look for the result in the query cache. The query cache is
       #   a best-effort cache that will be flushed whenever tables in the query
       #   are modified. The default value is true. For more information, see
       #   {query caching}[https://developers.google.com/bigquery/querying-data].
       #   (+Boolean+)
-      # <code>options[:dataset]</code>::
+      # +dataset+::
       #   Specifies the default datasetId and projectId to assume for any
       #   unqualified table names in the query. If not set, all table names in
       #   the query string must be qualified in the format 'datasetId.tableId'.
       #   (+String+)
-      # <code>options[:project]</code>::
+      # +project+::
       #   Specifies the default projectId to assume for any unqualified table
       #   names in the query. Only used if +dataset+ option is set. (+String+)
       #
@@ -223,8 +228,11 @@ module Gcloud
       #     puts row["name"]
       #   end
       #
-      def query query, options = {}
+      def query query, max: nil, timeout: 10000, dryrun: nil, cache: true,
+                dataset: nil, project: nil
         ensure_connection!
+        options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache,
+                    dataset: dataset, project: project }
         resp = connection.query query, options
         if resp.success?
           QueryData.from_gapi resp.data, connection
@@ -275,16 +283,14 @@ module Gcloud
       #   A unique ID for this dataset, without the project name.
       #   The ID must contain only letters (a-z, A-Z), numbers (0-9), or
       #   underscores (_). The maximum length is 1,024 characters. (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:name]</code>::
+      # +name+::
       #   A descriptive name for the dataset. (+String+)
-      # <code>options[:description]</code>::
+      # +description+::
       #   A user-friendly description of the dataset. (+String+)
-      # <code>options[:expiration]</code>::
+      # +expiration+::
       #   The default lifetime of all tables in the dataset, in milliseconds.
       #   The minimum value is 3600000 milliseconds (one hour). (+Integer+)
-      # <code>options[:access]</code>::
+      # +access+::
       #   The access rules for a Dataset using the Google Cloud Datastore API
       #   data structure of an array of hashes. See {BigQuery Access
       #   Control}[https://cloud.google.com/bigquery/access-control] for more
@@ -336,21 +342,21 @@ module Gcloud
       #     access.add_writer_user "writers@example.com"
       #   end
       #
-      def create_dataset dataset_id, options = {}
+      def create_dataset dataset_id, name: nil, description: nil,
+                         expiration: nil, access: nil
         if block_given?
           access_builder = Dataset::Access.new connection.default_access_rules,
                                                "projectId" => project
           yield access_builder
-          options[:access] = access_builder.access if access_builder.changed?
+          access = access_builder.access if access_builder.changed?
         end
 
         ensure_connection!
+        options = { name: name, description: description,
+                    expiration: expiration, access: access }
         resp = connection.insert_dataset dataset_id, options
-        if resp.success?
-          Dataset.from_gapi resp.data, connection
-        else
-          fail ApiError.from_response(resp)
-        end
+        return Dataset.from_gapi(resp.data, connection) if resp.success?
+        fail ApiError.from_response(resp)
       end
 
       ##
@@ -358,15 +364,13 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:all]</code>::
+      # +all+::
       #   Whether to list all datasets, including hidden ones. The default is
       #   +false+. (+Boolean+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   A previously-returned page token representing part of the larger set
       #   of results to view. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of datasets to return. (+Integer+)
       #
       # === Returns
@@ -415,8 +419,9 @@ module Gcloud
       #     tmp_datasets = bigquery.datasets token: tmp_datasets.token
       #   end
       #
-      def datasets options = {}
+      def datasets all: nil, token: nil, max: nil
         ensure_connection!
+        options = { all: all, token: token, max: max }
         resp = connection.list_datasets options
         if resp.success?
           Dataset::List.from_response resp, connection
@@ -462,17 +467,15 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:all]</code>::
+      # +all+::
       #   Whether to display jobs owned by all users in the project.
       #   The default is +false+. (+Boolean+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   A previously-returned page token representing part of the larger set
       #   of results to view. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of jobs to return. (+Integer+)
-      # <code>options[:filter]</code>::
+      # +filter+::
       #   A filter for job state. (+String+)
       #
       #   Acceptable values are:
@@ -522,8 +525,9 @@ module Gcloud
       #     tmp_jobs = bigquery.jobs token: tmp_jobs.token
       #   end
       #
-      def jobs options = {}
+      def jobs all: nil, token: nil, max: nil, filter: nil
         ensure_connection!
+        options = { all: all, token: token, max: max, filter: filter }
         resp = connection.list_jobs options
         if resp.success?
           Job::List.from_response resp, connection

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -99,16 +99,14 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   Page token, returned by a previous call, identifying the result set.
       #   (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of results to return. (+Integer+)
-      # <code>options[:start]</code>::
+      # +start+::
       #   Zero-based index of the starting row to read. (+Integer+)
-      # <code>options[:timeout]</code>::
+      # +timeout+::
       #   How long to wait for the query to complete, in milliseconds, before
       #   returning. Default is 10,000 milliseconds (10 seconds). (+Integer+)
       #
@@ -133,8 +131,9 @@ module Gcloud
       #   end
       #   data = data.next if data.next?
       #
-      def query_results options = {}
+      def query_results token: nil, max: nil, start: nil, timeout: nil
         ensure_connection!
+        options = { token: token, max: max, start: start, timeout: timeout }
         resp = connection.job_query_results job_id, options
         if resp.success?
           QueryData.from_gapi resp.data, connection

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -47,7 +47,7 @@ module Gcloud
       # Checks if the the query job allows arbitrarily large results at a slight
       # cost to performance.
       def large_results?
-        val = config["query"]["preserveNulls"]
+        val = config["query"]["allowLargeResults"]
         return false if val.nil?
         val
       end

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -79,15 +79,13 @@ module Gcloud
         #   The field name. The name must contain only letters (a-z, A-Z),
         #   numbers (0-9), or underscores (_), and must start with a letter or
         #   underscore. The maximum length is 128 characters. (+String+)
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:description]</code>::
+        # +description+::
         #   A description of the field. (+String+)
-        # <code>options[:mode]</code>::
+        # +mode+::
         #   The field's mode. The possible values are +:nullable+, +:required+,
         #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
-        def string name, options = {}
-          add_field name, :string, nil, options
+        def string name, description: nil, mode: nil
+          add_field name, :string, nil, description: description, mode: mode
         end
 
         ##
@@ -99,15 +97,13 @@ module Gcloud
         #   The field name. The name must contain only letters (a-z, A-Z),
         #   numbers (0-9), or underscores (_), and must start with a letter or
         #   underscore. The maximum length is 128 characters. (+String+)
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:description]</code>::
+        # +description+::
         #   A description of the field. (+String+)
-        # <code>options[:mode]</code>::
+        # +mode+::
         #   The field's mode. The possible values are +:nullable+, +:required+,
         #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
-        def integer name, options = {}
-          add_field name, :integer, nil, options
+        def integer name, description: nil, mode: nil
+          add_field name, :integer, nil, description: description, mode: mode
         end
 
         ##
@@ -119,15 +115,13 @@ module Gcloud
         #   The field name. The name must contain only letters (a-z, A-Z),
         #   numbers (0-9), or underscores (_), and must start with a letter or
         #   underscore. The maximum length is 128 characters. (+String+)
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:description]</code>::
+        # +description+::
         #   A description of the field. (+String+)
-        # <code>options[:mode]</code>::
+        # +mode+::
         #   The field's mode. The possible values are +:nullable+, +:required+,
         #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
-        def float name, options = {}
-          add_field name, :float, nil, options
+        def float name, description: nil, mode: nil
+          add_field name, :float, nil, description: description, mode: mode
         end
 
         ##
@@ -139,15 +133,13 @@ module Gcloud
         #   The field name. The name must contain only letters (a-z, A-Z),
         #   numbers (0-9), or underscores (_), and must start with a letter or
         #   underscore. The maximum length is 128 characters. (+String+)
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:description]</code>::
+        # +description+::
         #   A description of the field. (+String+)
-        # <code>options[:mode]</code>::
+        # +mode+::
         #   The field's mode. The possible values are +:nullable+, +:required+,
         #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
-        def boolean name, options = {}
-          add_field name, :boolean, nil, options
+        def boolean name, description: nil, mode: nil
+          add_field name, :boolean, nil, description: description, mode: mode
         end
 
         ##
@@ -159,15 +151,13 @@ module Gcloud
         #   The field name. The name must contain only letters (a-z, A-Z),
         #   numbers (0-9), or underscores (_), and must start with a letter or
         #   underscore. The maximum length is 128 characters. (+String+)
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:description]</code>::
+        # +description+::
         #   A description of the field. (+String+)
-        # <code>options[:mode]</code>::
+        # +mode+::
         #   The field's mode. The possible values are +:nullable+, +:required+,
         #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
-        def timestamp name, options = {}
-          add_field name, :timestamp, nil, options
+        def timestamp name, description: nil, mode: nil
+          add_field name, :timestamp, nil, description: description, mode: mode
         end
 
         ##
@@ -182,11 +172,9 @@ module Gcloud
         #   The field name. The name must contain only letters (a-z, A-Z),
         #   numbers (0-9), or underscores (_), and must start with a letter or
         #   underscore. The maximum length is 128 characters. (+String+)
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:description]</code>::
+        # +description+::
         #   A description of the field. (+String+)
-        # <code>options[:mode]</code>::
+        # +mode+::
         #   The field's mode. The possible values are +:nullable+, +:required+,
         #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
         #
@@ -207,12 +195,13 @@ module Gcloud
         #     end
         #   end
         #
-        def record name, options = {}
+        def record name, description: nil, mode: nil
           fail ArgumentError, "nested RECORD type is not permitted" if @nested
           fail ArgumentError, "a block is required" unless block_given?
           nested_schema = self.class.new nil, true
           yield nested_schema
-          add_field name, :record, nested_schema.fields, options
+          add_field name, :record, nested_schema.fields,
+                    description: description, mode: mode
         end
 
         protected
@@ -234,16 +223,17 @@ module Gcloud
           upcase_mode
         end
 
-        def add_field name, type, nested_fields, options
+        def add_field name, type, nested_fields, description: nil,
+                      mode: :nullable
           # Remove any existing field of this name
           @fields.reject! { |h| h["name"] == name }
           field = {
             "name" => name,
             "type" => upcase_type(type)
           }
-          field["mode"] = upcase_mode(options[:mode]) if options[:mode]
-          field["description"] =options[:description] if options[:description]
-          field["fields"] = nested_fields if nested_fields
+          field["fields"]      = nested_fields     if nested_fields
+          field["description"] = description       if description
+          field["mode"]        = upcase_mode(mode) if mode
           @fields << field
         end
       end

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -286,33 +286,31 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   The maximum number of rows of data to return per page of results.
       #   Setting this flag to a small value such as 1000 and then paging
       #   through results might improve reliability when the query result set is
       #   large. In addition to this limit, responses are also limited to 10 MB.
       #   By default, there is no maximum row count, and only the byte limit
       #   applies. (+Integer+)
-      # <code>options[:timeout]</code>::
+      # +timeout+::
       #   How long to wait for the query to complete, in milliseconds, before
       #   the request times out and returns. Note that this is only a timeout
       #   for the request, not the query. If the query takes longer to run than
       #   the timeout value, the call returns without any results and with
       #   QueryData#complete? set to false. The default value is 10000
       #   milliseconds (10 seconds). (+Integer+)
-      # <code>options[:dryrun]</code>::
-      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
-      #   is valid, BigQuery returns statistics about the job such as how many
-      #   bytes would be processed. If the query is invalid, an error returns.
-      #   The default value is +false+. (+Boolean+)
-      # <code>options[:cache]</code>::
+      # +cache+::
       #   Whether to look for the result in the query cache. The query cache is
       #   a best-effort cache that will be flushed whenever tables in the query
       #   are modified. The default value is true. For more information, see
       #   {query caching}[https://developers.google.com/bigquery/querying-data].
       #   (+Boolean+)
+      # +dryrun+::
+      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
+      #   is valid, BigQuery returns statistics about the job such as how many
+      #   bytes would be processed. If the query is invalid, an error returns.
+      #   The default value is +false+. (+Boolean+)
       #
       # === Returns
       #
@@ -335,9 +333,10 @@ module Gcloud
       #
       # :category: Data
       #
-      def data options = {}
+      def data max: nil, timeout: nil, cache: nil, dryrun: nil
         sql = "SELECT * FROM #{@gapi['id']}"
         ensure_connection!
+        options = { max: max, timeout: timeout, cache: cache, dryrun: dryrun }
         resp = connection.query sql, options
         if resp.success?
           QueryData.from_gapi resp.data, connection

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -67,9 +67,11 @@ module Gcloud
   def self.datastore project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Datastore::Dataset.default_project
     if keyfile.nil?
-      credentials = Gcloud::Datastore::Credentials.default options
+      credentials = Gcloud::Datastore::Credentials.default(
+        scope: options[:scope])
     else
-      credentials = Gcloud::Datastore::Credentials.new keyfile, options
+      credentials = Gcloud::Datastore::Credentials.new keyfile,
+                                                       scope: options[:scope]
     end
     Gcloud::Datastore::Dataset.new project, credentials
   end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -33,9 +33,7 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -64,14 +62,12 @@ module Gcloud
   #
   #   dataset.save entity
   #
-  def self.datastore project = nil, keyfile = nil, options = {}
+  def self.datastore project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Datastore::Dataset.default_project
     if keyfile.nil?
-      credentials = Gcloud::Datastore::Credentials.default(
-        scope: options[:scope])
+      credentials = Gcloud::Datastore::Credentials.default scope: scope
     else
-      credentials = Gcloud::Datastore::Credentials.new keyfile,
-                                                       scope: options[:scope]
+      credentials = Gcloud::Datastore::Credentials.new keyfile, scope: scope
     end
     Gcloud::Datastore::Dataset.new project, credentials
   end

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -241,9 +241,7 @@ module Gcloud
       #
       # +query+::
       #   The Query object with the search criteria. (+Query+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:namespace]</code>::
+      # +namespace+::
       #   The namespace the query is to run within. (+String+)
       #
       # === Returns
@@ -263,8 +261,8 @@ module Gcloud
       #     where("completed", "=", true)
       #   tasks = dataset.run query, namespace: "ns~todo-project"
       #
-      def run query, options = {}
-        partition = optional_partition_id options[:namespace]
+      def run query, namespace: nil
+        partition = optional_partition_id namespace
         response = connection.run_query query.to_proto, partition
         entities = to_gcloud_entities response.batch.entity_result
         cursor = Proto.encode_cursor response.batch.end_cursor

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -58,9 +58,9 @@ module Gcloud
   def self.dns project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Dns::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Dns::Credentials.default options
+      credentials = Gcloud::Dns::Credentials.default scope: options[:scope]
     else
-      credentials = Gcloud::Dns::Credentials.new keyfile, options
+      credentials = Gcloud::Dns::Credentials.new keyfile, scope: options[:scope]
     end
     Gcloud::Dns::Project.new project, credentials
   end

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -30,9 +30,7 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -55,12 +53,12 @@ module Gcloud
   #
   #   zone = dns.zone "example-com"
   #
-  def self.dns project = nil, keyfile = nil, options = {}
+  def self.dns project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Dns::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Dns::Credentials.default scope: options[:scope]
+      credentials = Gcloud::Dns::Credentials.default scope: scope
     else
-      credentials = Gcloud::Dns::Credentials.new keyfile, scope: options[:scope]
+      credentials = Gcloud::Dns::Credentials.new keyfile, scope: scope
     end
     Gcloud::Dns::Project.new project, credentials
   end

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -52,10 +52,10 @@ module Gcloud
         )
       end
 
-      def list_zones options = {}
+      def list_zones token: nil, max: nil
         params = { project: @project,
-                   pageToken: options.delete(:token),
-                   maxResults: options.delete(:max)
+                   pageToken: token,
+                   maxResults: max
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(
@@ -64,11 +64,12 @@ module Gcloud
         )
       end
 
-      def create_zone zone_name, zone_dns, options = {}
+      def create_zone zone_name, zone_dns, description: nil,
+                      name_server_set: nil
         body = { kind: "dns#managedZone",
                  name: zone_name, dnsName: zone_dns,
-                 description: (options[:description] || ""),
-                 nameServerSet: options[:name_server_set]
+                 description: (description || ""),
+                 nameServerSet: name_server_set
                }.delete_if { |_, v| v.nil? }
 
         @client.execute(

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -94,12 +94,12 @@ module Gcloud
         )
       end
 
-      def list_changes zone_id, options = {}
+      def list_changes zone_id, token: nil, max: nil, order: nil, sort: nil
         params = { project: @project, managedZone: zone_id,
-                   pageToken: options.delete(:token),
-                   maxResults: options.delete(:max),
-                   sortBy: options.delete(:sort),
-                   sortOrder: options.delete(:order)
+                   pageToken: token,
+                   maxResults: max,
+                   sortBy: sort,
+                   sortOrder: order
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -120,12 +120,12 @@ module Gcloud
         )
       end
 
-      def list_records zone_id, options = {}
+      def list_records zone_id, name = nil, type = nil, token: nil, max: nil
         params = { project: @project, managedZone: zone_id,
-                   pageToken: options.delete(:token),
-                   maxResults: options.delete(:max),
-                   name: options.delete(:name),
-                   type: options.delete(:type)
+                   pageToken: token,
+                   maxResults: max,
+                   name: name,
+                   type: type
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -61,29 +61,23 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:only]</code>::
+      # +only+::
       #   Include only records of this type or types. (+String+ or +Array+)
-      # <code>options[:except]</code>::
+      # +except+::
       #   Exclude records of this type or types. (+String+ or +Array+)
       #
       # === Returns
       #
       # An array of unsaved Record instances.
       #
-      def records options = {}
-        filtered_records options[:only], options[:except]
-      end
-
-      protected
-
-      def filtered_records only, except
+      def records only: nil, except: nil
         ret = @records
         ret = ret.select { |r| Array(only).include? r.type } if only
         ret = ret.reject { |r| Array(except).include? r.type } if except
         ret
       end
+
+      protected
 
       ##
       # The zonefile library returns a two-element array in which the first

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -171,12 +171,10 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   A previously-returned page token representing part of the larger set
       #   of results to view. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of zones to return. (+Integer+)
       #
       # === Returns
@@ -210,9 +208,9 @@ module Gcloud
       #     zones = zones.next
       #   end
       #
-      def zones options = {}
+      def zones token: nil, max: nil
         ensure_connection!
-        resp = connection.list_zones options
+        resp = connection.list_zones token: token, max: max
         if resp.success?
           Zone::List.from_response resp, connection
         else
@@ -234,13 +232,11 @@ module Gcloud
       # +zone_dns+::
       #   The DNS name of this managed zone, for instance "example.com.".
       #   (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:description]</code>::
+      # +description+::
       #   A string of at most 1024 characters associated with this resource for
       #   the user's convenience. Has no effect on the managed zone's function.
       #   (+String+)
-      # <code>options[:name_server_set]</code>::
+      # +name_server_set+::
       #   A NameServerSet is a set of DNS name servers that all host the same
       #   ManagedZones. Most users will leave this field unset. (+String+)
       #
@@ -256,9 +252,12 @@ module Gcloud
       #   dns = gcloud.dns
       #   zone = dns.create_zone "example-com", "example.com."
       #
-      def create_zone zone_name, zone_dns, options = {}
+      def create_zone zone_name, zone_dns, description: nil,
+                      name_server_set: nil
         ensure_connection!
-        resp = connection.create_zone zone_name, zone_dns, options
+        resp = connection.create_zone zone_name, zone_dns,
+                                      description: description,
+                                      name_server_set: name_server_set
         if resp.success?
           Zone.from_gapi resp.data, connection
         else

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -121,9 +121,7 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:force]</code>::
+      # +force+::
       #   If +true+, ensures the deletion of the zone by first deleting all
       #   records. If +false+ and the zone contains non-essential records, the
       #   request will fail. Default is +false+. (+Boolean+)
@@ -150,8 +148,8 @@ module Gcloud
       #   zone = dns.zone "example-com"
       #   zone.delete force: true
       #
-      def delete options = {}
-        clear! if options[:force]
+      def delete force: false
+        clear! if force
 
         ensure_connection!
         resp = connection.delete_zone id

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -222,12 +222,12 @@ module Gcloud
       #
       # +options+::
       #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   A previously-returned page token representing part of the larger set
       #   of results to view. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of changes to return. (+Integer+)
-      # <code>options[:order]</code>::
+      # +order+::
       #   Sort the changes by change sequence. (+Symbol+ or +String+)
       #
       #   Acceptable values are:
@@ -462,14 +462,14 @@ module Gcloud
       #   which zone file data can be read. (+String+ or +IO+)
       # +options+::
       #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:only]</code>::
+      # +only+::
       #   Include only records of this type or types. (+String+ or +Array+)
-      # <code>options[:except]</code>::
+      # +except+::
       #   Exclude records of this type or types. (+String+ or +Array+)
-      # <code>options[:skip_soa]</code>::
+      # +skip_soa+::
       #   Do not automatically update the SOA record serial number. See #update
       #   for details. (+Boolean+)
-      # <code>options[:soa_serial]</code>::
+      # +soa_serial+::
       #   A value (or a lambda or Proc returning a value) for the new SOA record
       #   serial number. See #update for details. (+Integer+, lambda, or +Proc+)
       #
@@ -486,11 +486,12 @@ module Gcloud
       #   zone = dns.zone "example-com"
       #   change = zone.import "path/to/db.example.com"
       #
-      def import path_or_io, options = {}
-        options[:except] = Array(options[:except]).map(&:to_s).map(&:upcase)
-        options[:except] = (options[:except] + %w(SOA NS)).uniq
-        additions = Gcloud::Dns::Importer.new(self, path_or_io).records(options)
-        update additions, []
+      def import path_or_io, only: nil, except: nil,
+                 skip_soa: nil, soa_serial: nil
+        except = (Array(except).map(&:to_s).map(&:upcase) + %w(SOA NS)).uniq
+        importer = Gcloud::Dns::Importer.new self, path_or_io
+        additions = importer.records only: only, except: except
+        update additions, [], skip_soa: skip_soa, soa_serial: soa_serial
       end
 
       # rubocop:disable all

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -276,13 +276,14 @@ module Gcloud
       #     changes = changes.next
       #   end
       #
-      def changes options = {}
+      def changes token: nil, max: nil, order: nil
         ensure_connection!
         # Fix the sort options
-        options[:order] = adjust_change_sort_order options[:order]
-        options[:sort]  = "changeSequence" if options[:order]
+        order = adjust_change_sort_order order
+        sort  = "changeSequence" if order
         # Continue with the API call
-        resp = connection.list_changes id, options
+        resp = connection.list_changes id, token: token, max: max,
+                                           order: order, sort: sort
         if resp.success?
           Change::List.from_response resp, self
         else

--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -111,7 +111,7 @@ module Gcloud
         #   end
         #
         def remove name, type
-          @deletions += @zone.records(name: name, type: type).all
+          @deletions += @zone.records(name, type).all
         end
 
         ##
@@ -180,7 +180,7 @@ module Gcloud
         #   end
         #
         def modify name, type
-          existing = @zone.records(name: name, type: type).all.to_a
+          existing = @zone.records(name, type).all.to_a
           updated = existing.map(&:dup)
           updated.each { |r| yield r }
           @additions += updated

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -31,9 +31,7 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -56,13 +54,12 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  def self.pubsub project = nil, keyfile = nil, options = {}
+  def self.pubsub project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Pubsub::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Pubsub::Credentials.default scope: options[:scope]
+      credentials = Gcloud::Pubsub::Credentials.default scope: scope
     else
-      credentials = Gcloud::Pubsub::Credentials.new keyfile,
-                                                    scope: options[:scope]
+      credentials = Gcloud::Pubsub::Credentials.new keyfile, scope: scope
     end
     Gcloud::Pubsub::Project.new project, credentials
   end

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -59,9 +59,10 @@ module Gcloud
   def self.pubsub project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Pubsub::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Pubsub::Credentials.default options
+      credentials = Gcloud::Pubsub::Credentials.default scope: options[:scope]
     else
-      credentials = Gcloud::Pubsub::Credentials.new keyfile, options
+      credentials = Gcloud::Pubsub::Credentials.new keyfile,
+                                                    scope: options[:scope]
     end
     Gcloud::Pubsub::Project.new project, credentials
   end

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -280,7 +280,7 @@ module Gcloud
       def subscription_data topic, options = {}
         deadline   = options[:deadline]
         endpoint   = options[:endpoint]
-        attributes = hashify options[:attributes]
+        attributes = (options[:attributes] || {}).to_h
 
         data = { topic: topic_path(topic) }
         data[:ackDeadlineSeconds] = deadline if deadline
@@ -289,17 +289,6 @@ module Gcloud
                                 attributes:   attributes }
         end
         data
-      end
-
-      ##
-      # Make sure the object is converted to a hash
-      # Ruby 1.9.3 doesn't support to_h, so here we are.
-      def hashify hash
-        if hash.respond_to? :to_h
-          hash.to_h
-        else
-          Hash.try_convert(hash) || {}
-        end
       end
     end
   end

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -266,7 +266,7 @@ module Gcloud
       #   The message data. (+String+)
       # +attributes+::
       #   Optional attributes for the message. (+Hash+)
-      # <code>attributes[:autocreate+::
+      # <code>attributes[:autocreate]</code>::
       #   Flag to control whether the provided topic will be created if it does
       #   not exist.
       #
@@ -354,7 +354,7 @@ module Gcloud
       # +endpoint+::
       #   A URL locating the endpoint to which messages should be pushed.
       #   e.g. "https://example.com/push" (+String+)
-      # <code>attributes[:autocreate+::
+      # +autocreate+::
       #   Flag to control whether the topic will be created if it does not
       #   exist.
       #

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -85,17 +85,15 @@ module Gcloud
       #
       # +topic_name+::
       #   Name of a topic. (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:autocreate]</code>::
+      # +autocreate+::
       #   Flag to control whether the requested topic will be created if it does
       #   not exist. Ignored if +skip_lookup+ is +true+. The default value is
       #   +false+. (+Boolean+)
-      # <code>options[:project]</code>::
+      # +project+::
       #   If the topic belongs to a project other than the one currently
       #   connected to, the alternate project ID can be specified here.
       #   (+String+)
-      # <code>options[:skip_lookup]</code>::
+      # +skip_lookup+::
       #   Optionally create a Topic object without verifying the topic resource
       #   exists on the Pub/Sub service. Calls made on this object will raise
       #   errors if the topic resource does not exist. Default is +false+.
@@ -150,15 +148,14 @@ module Gcloud
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "another-topic", skip_lookup: true
       #
-      def topic topic_name, options = {}
+      def topic topic_name, autocreate: nil, project: nil, skip_lookup: nil
         ensure_connection!
-        if options[:skip_lookup]
-          return Topic.new_lazy(topic_name, connection, options)
-        end
+        options = { project: project }
+        return Topic.new_lazy(topic_name, connection, options) if skip_lookup
         resp = connection.get_topic topic_name
         return Topic.from_gapi(resp.data, connection) if resp.success?
         if resp.status == 404
-          return create_topic(topic_name) if options[:autocreate]
+          return create_topic(topic_name) if autocreate
           return nil
         end
         fail ApiError.from_response(resp)
@@ -202,14 +199,11 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      #   (+String+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   The +token+ value returned by the last call to +topics+; indicates
       #   that this is a continuation of a call, and that the system should
       #   return the next page of data. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of topics to return. (+Integer+)
       #
       # === Returns
@@ -248,8 +242,9 @@ module Gcloud
       #     tmp_topics = pubsub.topics token: tmp_topics.token
       #   end
       #
-      def topics options = {}
+      def topics token: nil, max: nil
         ensure_connection!
+        options = { token: token, max: max }
         resp = connection.list_topics options
         if resp.success?
           Topic::List.from_response resp, connection
@@ -271,7 +266,7 @@ module Gcloud
       #   The message data. (+String+)
       # +attributes+::
       #   Optional attributes for the message. (+Hash+)
-      # <code>attributes[:autocreate]</code>::
+      # <code>attributes[:autocreate+::
       #   Flag to control whether the provided topic will be created if it does
       #   not exist.
       #
@@ -353,15 +348,13 @@ module Gcloud
       #   periods (.), tildes (~), plus (+) or percent signs (%). It must be
       #   between 3 and 255 characters in length, and it must not start with
       #   "goog". (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:deadline]</code>::
+      # +deadline+::
       #   The maximum number of seconds after a subscriber receives a message
       #   before the subscriber should acknowledge the message. (+Integer+)
-      # <code>options[:endpoint]</code>::
+      # +endpoint+::
       #   A URL locating the endpoint to which messages should be pushed.
       #   e.g. "https://example.com/push" (+String+)
-      # <code>attributes[:autocreate]</code>::
+      # <code>attributes[:autocreate+::
       #   Flag to control whether the topic will be created if it does not
       #   exist.
       #
@@ -411,15 +404,18 @@ module Gcloud
       #
       #   sub = pubsub.subscribe "new-topic", "new-topic-sub", autocreate: true
       #
-      def subscribe topic_name, subscription_name, options = {}
+      def subscribe topic_name, subscription_name, deadline: nil, endpoint: nil,
+                    autocreate: nil
         ensure_connection!
+        options = { deadline: deadline, endpoint: endpoint }
         resp = connection.create_subscription topic_name,
                                               subscription_name, options
         return Subscription.from_gapi(resp.data, connection) if resp.success?
-        if options[:autocreate] && resp.status == 404
+        if autocreate && resp.status == 404
           create_topic topic_name
           return subscribe(topic_name, subscription_name,
-                           options.merge(autocreate: false))
+                           deadline: deadline, endpoint: endpoint,
+                           autocreate: false)
         end
         fail ApiError.from_response(resp)
       end
@@ -433,13 +429,11 @@ module Gcloud
       #
       # +subscription_name+::
       #   Name of a subscription. (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:project]</code>::
+      # +project+::
       #   If the subscription belongs to a project other than the one currently
       #   connected to, the alternate project ID can be specified here.
       #   (+String+)
-      # <code>options[:skip_lookup]</code>::
+      # +skip_lookup+::
       #   Optionally create a Subscription object without verifying the
       #   subscription resource exists on the Pub/Sub service. Calls made on
       #   this object will raise errors if the service resource does not exist.
@@ -471,9 +465,10 @@ module Gcloud
       #   subscription = pubsub.subscription "my-sub", skip_lookup: true
       #   puts subscription.name
       #
-      def subscription subscription_name, options = {}
+      def subscription subscription_name, project: nil, skip_lookup: nil
         ensure_connection!
-        if options[:skip_lookup]
+        options = { project: project }
+        if skip_lookup
           return Subscription.new_lazy(subscription_name, connection, options)
         end
         resp = connection.get_subscription subscription_name
@@ -489,15 +484,13 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:prefix]</code>::
+      # +prefix+::
       #   Filter results to subscriptions whose names begin with this prefix.
       #   (+String+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   A previously-returned page token representing part of the larger set
       #   of results to view. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of subscriptions to return. (+Integer+)
       #
       # === Returns
@@ -537,8 +530,9 @@ module Gcloud
       #     tmp_subs = pubsub.subscriptions token: tmp_subs.token
       #   end
       #
-      def subscriptions options = {}
+      def subscriptions prefix: nil, token: nil, max: nil
         ensure_connection!
+        options = { prefix: prefix, token: token, max: max }
         resp = connection.list_subscriptions options
         if resp.success?
           Subscription::List.from_response resp, connection

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -108,12 +108,10 @@ module Gcloud
       #   periods (.), tildes (~), plus (+) or percent signs (%). It must be
       #   between 3 and 255 characters in length, and it must not start with
       #   "goog". (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:deadline]</code>::
+      # +deadline+::
       #   The maximum number of seconds after a subscriber receives a message
       #   before the subscriber should acknowledge the message. (+Integer+)
-      # <code>options[:endpoint]</code>::
+      # +endpoint+::
       #   A URL locating the endpoint to which messages should be pushed.
       #   e.g. "https://example.com/push" (+String+)
       #
@@ -156,8 +154,9 @@ module Gcloud
       #                         deadline: 120,
       #                         endpoint: "https://example.com/push"
       #
-      def subscribe subscription_name, options = {}
+      def subscribe subscription_name, deadline: nil, endpoint: nil
         ensure_connection!
+        options = { deadline: deadline, endpoint: endpoint }
         resp = connection.create_subscription name, subscription_name, options
         if resp.success?
           Subscription.from_gapi resp.data, connection
@@ -175,9 +174,7 @@ module Gcloud
       #
       # +subscription_name+::
       #   Name of a subscription. (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:skip_lookup]</code>::
+      # +skip_lookup+::
       #   Optionally create a Subscription object without verifying the
       #   subscription resource exists on the Pub/Sub service. Calls made on
       #   this object will raise errors if the service resource does not exist.
@@ -210,10 +207,10 @@ module Gcloud
       #   subscription = pubsub.subscription "my-sub", skip_lookup: true
       #   puts subscription.name
       #
-      def subscription subscription_name, options = {}
+      def subscription subscription_name, skip_lookup: nil
         ensure_connection!
-        if options[:skip_lookup]
-          return Subscription.new_lazy(subscription_name, connection, options)
+        if skip_lookup
+          return Subscription.new_lazy(subscription_name, connection)
         end
         resp = connection.get_subscription subscription_name
         return Subscription.from_gapi(resp.data, connection) if resp.success?
@@ -228,13 +225,11 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:token]</code>::
+      # +token+::
       #   The +token+ value returned by the last call to +subscriptions+;
       #   indicates that this is a continuation of a call, and that the system
       #   should return the next page of data. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of subscriptions to return. (+Integer+)
       #
       # === Returns
@@ -275,8 +270,9 @@ module Gcloud
       #     tmp_subs = topic.subscriptions token: tmp_subs.token
       #   end
       #
-      def subscriptions options = {}
+      def subscriptions token: nil, max: nil
         ensure_connection!
+        options = { token: token, max: max }
         resp = connection.list_topics_subscriptions name, options
         if resp.success?
           Subscription::List.from_response resp, connection
@@ -351,9 +347,7 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:force]</code>::
+      # +force+::
       #   Force the latest policy to be retrieved from the Pub/Sub service when
       #   +true. Otherwise the policy will be memoized to reduce the number of
       #   API calls made to the Pub/Sub service. The default is +false+.
@@ -396,8 +390,8 @@ module Gcloud
       #   topic = pubsub.topic "my-topic"
       #   policy = topic.policy force: true
       #
-      def policy options = {}
-        @policy = nil if options[:force]
+      def policy force: nil
+        @policy = nil if force
         @policy ||= begin
           ensure_connection!
           resp = connection.get_topic_policy name

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -612,11 +612,7 @@ module Gcloud
         ##
         # Make the hash look like it was returned from the Cloud API.
         def jsonify_hash hash
-          if hash.respond_to? :to_h
-            hash = hash.to_h
-          else
-            hash = Hash.try_convert(hash) || {}
-          end
+          hash = (hash || {}).to_h
           return hash if hash.empty?
           JSON.parse(JSON.dump(hash))
         end

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -27,9 +27,7 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -52,13 +50,12 @@ module Gcloud
   #     puts projects.project_id
   #   end
   #
-  def self.resource_manager keyfile = nil, options = {}
+  def self.resource_manager keyfile = nil, scope: nil
     if keyfile.nil?
-      credentials = Gcloud::ResourceManager::Credentials.default(
-        scope: options[:scope])
+      credentials = Gcloud::ResourceManager::Credentials.default scope: scope
     else
-      credentials = Gcloud::ResourceManager::Credentials.new(
-        keyfile, scope: options[:scope])
+      credentials = Gcloud::ResourceManager::Credentials.new keyfile,
+                                                             scope: scope
     end
     Gcloud::ResourceManager::Manager.new credentials
   end

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -54,9 +54,11 @@ module Gcloud
   #
   def self.resource_manager keyfile = nil, options = {}
     if keyfile.nil?
-      credentials = Gcloud::ResourceManager::Credentials.default options
+      credentials = Gcloud::ResourceManager::Credentials.default(
+        scope: options[:scope])
     else
-      credentials = Gcloud::ResourceManager::Credentials.new keyfile, options
+      credentials = Gcloud::ResourceManager::Credentials.new(
+        keyfile, scope: options[:scope])
     end
     Gcloud::ResourceManager::Manager.new credentials
   end

--- a/lib/gcloud/resource_manager/connection.rb
+++ b/lib/gcloud/resource_manager/connection.rb
@@ -36,10 +36,10 @@ module Gcloud
         @res_man = @client.discovered_api "cloudresourcemanager", API_VERSION
       end
 
-      def list_project options = {}
-        params = { filter: options.delete(:filter),
-                   pageToken: options.delete(:token),
-                   maxResults: options.delete(:max)
+      def list_project filter: nil, token: nil, max: nil
+        params = { filter: filter,
+                   pageToken: token,
+                   maxResults: max
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -54,9 +54,7 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:filter]</code>::
+      # +filter+::
       #   An expression for filtering the results of the request. Filter rules
       #   are case insensitive. (+String+)
       #
@@ -74,10 +72,10 @@ module Gcloud
       #   * +labels.color:red+ - The project's label color has the value red.
       #   * <code>labels.color:red labels.size:big</code> - The project's label
       #     color has the value red and its label size has the value big.
-      # <code>options[:token]</code>::
+      # +token+::
       #   A previously-returned page token representing part of the larger set
       #   of results to view. (+String+)
-      # <code>options[:max]</code>::
+      # +max+::
       #   Maximum number of projects to return. (+Integer+)
       #
       # === Returns
@@ -119,8 +117,8 @@ module Gcloud
       #     puts project.project_id
       #   end
       #
-      def projects options = {}
-        resp = connection.list_project options
+      def projects filter: nil, token: nil, max: nil
+        resp = connection.list_project filter: filter, token: token, max: max
         if resp.success?
           Project::List.from_response resp, self
         else
@@ -174,16 +172,14 @@ module Gcloud
       #   The unique, user-assigned ID of the project. It must be 6 to 30
       #   lowercase letters, digits, or hyphens. It must start with a letter.
       #   Trailing hyphens are prohibited. (+String+)
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:name]</code>::
+      # +name+::
       #   The user-assigned name of the project. This field is optional and can
       #   remain unset.
       #
       #   Allowed characters are: lowercase and uppercase letters, numbers,
       #   hyphen, single-quote, double-quote, space, and exclamation point.
       #   (+String+)
-      # <code>options[:labels]</code>::
+      # +labels+::
       #   The labels associated with this project.
       #
       #   Label keys must be between 1 and 63 characters long and must conform
@@ -218,10 +214,10 @@ module Gcloud
       #                                             name: "Todos Development",
       #                                             labels: {env: :development}
       #
-      def create_project project_id, options = {}
+      def create_project project_id, name: nil, labels: nil
         resp = connection.create_project project_id,
-                                         options[:name],
-                                         options[:labels]
+                                         name,
+                                         labels
         if resp.success?
           Project.from_gapi resp.data, connection
         else

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -366,9 +366,7 @@ module Gcloud
       #
       # === Parameters
       #
-      # +options+::
-      #   An optional Hash for controlling additional behavior. (+Hash+)
-      # <code>options[:force]</code>::
+      # +force+::
       #   Force load the latest policy when +true+. Otherwise the policy will be
       #   memoized to reduce the number of API calls made. The default is
       #   +false+. (+Boolean+)
@@ -411,8 +409,8 @@ module Gcloud
       #   project = resource_manager.project "tokyo-rain-123"
       #   policy = project.policy force: true
       #
-      def policy options = {}
-        @policy = nil if options[:force]
+      def policy force: nil
+        @policy = nil if force
         @policy ||= begin
           ensure_connection!
           resp = connection.get_policy project_id

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -31,9 +31,7 @@ module Gcloud
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
-  # +options+::
-  #   An optional Hash for controlling additional behavior. (+Hash+)
-  # <code>options[:scope]</code>::
+  # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See {Using OAuth 2.0 to Access Google
   #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
@@ -57,13 +55,12 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  def self.storage project = nil, keyfile = nil, options = {}
+  def self.storage project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Storage::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Storage::Credentials.default scope: options[:scope]
+      credentials = Gcloud::Storage::Credentials.default scope: scope
     else
-      credentials = Gcloud::Storage::Credentials.new keyfile,
-                                                     scope: options[:scope]
+      credentials = Gcloud::Storage::Credentials.new keyfile, scope: scope
     end
     Gcloud::Storage::Project.new project, credentials
   end

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -60,9 +60,10 @@ module Gcloud
   def self.storage project = nil, keyfile = nil, options = {}
     project ||= Gcloud::Storage::Project.default_project
     if keyfile.nil?
-      credentials = Gcloud::Storage::Credentials.default options
+      credentials = Gcloud::Storage::Credentials.default scope: options[:scope]
     else
-      credentials = Gcloud::Storage::Credentials.new keyfile, options
+      credentials = Gcloud::Storage::Credentials.new keyfile,
+                                                     scope: options[:scope]
     end
     Gcloud::Storage::Project.new project, credentials
   end

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -75,14 +75,12 @@ module Gcloud
         #   The list of HTTP methods permitted in cross origin resource sharing
         #   with the bucket. (GET, OPTIONS, POST, etc) Note: "*" is permitted in
         #   the list of methods, and means "any method". (+String+ or +Array+)
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:headers]</code>::
+        # +headers+::
         #   The list of header field names to send in the
         #   Access-Control-Allow-Headers header in the preflight response.
         #   Indicates the custom request headers that may be used in the actual
         #   request. (+String+ or +Array+)
-        # <code>options[:max_age]</code>::
+        # +max_age+::
         #   The value to send in the Access-Control-Max-Age header in the
         #   preflight response. Indicates how many seconds the results of a
         #   preflight request can be cached in a preflight result cache. The
@@ -102,10 +100,10 @@ module Gcloud
         #                max_age: 300
         #   end
         #
-        def add_rule origin, methods, options = {}
+        def add_rule origin, methods, headers: nil, max_age: nil
           rule = { "origin" => Array(origin), "method" => Array(methods) }
-          rule["responseHeader"] = Array(options[:headers]) || []
-          rule["maxAgeSeconds"] = options[:max_age] || 1800
+          rule["responseHeader"] = Array(headers) || []
+          rule["maxAgeSeconds"]  = max_age || 1800
           push rule
         end
       end

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -174,9 +174,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:generation]</code>::
+        # +generation+::
         #   When present, selects a specific revision of this object.
         #   Default is the latest version. (+Integer+)
         #
@@ -210,7 +208,8 @@ module Gcloud
         #   email = "authors@example.net"
         #   file.acl.add_owner "group-#{email}"
         #
-        def add_owner entity, options = {}
+        def add_owner entity, generation: nil
+          options = { generation: generation }
           resp = @connection.insert_file_acl @bucket, @file, entity,
                                              "OWNER", options
           if resp.success?
@@ -239,9 +238,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:generation]</code>::
+        # +generation+::
         #   When present, selects a specific revision of this object.
         #   Default is the latest version. (+Integer+)
         #
@@ -275,7 +272,8 @@ module Gcloud
         #   email = "authors@example.net"
         #   file.acl.add_writer "group-#{email}"
         #
-        def add_writer entity, options = {}
+        def add_writer entity, generation: nil
+          options = { generation: generation }
           resp = @connection.insert_file_acl @bucket, @file, entity,
                                              "WRITER", options
           if resp.success?
@@ -304,9 +302,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:generation]</code>::
+        # +generation+::
         #   When present, selects a specific revision of this object.
         #   Default is the latest version. (+Integer+)
         #
@@ -340,7 +336,8 @@ module Gcloud
         #   email = "authors@example.net"
         #   file.acl.add_reader "group-#{email}"
         #
-        def add_reader entity, options = {}
+        def add_reader entity, generation: nil
+          options = { generation: generation }
           resp = @connection.insert_file_acl @bucket, @file, entity,
                                              "READER", options
           if resp.success?
@@ -369,9 +366,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +options+::
-        #   An optional Hash for controlling additional behavior. (+Hash+)
-        # <code>options[:generation]</code>::
+        # +generation+::
         #   When present, selects a specific revision of this object.
         #   Default is the latest version. (+Integer+)
         #
@@ -388,7 +383,8 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.delete "user-#{email}"
         #
-        def delete entity, options = {}
+        def delete entity, generation: nil
+          options = { generation: generation }
           resp = @connection.delete_file_acl @bucket, @file, entity, options
           if resp.success?
             @owners.delete entity  unless @owners.nil?

--- a/test/gcloud/bigquery/dataset_query_test.rb
+++ b/test/gcloud/bigquery/dataset_query_test.rb
@@ -31,7 +31,6 @@ describe Gcloud::Bigquery::Dataset, :query, :mock_bigquery do
       json["defaultDataset"]["projectId"].must_equal dataset.project_id
       json["timeoutMs"].must_equal 10000
       json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_be :nil?
       json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]

--- a/test/gcloud/bigquery/dataset_query_test.rb
+++ b/test/gcloud/bigquery/dataset_query_test.rb
@@ -29,10 +29,10 @@ describe Gcloud::Bigquery::Dataset, :query, :mock_bigquery do
       json["defaultDataset"].wont_be :nil?
       json["defaultDataset"]["datasetId"].must_equal dataset.dataset_id
       json["defaultDataset"]["projectId"].must_equal dataset.project_id
-      json["timeoutMs"].must_be :nil?
+      json["timeoutMs"].must_equal 10000
       json["dryRun"].must_be :nil?
       json["preserveNulls"].must_be :nil?
-      json["useQueryCache"].must_be :nil?
+      json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]
     end

--- a/test/gcloud/bigquery/project_query_job_test.rb
+++ b/test/gcloud/bigquery/project_query_job_test.rb
@@ -29,8 +29,8 @@ describe Gcloud::Bigquery::Project, :query_job, :mock_bigquery do
     mock_connection.post "/bigquery/v2/projects/#{project}/jobs" do |env|
       json = JSON.parse(env.body)
       json["configuration"]["query"]["query"].must_equal query
-      json["configuration"]["query"]["priority"].must_be :nil?
-      json["configuration"]["query"]["useQueryCache"].must_be :nil?
+      json["configuration"]["query"]["priority"].must_equal "INTERACTIVE"
+      json["configuration"]["query"]["useQueryCache"].must_equal true
       json["configuration"]["query"]["destinationTable"].must_be :nil?
       json["configuration"]["query"]["createDisposition"].must_be :nil?
       json["configuration"]["query"]["writeDisposition"].must_be :nil?

--- a/test/gcloud/bigquery/project_query_test.rb
+++ b/test/gcloud/bigquery/project_query_test.rb
@@ -31,10 +31,9 @@ describe Gcloud::Bigquery::Project, :query, :mock_bigquery do
       json["query"].must_equal query
       json["maxResults"].must_be :nil?
       json["defaultDataset"].must_be :nil?
-      json["timeoutMs"].must_be :nil?
+      json["timeoutMs"].must_equal 10000
       json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_be :nil?
-      json["useQueryCache"].must_be :nil?
+      json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]
     end
@@ -92,10 +91,9 @@ describe Gcloud::Bigquery::Project, :query, :mock_bigquery do
       json["query"].must_equal query
       json["maxResults"].must_equal 42
       json["defaultDataset"].must_be :nil?
-      json["timeoutMs"].must_be :nil?
+      json["timeoutMs"].must_equal 10000
       json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_be :nil?
-      json["useQueryCache"].must_be :nil?
+      json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]
     end
@@ -113,10 +111,9 @@ describe Gcloud::Bigquery::Project, :query, :mock_bigquery do
       json["defaultDataset"].wont_be :nil?
       json["defaultDataset"]["datasetId"].must_equal "some_random_dataset"
       json["defaultDataset"]["projectId"].must_equal project
-      json["timeoutMs"].must_be :nil?
+      json["timeoutMs"].must_equal 10000
       json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_be :nil?
-      json["useQueryCache"].must_be :nil?
+      json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]
     end
@@ -134,10 +131,9 @@ describe Gcloud::Bigquery::Project, :query, :mock_bigquery do
       json["defaultDataset"].wont_be :nil?
       json["defaultDataset"]["datasetId"].must_equal "some_random_dataset"
       json["defaultDataset"]["projectId"].must_equal "some_random_project"
-      json["timeoutMs"].must_be :nil?
+      json["timeoutMs"].must_equal 10000
       json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_be :nil?
-      json["useQueryCache"].must_be :nil?
+      json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]
     end
@@ -156,8 +152,7 @@ describe Gcloud::Bigquery::Project, :query, :mock_bigquery do
       json["defaultDataset"].must_be :nil?
       json["timeoutMs"].must_equal 15000
       json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_be :nil?
-      json["useQueryCache"].must_be :nil?
+      json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]
     end
@@ -167,40 +162,20 @@ describe Gcloud::Bigquery::Project, :query, :mock_bigquery do
     data.count.must_equal 3
   end
 
-  it "queries the data with XXX option" do
+  it "queries the data with dryrun option" do
     mock_connection.post "/bigquery/v2/projects/#{project}/queries" do |env|
       json = JSON.parse(env.body)
       json["query"].must_equal query
       json["maxResults"].must_be :nil?
       json["defaultDataset"].must_be :nil?
-      json["timeoutMs"].must_be :nil?
+      json["timeoutMs"].must_equal 10000
       json["dryRun"].must_equal true
-      json["preserveNulls"].must_be :nil?
-      json["useQueryCache"].must_be :nil?
+      json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]
     end
 
     data = bigquery.query query, dryrun: true
-    data.class.must_equal Gcloud::Bigquery::QueryData
-    data.count.must_equal 3
-  end
-
-  it "queries the data with preserve_nulls option" do
-    mock_connection.post "/bigquery/v2/projects/#{project}/queries" do |env|
-      json = JSON.parse(env.body)
-      json["query"].must_equal query
-      json["maxResults"].must_be :nil?
-      json["defaultDataset"].must_be :nil?
-      json["timeoutMs"].must_be :nil?
-      json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_equal true
-      json["useQueryCache"].must_be :nil?
-      [200, {"Content-Type"=>"application/json"},
-       query_data_json]
-    end
-
-    data = bigquery.query query, preserve_nulls: true
     data.class.must_equal Gcloud::Bigquery::QueryData
     data.count.must_equal 3
   end
@@ -211,9 +186,8 @@ describe Gcloud::Bigquery::Project, :query, :mock_bigquery do
       json["query"].must_equal query
       json["maxResults"].must_be :nil?
       json["defaultDataset"].must_be :nil?
-      json["timeoutMs"].must_be :nil?
+      json["timeoutMs"].must_equal 10000
       json["dryRun"].must_be :nil?
-      json["preserveNulls"].must_be :nil?
       json["useQueryCache"].must_equal true
       [200, {"Content-Type"=>"application/json"},
        query_data_json]

--- a/test/gcloud/bigquery/query_job_query_results_test.rb
+++ b/test/gcloud/bigquery/query_job_query_results_test.rb
@@ -173,7 +173,6 @@ describe Gcloud::Bigquery::QueryJob, :query_results, :mock_bigquery do
         "projectId" => project
       },
       "priority" => "BATCH",
-      "preserveNulls" => true,
       "allowLargeResults" => true,
       "useQueryCache" => true,
       "flattenResults" => true

--- a/test/gcloud/bigquery/query_job_test.rb
+++ b/test/gcloud/bigquery/query_job_test.rb
@@ -74,7 +74,6 @@ describe Gcloud::Bigquery::QueryJob, :mock_bigquery do
         "projectId" => project
       },
       "priority" => "BATCH",
-      "preserveNulls" => true,
       "allowLargeResults" => true,
       "useQueryCache" => true,
       "flattenResults" => true

--- a/test/gcloud/credentials_test.rb
+++ b/test/gcloud/credentials_test.rb
@@ -33,7 +33,7 @@ describe Gcloud::Credentials, :private do
     mocked_signet = MiniTest::Mock.new
     mocked_signet.expect :fetch_access_token!, true
 
-    stubbed_signet = ->(options) {
+    stubbed_signet = ->(options, scope: nil) {
       options[:token_credential_uri].must_equal "https://accounts.google.com/o/oauth2/token"
       options[:audience].must_equal "https://accounts.google.com/o/oauth2/token"
       options[:scope].must_equal []
@@ -54,7 +54,7 @@ describe Gcloud::Credentials, :private do
     mocked_signet = MiniTest::Mock.new
     mocked_signet.expect :fetch_access_token!, true
 
-    stubbed_signet = ->(options) {
+    stubbed_signet = ->(options, scope: nil) {
       options[:token_credential_uri].must_equal "https://accounts.google.com/o/oauth2/token"
       options[:audience].must_equal "https://accounts.google.com/o/oauth2/token"
       options[:scope].must_equal ["http://example.com/scope"]

--- a/test/gcloud/dns/zone_test.rb
+++ b/test/gcloud/dns/zone_test.rb
@@ -264,19 +264,6 @@ describe Gcloud::Dns::Zone, :mock_dns do
     records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
   end
 
-  it "lists records with name option" do
-    num_records = 3
-    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/rrsets" do |env|
-      env.params["name"].must_equal record_name
-      [200, {"Content-Type" => "application/json"},
-       list_records_json(num_records)]
-    end
-
-    records = zone.records name: record_name
-    records.size.must_equal num_records
-    records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
-  end
-
   it "lists records with name and type params" do
     num_records = 3
     mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/rrsets" do |env|
@@ -291,20 +278,6 @@ describe Gcloud::Dns::Zone, :mock_dns do
     records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
   end
 
-  it "lists records with name and type options" do
-    num_records = 3
-    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/rrsets" do |env|
-      env.params["name"].must_equal record_name
-      env.params["type"].must_equal record_type
-      [200, {"Content-Type" => "application/json"},
-       list_records_json(num_records)]
-    end
-
-    records = zone.records name: record_name, type: record_type
-    records.size.must_equal num_records
-    records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
-  end
-
   it "lists records with subdomain and type params" do
     num_records = 3
     mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/rrsets" do |env|
@@ -315,20 +288,6 @@ describe Gcloud::Dns::Zone, :mock_dns do
     end
 
     records = zone.records "www", "A"
-    records.size.must_equal num_records
-    records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
-  end
-
-  it "lists records with subdomain and type options" do
-    num_records = 3
-    mock_connection.get "/dns/v1/projects/#{project}/managedZones/#{zone.id}/rrsets" do |env|
-      env.params["name"].must_equal "www.example.com."
-      env.params["type"].must_equal "A"
-      [200, {"Content-Type" => "application/json"},
-       list_records_json(num_records)]
-    end
-
-    records = zone.records name: "www", type: "A"
     records.size.must_equal num_records
     records.each { |z| z.must_be_kind_of Gcloud::Dns::Record }
   end

--- a/test/gcloud/gcloud_test.rb
+++ b/test/gcloud/gcloud_test.rb
@@ -20,10 +20,10 @@ require "gcloud/pubsub"
 describe Gcloud do
   it "calls out to Gcloud.datastore" do
     gcloud = Gcloud.new
-    stubbed_datastore = ->(project, keyfile, options) {
+    stubbed_datastore = ->(project, keyfile, scope: nil) {
       project.must_equal nil
       keyfile.must_equal nil
-      options.must_equal({})
+      scope.must_be :nil?
       "datastore-project-object-empty"
     }
     Gcloud.stub :datastore, stubbed_datastore do
@@ -34,10 +34,10 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.datastore" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_datastore = ->(project, keyfile, options) {
+    stubbed_datastore = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({})
+      scope.must_be :nil?
       "datastore-project-object"
     }
     Gcloud.stub :datastore, stubbed_datastore do
@@ -48,10 +48,10 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.datastore" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_datastore = ->(project, keyfile, options) {
+    stubbed_datastore = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({scope: "http://example.com/scope"})
+      scope.must_equal "http://example.com/scope"
       "datastore-project-object-scoped"
     }
     Gcloud.stub :datastore, stubbed_datastore do
@@ -62,10 +62,10 @@ describe Gcloud do
 
   it "calls out to Gcloud.storage" do
     gcloud = Gcloud.new
-    stubbed_storage = ->(project, keyfile, options) {
+    stubbed_storage = ->(project, keyfile, scope: nil) {
       project.must_equal nil
       keyfile.must_equal nil
-      options.must_equal({})
+      scope.must_be :nil?
       "storage-project-object-empty"
     }
     Gcloud.stub :storage, stubbed_storage do
@@ -76,10 +76,10 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.storage" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_storage = ->(project, keyfile, options) {
+    stubbed_storage = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({})
+      scope.must_be :nil?
       "storage-project-object"
     }
     Gcloud.stub :storage, stubbed_storage do
@@ -90,10 +90,10 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.storage" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_storage = ->(project, keyfile, options) {
+    stubbed_storage = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({scope: "http://example.com/scope"})
+      scope.must_equal "http://example.com/scope"
       "storage-project-object-scoped"
     }
     Gcloud.stub :storage, stubbed_storage do
@@ -104,10 +104,10 @@ describe Gcloud do
 
   it "calls out to Gcloud.pubsub" do
     gcloud = Gcloud.new
-    stubbed_pubsub = ->(project, keyfile, options) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil) {
       project.must_equal nil
       keyfile.must_equal nil
-      options.must_equal({})
+      scope.must_be :nil?
       "pubsub-project-object-empty"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
@@ -118,10 +118,10 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.pubsub" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_pubsub = ->(project, keyfile, options) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({})
+      scope.must_be :nil?
       "pubsub-project-object"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
@@ -132,10 +132,10 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.pubsub" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_pubsub = ->(project, keyfile, options) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({scope: "http://example.com/scope"})
+      scope.must_equal "http://example.com/scope"
       "pubsub-project-object-scoped"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
@@ -146,10 +146,10 @@ describe Gcloud do
 
   it "calls out to Gcloud.bigquery" do
     gcloud = Gcloud.new
-    stubbed_bigquery = ->(project, keyfile, options) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil) {
       project.must_equal nil
       keyfile.must_equal nil
-      options.must_equal({})
+      scope.must_be :nil?
       "bigquery-project-object-empty"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
@@ -160,10 +160,10 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.bigquery" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_bigquery = ->(project, keyfile, options) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({})
+      scope.must_be :nil?
       "bigquery-project-object"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
@@ -174,10 +174,10 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.bigquery" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_bigquery = ->(project, keyfile, options) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({scope: "http://example.com/scope"})
+      scope.must_equal "http://example.com/scope"
       "bigquery-project-object-scoped"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
@@ -188,10 +188,10 @@ describe Gcloud do
 
   it "calls out to Gcloud.dns" do
     gcloud = Gcloud.new
-    stubbed_dns = ->(project, keyfile, options) {
+    stubbed_dns = ->(project, keyfile, scope: nil) {
       project.must_equal nil
       keyfile.must_equal nil
-      options.must_equal({})
+      scope.must_be :nil?
       "dns-project-object-empty"
     }
     Gcloud.stub :dns, stubbed_dns do
@@ -202,10 +202,10 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.dns" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_dns = ->(project, keyfile, options) {
+    stubbed_dns = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({})
+      scope.must_be :nil?
       "dns-project-object"
     }
     Gcloud.stub :dns, stubbed_dns do
@@ -216,10 +216,10 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.dns" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_dns = ->(project, keyfile, options) {
+    stubbed_dns = ->(project, keyfile, scope: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
-      options.must_equal({scope: "http://example.com/scope"})
+      scope.must_equal "http://example.com/scope"
       "dns-project-object-scoped"
     }
     Gcloud.stub :dns, stubbed_dns do


### PR DESCRIPTION
Remove ruby 1.9.3 from the project and upgrade to ruby 2 syntax.

- [x] Update core docs
- [x] remove 1.9 specific code
- [x] Add ruby 2 dependency
- [x] Replace BigQuery options hash with optional names parameters
- [x] Replace Datastore options hash with optional names parameters
- [x] Replace DNS options hash with optional names parameters
- [x] Replace Pub/Sub options hash with optional names parameters
- [x] Replace Resource Manager options hash with optional names parameters
- [x] Replace Storage options hash with optional names parameters

[closes #432]