### PR TITLE
Simplify search expressions

### DIFF
--- a/acceptance/search/search_test.rb
+++ b/acceptance/search/search_test.rb
@@ -170,7 +170,8 @@ describe "Search", :search do
       sr["score"].wont_be :empty?
     end
 
-    search_results = index.search "where", fields: ["question_snippet", "answer"], expressions: {name: "question_snippet", expression: "snippet(\"where\", question)"}
+    search_results = index.search "where", fields: ["question_snippet", "answer"],
+                                  expressions: { question_snippet: "snippet(\"where\", question)" }
     search_results.count.must_equal 2
     search_results.map(&:doc_id).must_include chris_where_doc.doc_id
     search_results.map(&:doc_id).must_include mike_where_doc.doc_id
@@ -178,6 +179,23 @@ describe "Search", :search do
       sr["question"].must_be :empty?
       sr["question_snippet"].wont_be :empty?
       sr["answer"].wont_be :empty?
+      sr["answer_snippet"].must_be :empty?
+      sr["tags"].must_be :empty?
+      sr["rank"].must_be :empty?
+      sr["score"].must_be :empty?
+    end
+
+    search_results = index.search "What", fields: ["question_snippet", "answer_snippet"],
+                                  expressions: { question_snippet: "snippet(\"what\", question)",
+                                                 answer_snippet: "snippet(\"what\", answer)" }
+    search_results.count.must_equal 2
+    search_results.map(&:doc_id).must_include chris_what_doc.doc_id
+    search_results.map(&:doc_id).must_include mike_what_doc.doc_id
+    search_results.each do |sr|
+      sr["question"].must_be :empty?
+      sr["question_snippet"].wont_be :empty?
+      sr["answer"].must_be :empty?
+      sr["answer_snippet"].wont_be :empty?
       sr["tags"].must_be :empty?
       sr["rank"].must_be :empty?
       sr["score"].must_be :empty?

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -253,9 +253,8 @@ module Gcloud
   #   search = gcloud.search
   #   index = search.index "products"
   #
-  #   expressions = [{ name: "total_price", expression: "(price + tax)" }]
   #   results = index.search "cotton T-shirt",
-  #                          expressions: expressions,
+  #                          expressions: { total_price: "(price + tax)" },
   #                          fields: ["name", "total_price", "highlight"]
   #
   # Just as in documents, Result data is accessible via Fields methods:

--- a/test/gcloud/search/index_test.rb
+++ b/test/gcloud/search/index_test.rb
@@ -371,7 +371,7 @@ describe Gcloud::Search::Index, :mock_search do
   end
 
   it "searches one expression set" do
-    expression = { name: "TotalPrice", expression: "(Price+Tax)" }
+    expression = { "TotalPrice" => "(Price+Tax)" }
     expression_json = { "expression" => "(Price+Tax)", "name" => "TotalPrice" }
 
     mock_connection.get "/v1/projects/#{project}/indexes/#{index.index_id}/search" do |env|
@@ -384,13 +384,11 @@ describe Gcloud::Search::Index, :mock_search do
   end
 
   it "searches with expressions set" do
-    expressions = [
-      { name: "TotalPrice", expression: "(Price+Tax)" },
-      { name: "snippet", expression: "snippet('good times', content)" }
-    ]
+    expressions = { "TotalPrice" => "(Price+Tax)",
+                    snippet: "snippet(\"good times\", content)" }
     expressions_json = [
       { "expression" => "(Price+Tax)", "name" => "TotalPrice" },
-      { "expression" => "snippet('good times', content)", "name" => "snippet" }
+      { "expression" => "snippet(\"good times\", content)", "name" => "snippet" }
     ]
 
     mock_connection.get "/v1/projects/#{project}/indexes/#{index.index_id}/search" do |env|


### PR DESCRIPTION
Instead of accepting an array of hashes, accept a single hash and convert to the
array of hashes that the API expects. This is much simpler for users.