### PR TITLE
Fix DNS test

### DIFF
--- a/acceptance/dns/dns_test.rb
+++ b/acceptance/dns/dns_test.rb
@@ -170,21 +170,21 @@ describe Gcloud::Dns, :dns do
       change = zone.add "retrieve.#{zone.dns}", "A", 86400, "9.10.11.12"
       change.wait_until_done!
 
-      zone.records(name: "retrieve.#{zone.dns}", type: "A").count.must_be :>=, 1
+      zone.records("retrieve.#{zone.dns}", "A").count.must_be :>=, 1
     end
 
     it "replaces records" do
-      zone.records(name: "replace.#{zone.dns}", type: "A").count.must_be :zero?
+      zone.records("replace.#{zone.dns}", "A").count.must_be :zero?
 
       change = zone.add "replace.#{zone.dns}", "A", 86400, "1.2.3.4"
       change.wait_until_done!
 
-      zone.records(name: "replace.#{zone.dns}", type: "A").count.wont_be :zero?
+      zone.records("replace.#{zone.dns}", "A").count.wont_be :zero?
 
       change = zone.replace "replace.#{zone.dns}", "A", 86400, "5.6.7.8"
       change.wait_until_done!
 
-      zone.records(name: "replace.#{zone.dns}", type: "A").count.wont_be :zero?
+      zone.records("replace.#{zone.dns}", "A").count.wont_be :zero?
     end
   end
 


### PR DESCRIPTION
Fix tests broken by PR #462.

```sh
  1) Error:
Gcloud::Dns::dns::Records#test_0002_retrieve records by name and type:
ArgumentError: unknown keywords: name, type
    /home/travis/build/GoogleCloudPlatform/gcloud-ruby/lib/gcloud/dns/zone.rb:367:in `records'
    /home/travis/build/GoogleCloudPlatform/gcloud-ruby/acceptance/dns/dns_test.rb:173:in `block (3 levels) in <top (required)>'
  2) Error:
Gcloud::Dns::dns::Records#test_0003_replaces records:
ArgumentError: unknown keywords: name, type
    /home/travis/build/GoogleCloudPlatform/gcloud-ruby/lib/gcloud/dns/zone.rb:367:in `records'
    /home/travis/build/GoogleCloudPlatform/gcloud-ruby/acceptance/dns/dns_test.rb:177:in `block (3 levels) in <top (required)>'
```