### PR TITLE
Convert Search docs to YARD 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ coverage
 doc
 pkg
 
+# Ignore YARD cache
+.yardoc
+
 # Ignore vagrant directory
 .vagrant
 

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+-
+OVERVIEW.md
+README.md
+AUTHENTICATION.md
+CONTRIBUTING.md
+CHANGELOG.md

--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      "httpclient", "~> 2.5"
   gem.add_development_dependency      "simplecov", "~> 0.9"
   gem.add_development_dependency      "coveralls", "~> 0.7"
+  gem.add_development_dependency      "yard", "~> 0.8"
 end

--- a/lib/gcloud/search/api_client.rb
+++ b/lib/gcloud/search/api_client.rb
@@ -19,10 +19,10 @@ require "google/api_client"
 module Gcloud
   module Search
     ##
-    # Temporary substitute for Google::APIClient. Once the Search API is
-    # discoverable, initialization of this class in Connection should be
+    # @private Temporary substitute for Google::APIClient. Once the Search API
+    # is discoverable, initialization of this class in Connection should be
     # replaced with the Google API Client.
-    class APIClient #:nodoc:
+    class APIClient
       attr_accessor :authorization, :connection
 
       ##
@@ -50,7 +50,7 @@ module Gcloud
 
       ##
       # Return type for APIClient#discovered_api
-      class DiscoveredApi #:nodoc:
+      class DiscoveredApi
         def initialize name, version
           @name = name
           @version = version
@@ -70,7 +70,7 @@ module Gcloud
 
       ##
       # Return type for DiscoveredApi http verb methods
-      class ResourcePath #:nodoc:
+      class ResourcePath
         def initialize api_name, api_version, resource_root, resource_id_param
           @root = "https://#{api_name}.googleapis.com/#{api_version}" \
                   "/projects/{projectId}/#{resource_root}"
@@ -100,7 +100,7 @@ module Gcloud
 
       ##
       # Special-case return type for DiscoveredApi http search verb method
-      class IndexResourcePath < ResourcePath #:nodoc:
+      class IndexResourcePath < ResourcePath
         def search
           api_method :get, "/{indexId}/search"
         end

--- a/lib/gcloud/search/connection.rb
+++ b/lib/gcloud/search/connection.rb
@@ -19,19 +19,19 @@ require "gcloud/search/api_client"
 module Gcloud
   module Search
     ##
-    # Represents the connection to Search,
+    # @private Represents the connection to Search,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
-      attr_accessor :client #:nodoc:
-      attr_accessor :connection #:nodoc:
+      attr_accessor :credentials
+      attr_accessor :client
+      attr_accessor :connection
 
       ##
       # Creates a new Connection instance.
-      def initialize project, credentials #:nodoc:
+      def initialize project, credentials
         @project = project
         @credentials = credentials
         client_config = {
@@ -120,7 +120,7 @@ module Gcloud
         )
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
 

--- a/lib/gcloud/search/credentials.rb
+++ b/lib/gcloud/search/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Search
     ##
-    # Represents the Oauth2 signing logic for Search.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the Oauth2 signing logic for Search.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/cloudsearch",
                "https://www.googleapis.com/auth/userinfo.email"]
       PATH_ENV_VARS = %w(SEARCH_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -23,11 +23,11 @@ module Gcloud
     # = Document
     #
     # A document is an object that stores data that can be searched. Each
-    # document has a #doc_id that is
-    # unique within its index, a #rank, and a list of #fields that contain typed
-    # data. Its field values can be accessed through hash-like methods such as
-    # #[] and #each.
+    # document has a {#doc_id} that is unique within its index, a {#rank}, and a
+    # list of {#fields} that contain typed data. Its field values can be
+    # accessed through hash-like methods such as {#[]} and {#each}.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -40,22 +40,22 @@ module Gcloud
     #   document.rank #=> 1443648166
     #   document["price"] #=> 24.95
     #
-    # For more information, see {Documents and
-    # Indexes}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   Indexes
     #
     class Document
       ##
-      # Creates a new Document instance.
+      # @private Creates a new Document instance.
       #
-      def initialize #:nodoc:
+      def initialize
         @fields = Fields.new
         @raw = {}
       end
 
       ##
       # The unique identifier for the document. Can be set explicitly when the
-      # document is saved. (See Index#document and #doc_id= .) If missing, it is
-      # automatically assigned to the document when saved.
+      # document is saved. (See {Index#document} and {#doc_id=}.) If missing, it
+      # is automatically assigned to the document when saved.
       def doc_id
         @raw["docId"]
       end
@@ -74,7 +74,7 @@ module Gcloud
       ##
       # A positive integer which determines the default ordering of documents
       # returned from a search. The rank can be set explicitly when the document
-      # is saved. (See Index#document and #rank= .)  If missing, it is
+      # is saved. (See {Index#document} and {#rank=}.)  If missing, it is
       # automatically assigned to the document when saved.
       def rank
         @raw["rank"]
@@ -87,7 +87,7 @@ module Gcloud
       # never be assigned to more than 10,000 documents. By default (when it is
       # not specified or set to 0), it is set at the time the document is
       # created to the number of seconds since January 1, 2011. The rank can be
-      # used in Index#search options +expressions+, +order+, and
+      # used in {Index#search} options +expressions+, +order+, and
       # +fields+, where it is referenced as +rank+.
       def rank= new_rank
         @raw["rank"] = new_rank
@@ -96,18 +96,12 @@ module Gcloud
       ##
       # Retrieve the field values associated to a field name.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @return [FieldValues]
       #
-      # === Returns
-      #
-      # FieldValues
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -130,7 +124,7 @@ module Gcloud
 
       ##
       # The fields in the document. Each field has a name (String) and a list of
-      # values (FieldValues). (See Fields)
+      # values ({FieldValues}). (See {Fields})
       def fields
         @fields
       end
@@ -144,20 +138,15 @@ module Gcloud
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
       # +:datetime+ or +:number+, then the added value will replace any existing
-      # values of the same type (since there can be only one). (See Fields#add)
+      # values of the same type (since there can be only one).
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The name of the field. (+String+)
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. An attempt is made to set the correct
-      #   type when this option is missing, although it must be provided for
-      #   +:geo+ values. A field can have multiple values with same or different
-      #   types; however, it cannot have multiple +:datetime+ or +:number+
-      #   values. (+Symbol+)
+      # @param [String] name The name of the field.
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. An attempt is made to
+      #   set the correct type when this option is missing, although it must be
+      #   provided for +:geo+ values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple +:datetime+ or
+      #   +:number+ values.
       #
       #   The following values are supported:
       #   * +:default+ - The value is a string. The format will be automatically
@@ -169,19 +158,15 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing
-      #     coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
-      #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
+      # @param [String] lang The language of a string value. Must be a valid
+      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -203,15 +188,11 @@ module Gcloud
       # rubocop:enable Metrics/LineLength
 
       ##
-      # Deletes a field and all values. (See Fields#delete)
+      # Deletes a field and all values. (See {Fields#delete})
       #
-      # === Parameters
+      # @param [String] name The name of the field.
       #
-      # +name+::
-      #   The name of the field. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -228,10 +209,9 @@ module Gcloud
       ##
       # Calls block once for each field, passing the field name and values pair
       # as parameters. If no block is given an enumerator is returned instead.
-      # (See Fields#each)
+      # (See {Fields#each})
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -253,8 +233,9 @@ module Gcloud
 
       ##
       # Returns a new array populated with all the field names.
-      # (See Fields#names)
+      # (See {Fields#names})
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -272,8 +253,8 @@ module Gcloud
       end
 
       ##
-      # Override to keep working in interactive shells manageable.
-      def inspect #:nodoc:
+      # @private Override to keep working in interactive shells manageable.
+      def inspect
         insp_rank = ""
         insp_rank = ", rank: #{rank}" if rank
         insp_fields = ", fields: (#{fields.names.map(&:inspect).join ', '})"
@@ -281,8 +262,8 @@ module Gcloud
       end
 
       ##
-      # New Document from a raw data object.
-      def self.from_hash hash #:nodoc:
+      # @private New Document from a raw data object.
+      def self.from_hash hash
         doc = new
         doc.instance_variable_set "@raw", hash
         doc.instance_variable_set "@fields", Fields.from_raw(hash["fields"])
@@ -290,8 +271,8 @@ module Gcloud
       end
 
       ##
-      # Returns the Document data as a hash
-      def to_hash #:nodoc:
+      # @private Returns the Document data as a hash
+      def to_hash
         hash = @raw.dup
         hash["fields"] = @fields.to_raw
         hash

--- a/lib/gcloud/search/document/list.rb
+++ b/lib/gcloud/search/document/list.rb
@@ -25,7 +25,7 @@ module Gcloud
         attr_accessor :token
 
         ##
-        # Create a new Document::List with an array of Document instances.
+        # Create a new Document::List with an array of {Document} instances.
         def initialize arr = []
           super arr
         end
@@ -45,7 +45,7 @@ module Gcloud
         end
 
         ##
-        # Retrieves all documents by repeatedly loading pages until #next?
+        # Retrieves all documents by repeatedly loading pages until {#next?}
         # returns false. Returns the list instance for method chaining.
         def all
           while next?
@@ -57,8 +57,8 @@ module Gcloud
         end
 
         ##
-        # New Documents::List from a response object.
-        def self.from_response resp, index #:nodoc:
+        # @private New Documents::List from a response object.
+        def self.from_response resp, index
           data = JSON.parse resp.body
           documents = new(Array(data["documents"]).map do |doc_hash|
             Document.from_hash doc_hash

--- a/lib/gcloud/search/errors.rb
+++ b/lib/gcloud/search/errors.rb
@@ -33,13 +33,15 @@ module Gcloud
       # The errors encountered.
       attr_reader :errors
 
-      def initialize message, code, errors = [] #:nodoc:
+      # @private
+      def initialize message, code, errors = []
         super message
         @code   = code
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         data = JSON.parse resp.body
         if data["error"]
           from_response_data data["error"]
@@ -50,11 +52,13 @@ module Gcloud
         from_response_status resp
       end
 
-      def self.from_response_data error #:nodoc:
+      # @private
+      def self.from_response_data error
         new error["message"], error["code"], error["errors"]
       end
 
-      def self.from_response_status resp #:nodoc:
+      # @private
+      def self.from_response_status resp
         if resp.status == 404
           new "#{resp.body}: #{resp.request.uri.request_uri}",
               resp.status

--- a/lib/gcloud/search/field_value.rb
+++ b/lib/gcloud/search/field_value.rb
@@ -19,7 +19,7 @@ module Gcloud
     # = FieldValue
     #
     # FieldValue is used to represent a value that belongs to a field. (See
-    # Fields and FieldValues)
+    # {Fields} and {FieldValues})
     #
     # A field value must have a type. A value that is a Numeric will default to
     # `:number`, while a DateTime will default to `:datetime`. If a type is not
@@ -29,6 +29,7 @@ module Gcloud
     # an {ISO 639-1
     # code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -41,8 +42,8 @@ module Gcloud
     #     puts "* #{value} (#{value.type}) [#{value.lang}]"
     #   end
     #
-    # For more information see {Documents and
-    # fields}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   fields
     #
     class FieldValue < DelegateClass(::Object)
       attr_reader :type, :lang, :name
@@ -51,16 +52,12 @@ module Gcloud
       # Disabled because there are links in the docs that are long.
 
       ##
-      # Create a new FieldValue object.
+      # @private Create a new FieldValue object.
       #
-      # === Parameters
-      #
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. A field can have multiple values with
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. A field can have multiple values with
       #   same or different types; however, it cannot have multiple Timestamp or
-      #   number values. (+Symbol+)
+      #   number values.
       #
       #   The following values are supported:
       #   * +:text+ - The value is a string with maximum length 1024**2
@@ -76,15 +73,11 @@ module Gcloud
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
+      # @param [String] lang The language of a string value. Must be a valid {ISO 639-1
       #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @param [String] name The name of the field. New values will be configured with this name.
       #
-      def initialize value, type: nil, lang: nil, name: nil #:nodoc:
+      def initialize value, type: nil, lang: nil, name: nil
         super value
         if type
           @type = type.to_s.downcase.to_sym
@@ -105,14 +98,14 @@ module Gcloud
       end
 
       ##
-      # Get the original value object.
-      def value #:nodoc:
+      # @private Get the original value object.
+      def value
         __getobj__
       end
 
       ##
-      # Create a new FieldValue instance from a value Hash.
-      def self.from_raw field_value, name = nil #:nodoc:
+      # @private Create a new FieldValue instance from a value Hash.
+      def self.from_raw field_value, name = nil
         value = field_value["stringValue"]
         type = field_value["stringFormat"]
         if field_value["timestampValue"]
@@ -130,8 +123,8 @@ module Gcloud
       end
 
       ##
-      # Create a raw Hash object containing the field value.
-      def to_raw #:nodoc:
+      # @private Create a raw Hash object containing the field value.
+      def to_raw
         case type
         when :atom, :default, :html, :text
           {
@@ -150,7 +143,7 @@ module Gcloud
 
       protected
 
-      def infer_type #:nodoc:
+      def infer_type
         if respond_to? :rfc3339
           :datetime
         elsif value.is_a? Numeric # must call on original object...

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -30,8 +30,9 @@ module Gcloud
     # Each field on a document can have multiple values. FieldValues is the
     # object that manages the multiple values. Values can be the same or
     # different types; however, it cannot have multiple datetime (DateTime) or
-    # number (Float) values. (See FieldValue)
+    # number (Float) values. (See {FieldValue})
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -44,25 +45,20 @@ module Gcloud
     #     puts "* #{value} (#{value.type}) [#{value.lang}]"
     #   end
     #
-    # For more information see {Documents and
-    # fields}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   Indexes
     #
     class FieldValues
       include Enumerable
 
       ##
-      # Create a new FieldValues object.
+      # @private Create a new FieldValues object.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
+      # @param [Array<FieldValue>] values A list of values to add to the field.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
-      # +values+::
-      #   A list of values to add to the field. (+Array+ of +FieldValue+
-      #   objects)
-      #
-      def initialize name, values = [] # :nodoc:
+      def initialize name, values = []
         @name = name
         @values = values
       end
@@ -77,7 +73,8 @@ module Gcloud
       # before an element. Additionally, an empty array is returned when the
       # starting index for an element range is at the end of the array.
       #
-      # Returns nil if the index (or starting index) are out of range.
+      # @return [FieldValue, nil] Returns nil if the index (or starting index)
+      #   are out of range.
       def [] index
         @values[index]
       end
@@ -86,21 +83,18 @@ module Gcloud
       # Disabled because there are links in the docs that are long.
 
       ##
-      # Add a new value. The field name will be added to the value object. If
+      # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
       # +:datetime+ or +:number+, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
-      # === Parameters
-      #
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. An attempt is made to set the correct
-      #   type when this option is missing, although it must be provided for
-      #   +:geo+ values. A field can have multiple values with same or different
-      #   types; however, it cannot have multiple +:datetime+ or +:number+
-      #   values. (+Symbol+)
+      # @param [String] name The name of the field.
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. An attempt is made to
+      #   set the correct type when this option is missing, although it must be
+      #   provided for +:geo+ values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple +:datetime+ or
+      #   +:number+ values.
       #
       #   The following values are supported:
       #   * +:default+ - The value is a string. The format will be automatically
@@ -112,23 +106,17 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing
-      #     coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
-      #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
+      # @param [String] lang The language of a string value. Must be a valid
+      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
       #
-      # === Returns
+      # @return [FieldValue]
       #
-      # FieldValue
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -156,17 +144,12 @@ module Gcloud
       ##
       # Deletes all values that are equal to value.
       #
-      # === Parameters
+      # @param [String] value The value to remove from the list of values.
       #
-      # +value+::
-      #   The value to remove from the list of values.
+      # @return [FieldValue, nil] The last deleted +FieldValue+, or +nil+ if no
+      #   matching value is found.
       #
-      # === Returns
-      #
-      # The last deleted +FieldValue+, or +nil+ if no matching value is found.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -186,21 +169,14 @@ module Gcloud
       ##
       # Deletes the value at the specified index, returning that FieldValue, or
       # +nil+ if the index is out of range.
-      ##
-      # Deletes all values that are equal to value.
       #
-      # === Parameters
+      # @param [String] index The index of the value to be removed from the list
+      #   of values.
       #
-      # +index+::
-      #   The index of the value to be removed from the list of values.
+      # @return [FieldValue] The deleted +FieldValue+ found at the specified
+      #   index, or # +nil+ if the index is out of range.
       #
-      # === Returns
-      #
-      # The deleted +FieldValue+ found at the specified index, or # +nil+ if the
-      # index is out of range.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -222,8 +198,7 @@ module Gcloud
       #
       # An Enumerator is returned if no block is given.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -247,15 +222,15 @@ module Gcloud
       end
 
       ##
-      # Create a new FieldValues instance from a name and values Hash.
-      def self.from_raw name, values #:nodoc:
+      # @private Create a new FieldValues instance from a name and values Hash.
+      def self.from_raw name, values
         field_values = values.map { |value| FieldValue.from_raw value, name }
         FieldValues.new name, field_values
       end
 
       ##
-      # Create a raw Hash object containing all the field values.
-      def to_raw #:nodoc:
+      # @private Create a raw Hash object containing all the field values.
+      def to_raw
         { "values" => @values.map(&:to_raw) }
       end
     end

--- a/lib/gcloud/search/fields.rb
+++ b/lib/gcloud/search/fields.rb
@@ -30,8 +30,9 @@ module Gcloud
     #
     # A field can have multiple values with same or different types; however, it
     # cannot have multiple datetime (DateTime) or number (Float) values. (See
-    # FieldValues and FieldValue)
+    # {FieldValues} and {FieldValue})
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -47,33 +48,27 @@ module Gcloud
     #     end
     #   end
     #
-    # For more information see {Documents and
-    # fields}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   fields
     #
     class Fields
       include Enumerable
 
       ##
-      # Create a new empty fields object.
-      def initialize #:nodoc:
+      # @private Create a new empty fields object.
+      def initialize
         @hash = {}
       end
 
       ##
       # Retrieve the field values associated to a field name.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @return [FieldValues]
       #
-      # === Returns
-      #
-      # FieldValues
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -99,18 +94,13 @@ module Gcloud
       # +:datetime+ or +:number+, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The name of the field. (+String+)
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. An attempt is made to set the correct
-      #   type when this option is missing, although it must be provided for
-      #   +:geo+ values. A field can have multiple values with same or different
-      #   types; however, it cannot have multiple +:datetime+ or +:number+
-      #   values. (+Symbol+)
+      # @param [String] name The name of the field.
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. An attempt is made to
+      #   set the correct type when this option is missing, although it must be
+      #   provided for +:geo+ values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple +:datetime+ or
+      #   +:number+ values.
       #
       #   The following values are supported:
       #   * +:default+ - The value is a string. The format will be automatically
@@ -122,19 +112,15 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing
-      #     coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
-      #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
+      # @param [String] lang The language of a string value. Must be a valid
+      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -159,13 +145,9 @@ module Gcloud
       ##
       # Deletes a field and all values.
       #
-      # === Parameters
+      # @param [String] name The name of the field.
       #
-      # +name+::
-      #   The name of the field. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -183,8 +165,7 @@ module Gcloud
       # Calls block once for each field, passing the field name and values pair
       # as parameters. If no block is given an enumerator is returned instead.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -208,6 +189,7 @@ module Gcloud
       ##
       # Returns a new array populated with all the field names.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -226,8 +208,8 @@ module Gcloud
       end
 
       ##
-      # Create a new Fields instance from a raw Hash.
-      def self.from_raw raw #:nodoc:
+      # @private Create a new Fields instance from a raw Hash.
+      def self.from_raw raw
         hsh = {}
         raw.each do |k, v|
           hsh[k] = FieldValues.from_raw k, v["values"]
@@ -238,8 +220,9 @@ module Gcloud
       end
 
       ##
-      # Create a raw Hash object containing all the field names and values.
-      def to_raw #:nodoc:
+      # @private Create a raw Hash object containing all the field names and
+      # values.
+      def to_raw
         hsh = {}
         @hash.each do |k, v|
           hsh[k] = v.to_raw unless v.empty?
@@ -250,8 +233,8 @@ module Gcloud
       protected
 
       ##
-      # Find all the fields that have values. This is needed because a field is
-      # required to have at least one value.
+      # @private Find all the fields that have values. This is needed because a
+      # field is required to have at least one value.
       #
       # Users can remove all values, and the empty FieldValues object will
       # remain in the internal hash. This is the same as not having that field.
@@ -259,7 +242,7 @@ module Gcloud
       # Users can also reference the field by name before adding a value. So we
       # have multiple valid use cases which add an empty FieldValues object to
       # the hash.
-      def fields_with_values #:nodoc:
+      def fields_with_values
         @hash.select { |_name, values| values.any? }
       end
     end

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -22,15 +22,16 @@ module Gcloud
     ##
     # = Index
     #
-    # An index manages Document instances for retrieval. Indexes cannot be
+    # An index manages {Document} instances for retrieval. Indexes cannot be
     # created, updated, or deleted directly on the server: They are derived from
     # the documents that reference them. You can manage groups of documents by
     # putting them into separate indexes.
     #
-    # With an index, you can retrieve documents with #find and #documents;
-    # manage them with #document, #save, and #remove; and perform searches over
-    # their fields with #search.
+    # With an index, you can retrieve documents with {#find} and {#documents};
+    # manage them with {#document}, {#save}, and {#remove}; and perform searches
+    # over their fields with {#search}.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -42,22 +43,22 @@ module Gcloud
     #     puts result.doc_id
     #   end
     #
-    # For more information, see {Documents and
-    # Indexes}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   Indexes
     #
     class Index
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The raw data object.
-      attr_accessor :raw #:nodoc:
+      # @private The raw data object.
+      attr_accessor :raw
 
       ##
-      # Creates a new Index instance.
+      # @private Creates a new Index instance.
       #
-      def initialize #:nodoc:
+      def initialize
         @connection = nil
         @raw = nil
       end
@@ -74,48 +75,54 @@ module Gcloud
       end
 
       ##
-      # The names of fields in which TEXT values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which TEXT values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def text_fields
         return @raw["indexedField"]["textFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which HTML values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which HTML values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def html_fields
         return @raw["indexedField"]["htmlFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which ATOM values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which ATOM values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def atom_fields
         return @raw["indexedField"]["atomFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which DATE values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which DATE values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def datetime_fields
         return @raw["indexedField"]["dateFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which NUMBER values are stored. See {Indexschemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which NUMBER values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def number_fields
         return @raw["indexedField"]["numberFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which GEO values are stored. See {Index
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which GEO values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def geo_fields
         return @raw["indexedField"]["geoFields"] if @raw["indexedField"]
         []
@@ -144,17 +151,12 @@ module Gcloud
       ##
       # Retrieves an existing document by id.
       #
-      # === Parameters
+      # @param [String, Gcloud::Search::Document] doc_id The id of a document or
+      #   a Document instance.
+      # @return [Gcloud::Search::Document, nil] Returns +nil+ if the document
+      #   does not exist
       #
-      # +doc_id+::
-      #   The id of a document or a Document instance. (+String+ or Document)
-      #
-      # === Returns
-      #
-      # Gcloud::Search::Document or +nil+ if the document does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -179,36 +181,29 @@ module Gcloud
 
       ##
       # Helper for creating a new Document instance. The returned instance is
-      # local: It is either not yet saved to the service (see #save), or if it
+      # local: It is either not yet saved to the service (see {#save}), or if it
       # has been given the id of an existing document, it is not yet populated
-      # with the document's data (see #find).
+      # with the document's data (see {#find}).
       #
-      # === Parameters
+      # @param [String, nil] doc_id An optional unique ID for the new document.
+      #   When the document is saved, this value must contain only visible,
+      #   printable ASCII characters (ASCII codes 33 through 126 inclusive) and
+      #   be no longer than 500 characters. It cannot begin with an exclamation
+      #   point (<code>!</code>), and it cannot begin and end with double
+      #   underscores (<code>__</code>).
+      # @param [Integer, nil] rank An optional rank for the new document. An
+      #   integer which determines the default ordering of documents returned
+      #   from a search. It is a bad idea to assign the same rank to many
+      #   documents, and the same rank should never be assigned to more than
+      #   10,000 documents. By default (when it is not specified or set to 0),
+      #   it is set at the time the document is saved to the number of seconds
+      #   since January 1, 2011. The rank can be used in the +expressions+,
+      #   +order+, and +fields+ options in {#search}, where it should referenced
+      #   as +rank+.
       #
-      # +doc_id+::
-      #   The unique identifier of the new document. This is optional. When the
-      #   document is saved, this value must contain only visible, printable
-      #   ASCII characters (ASCII codes 33 through 126 inclusive) and be no
-      #   longer than 500 characters. It cannot begin with an exclamation point
-      #   (<code>!</code>), and it cannot begin and end with double underscores
-      #   (<code>__</code>). (+String+)
-      # +rank+::
-      #   The rank of the new document. This is optional. A positive integer
-      #   which determines the default ordering of documents returned from a
-      #   search. It is a bad idea to assign the same rank to many documents,
-      #   and the same rank should never be assigned to more than 10,000
-      #   documents. By default (when it is not specified or set to 0), it is
-      #   set at the time the document is saved to the number of seconds since
-      #   January 1, 2011. The rank can be used in the +expressions+, +order+,
-      #   and +fields+ options in #search, where it should referenced as
-      #   +rank+. (+Integer+)
+      # @return [Gcloud::Search::Document]
       #
-      # === Returns
-      #
-      # Gcloud::Search::Document
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -219,8 +214,7 @@ module Gcloud
       #   document.doc_id #=> nil
       #   document.rank #=> nil
       #
-      # To check if an index already contains a document with the same id, pass
-      # the instance to #find:
+      # @example To check if an index already contains a document:
       #
       #   require "gcloud"
       #
@@ -241,21 +235,14 @@ module Gcloud
       ##
       # Retrieves the list of documents belonging to the index.
       #
-      # === Parameters
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of documents to return. The default
+      #   is +100+.
+      # @return [Array<Gcloud::Search::Document>] See
+      #   {Gcloud::Search::Document::List})
       #
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of documents to return. The default is +100+.
-      #   (+Integer+)
-      #
-      # === Returns
-      #
-      # Array of Gcloud::Search::Document (See Gcloud::Search::Document::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -267,8 +254,7 @@ module Gcloud
       #     puts index.index_id
       #   end
       #
-      # If you have a significant number of documents, you may need to paginate
-      # through them: (See Gcloud::Search::Document::List)
+      # @example With pagination: (See {Gcloud::Search::Document::List})
       #
       #   require "gcloud"
       #
@@ -295,21 +281,15 @@ module Gcloud
 
       ##
       # Saves a new or existing document to the index. If the document instance
-      # is new and has been given an id (see #document), it will replace an
+      # is new and has been given an id (see {#document}), it will replace an
       # existing document in the index that has the same unique id.
       #
-      # === Parameters
+      # @param [Gcloud::Search::Document] document A Document instance, either
+      #   new (see {#document}) or existing (see {#find}).
       #
-      # +document+::
-      #   A Document instance, either new (see #document) or existing (see
-      #   #find).
+      # @return [Gcloud::Search::Document]
       #
-      # === Returns
-      #
-      # Gcloud::Search::Document
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -340,17 +320,10 @@ module Gcloud
       ##
       # Permanently deletes the document from the index.
       #
-      # === Parameters
+      # @param [String] doc_id The id of the document.
+      # @return [Boolean] +true+ if successful
       #
-      # +doc_id+::
-      #   The id of the document. (+String+)
-      #
-      # === Returns
-      #
-      # +true+ if successful
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -373,24 +346,19 @@ module Gcloud
       # be created, updated, or deleted directly on the server: They are derived
       # from the documents that reference them.)
       #
-      # === Parameters
+      # @param [Boolean] force If +true+, ensures the deletion of the index by
+      #   first deleting all documents. If +false+ and the index contains
+      #   documents, the request will fail. Default is +false+.
       #
-      # +force+::
-      #   If +true+, ensures the deletion of the index by first deleting all
-      #   documents. If +false+ and the index contains documents, the request
-      #   will fail. Default is +false+. (+Boolean+)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   search = gcloud.search
       #   index = search.index "books"
+      #   index.delete
       #
-      # An index containing documents can be forcefully deleted with the +force+
-      # option:
-      #
+      # @example Deleting an index containing documents with the +force+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -417,8 +385,8 @@ module Gcloud
       end
 
       ##
-      # New Index from a raw data object.
-      def self.from_raw raw, conn #:nodoc:
+      # @private New Index from a raw data object.
+      def self.from_raw raw, conn
         new.tap do |f|
           f.raw = raw
           f.connection = conn
@@ -430,76 +398,76 @@ module Gcloud
 
       ##
       # Runs a search against the documents in the index using the provided
-      # query. For more information see the REST API documentation for
-      # {indexes.search}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/search].
+      # query.
       #
-      # === Parameters
+      # By default, Result objects are sorted by document rank. For more information
+      # see the {REST API documentation for Document.rank}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank].
       #
-      # +query+::
-      #   The query string in search query syntax. If the query is +nil+ or
-      #   empty, all documents are returned. For more information see {Query
-      #   Strings}[https://cloud.google.com/search/query]. (+String+)
-      # +expressions+::
-      #   Customized expressions used in +order+ or +fields+. The expression can
-      #   contain fields in Document, the built-in fields ( +rank+, the document
-      #   +rank+, and +score+ if scoring is enabled) and fields defined in
-      #   +expressions+. All field expressions expressed as a +Hash+ with the
-      #   keys as the +name+ and the values as the +expression+. The expression
-      #   value can be a combination of supported functions encoded in the
-      #   string. Expressions involving number fields can use the arithmetical
-      #   operators (+, -, *, /) and the built-in numeric functions (+max+,
-      #   +min+, +pow+, +count+, +log+, +abs+). Expressions involving geopoint
-      #   fields can use the +geopoint+ and +distance+ functions. Expressions
-      #   for text and html fields can use the +snippet+ function. (+Hash+)
-      # +matched_count_accuracy+::
-      #   Minimum accuracy requirement for Result::List#matched_count. If
-      #   specified, +matched_count+ will be accurate to at least that number.
-      #   For example, when set to 100, any <code>matched_count <= 100</code> is
-      #   accurate. This option may add considerable latency/expense. By default
-      #   (when it is not specified or set to 0), the accuracy is the same as
-      #   +max+. (+Integer+)
-      # +offset+::
-      #   Used to advance pagination to an arbitrary result, independent of the
-      #   previous results. Offsets are an inefficient alternative to using
-      #   +token+. (Both cannot be both set.) The default is 0.
-      #   (+Integer+)
-      # +order+::
-      #   A comma-separated list of fields for sorting on the search result,
-      #   including fields from Document, the built-in fields (+rank+ and
-      #   +score+), and fields defined in expressions. The default sorting
-      #   order is ascending. To specify descending order for a field, a suffix
-      #   <code>" desc"</code> should be appended to the field name. For
+      # You can specify how to sort results with the +order+ option. In the
+      # example below, the <code>-</code> character before +avg_review+ means
+      # that results will be sorted in ascending order by +published+ and then
+      # in descending order by +avg_review+. You can add computed fields with
+      # the +expressions+ option, and limit the fields that are returned with
+      # the +fields+ option.
+      #
+      # @see https://cloud.google.com/search/reference/rest/v1/projects/indexes/search
+      #   The REST API documentation for indexes.search
+      #
+      # @param [String] query The query string in search query syntax. If the
+      #   query is +nil+ or empty, all documents are returned. For more
+      #   information see {Query
+      #   Strings}[https://cloud.google.com/search/query].
+      # @param [Hash] expressions Customized expressions used in +order+ or
+      #   +fields+. The expression can contain fields in Document, the built-in
+      #   fields ( +rank+, the document +rank+, and +score+ if scoring is
+      #   enabled) and fields defined in +expressions+. All field expressions
+      #   expressed as a +Hash+ with the keys as the +name+ and the values as
+      #   the +expression+. The expression value can be a combination of
+      #   supported functions encoded in the string. Expressions involving
+      #   number fields can use the arithmetical operators (+, -, *, /) and the
+      #   built-in numeric functions (+max+, +min+, +pow+, +count+, +log+,
+      #   +abs+). Expressions involving geopoint fields can use the +geopoint+
+      #   and +distance+ functions. Expressions for text and html fields can use
+      #   the +snippet+ function.
+      # @param [Integer] matched_count_accuracy Minimum accuracy requirement for
+      #   {Result::List#matched_count}. If specified, +matched_count+ will be
+      #   accurate to at least that number. For example, when set to 100, any
+      #   <code>matched_count <= 100</code> is accurate. This option may add
+      #   considerable latency/expense. By default (when it is not specified or
+      #   set to 0), the accuracy is the same as +max+.
+      # @param [Integer] offset Used to advance pagination to an arbitrary
+      #   result, independent of the previous results. Offsets are an
+      #   inefficient alternative to using +token+. (Both cannot be both set.)
+      #   The default is 0.
+      # @param [String] order A comma-separated list of fields for sorting on
+      #   the search result, including fields from Document, the built-in fields
+      #   (+rank+ and +score+), and fields defined in expressions. The default
+      #   sorting order is ascending. To specify descending order for a field, a
+      #   suffix <code>" desc"</code> should be appended to the field name. For
       #   example: <code>orderBy="foo desc,bar"</code>. The default value for
       #   text sort is the empty string, and the default value for numeric sort
       #   is 0. If not specified, the search results are automatically sorted by
       #   descending +rank+. Sorting by ascending +rank+ is not allowed.
-      #   (+String+)
-      # +fields+::
-      #   The fields to return in the Search::Result objects. These can be
-      #   fields from Document, the built-in fields +rank+ and +score+, and
-      #   fields defined in expressions. The default is to return all fields.
-      #   (+String+ or +Array+ of +String+)
-      # +scorer+::
-      #   The scoring function to invoke on a search result for this query. If
-      #   scorer is not set, scoring is disabled and +score+ is 0 for all
-      #   documents in the search result. To enable document relevancy score
-      #   based on term frequency, set +scorer+ to +:generic+.
-      #   (+String+ or +Symbol+)
-      # +scorer_size+::
-      #   Maximum number of top retrieved results to score. It is valid only
-      #   when +scorer+ is set. The default is 100. (+Integer+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of results to return per page. (+Integer+)
+      # @param [String, Array<String>] fields The fields to return in the
+      #   {Search::Result} objects. These can be fields from {Document}, the
+      #   built-in fields +rank+ and +score+, and fields defined in expressions.
+      #   The default is to return all fields.
+      # @param [String, Symbol] scorer The scoring function to invoke on a
+      #   search result for this query. If scorer is not set, scoring is
+      #   disabled and +score+ is 0 for all documents in the search result. To
+      #   enable document relevancy score based on term frequency, set +scorer+
+      #   to +:generic+.
+      # @param [Integer] scorer_size Maximum number of top retrieved results to
+      #   score. It is valid only when +scorer+ is set. The default is 100.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set
+      #   of results to view.
+      # @param [Integer] max Maximum number of results to return per page.
       #
-      # === Returns
+      # @return [Array<Gcloud::Search::Result>] (See
+      #   {Gcloud::Search::Result::List})
       #
-      # Array of Gcloud::Search::Result (See Gcloud::Search::Result::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -511,8 +479,7 @@ module Gcloud
       #     puts result.doc_id
       #   end
       #
-      # If you have a significant number of search results, you may need to
-      # paginate through them: (See Gcloud::Search::Result::List)
+      # @example With pagination: (See {Gcloud::Search::Result::List})
       #
       #   require "gcloud"
       #
@@ -529,14 +496,7 @@ module Gcloud
       #     results = results.next
       #   end
       #
-      # By default, Result objects are sorted by document rank. For more information
-      # see the {REST API documentation for Document.rank}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank].
-      #
-      # You can specify how to sort results with the +order+ option. In the example
-      # below, the <code>-</code> character before +avg_review+ means that results
-      # will be sorted in ascending order by +published+ and then in descending
-      # order by +avg_review+.
-      #
+      # @example With the +order+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -546,8 +506,7 @@ module Gcloud
       #   results = index.search "dark stormy", order: "published, avg_review desc"
       #   documents = index.search query # API call
       #
-      # You can add computed fields with the +expressions+ option, and limit the
-      # fields that are returned with the +fields+ option:
+      # @example With the +fields+ option:
       #
       #   require "gcloud"
       #
@@ -559,7 +518,7 @@ module Gcloud
       #                          expressions: { total_price: "(price + tax)" },
       #                          fields: ["name", "total_price", "highlight"]
       #
-      # Just as in documents, Result data is accessible via Fields methods:
+      # @example Just as in documents, data is accessible via {Fields} methods:
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/search/index/list.rb
+++ b/lib/gcloud/search/index/list.rb
@@ -25,7 +25,7 @@ module Gcloud
         attr_accessor :token
 
         ##
-        # Create a new Index::List with an array of Index instances.
+        # Create a new Index::List with an array of {Index} instances.
         def initialize arr = []
           super arr
         end
@@ -50,7 +50,7 @@ module Gcloud
         end
 
         ##
-        # Retrieves all indexes by repeatedly loading pages until #next?
+        # Retrieves all indexes by repeatedly loading pages until {#next?}
         # returns false. Returns the list instance for method chaining.
         def all
           while next?
@@ -62,8 +62,8 @@ module Gcloud
         end
 
         ##
-        # New Indexs::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Index::List from a response object.
+        def self.from_response resp, conn
           data = JSON.parse resp.body
           indexes = new(Array(data["indexes"]).map do |raw_index|
             Index.from_raw raw_index, conn

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -28,25 +28,25 @@ module Gcloud
     # information about billing and authorized users, and they control access to
     # Google Cloud Search resources. Each project has a friendly name and a
     # unique ID. Projects can be created only in the {Google Developers
-    # Console}[https://console.developers.google.com].
+    # Console}[https://console.developers.google.com]. See {Gcloud#search}.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
     #   search = gcloud.search
     #   index = search.index "books"
     #
-    # See Gcloud#search
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Connection instance.
+      # @private Creates a new Connection instance.
       #
       # See Gcloud.search
-      def initialize project, credentials #:nodoc:
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -55,8 +55,9 @@ module Gcloud
       ##
       # The ID of the current project.
       #
-      # === Example
+      # @return [String]
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-project", "/path/to/keyfile.json"
@@ -69,8 +70,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["SEARCH_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -80,22 +81,15 @@ module Gcloud
       ##
       # Retrieves an existing index by ID.
       #
-      # === Parameters
+      # @param [String] index_id The ID of an index.
+      # @param [Boolean] skip_lookup Optionally create an Index object without
+      #   verifying the index resource exists on the Search service. Documents
+      #   saved on this object will create the index resource if the resource
+      #   does not yet exist. Default is +false+.
       #
-      # +index_id+::
-      #   The ID of an index. (+String+)
-      # +skip_lookup+::
-      #   Optionally create an Index object without verifying the index resource
-      #   exists on the Search service. Documents saved on this object will
-      #   create the index resource if the resource does not yet exist. Default
-      #   is +false+. (+Boolean+)
+      # @return [Gcloud::Search::Index, nil] nil if the index does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Search::Index or nil if the index does not exist
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -104,9 +98,7 @@ module Gcloud
       #   index = search.index "books"
       #   index.index_id #=> "books"
       #
-      # A new index can be created by providing the desired +index_id+ and the
-      # +skip_lookup+ option:
-      #
+      # @example A new index can be created with +index_id+ and +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -130,23 +122,17 @@ module Gcloud
       ##
       # Retrieves the list of indexes belonging to the project.
       #
-      # === Parameters
+      # @param [String] prefix The prefix of the index name. It is used to list
+      #   all indexes with names that have this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of indexes to return. The default is
+      #   +100+.
       #
-      # +prefix+::
-      #   The prefix of the index name. It is used to list all indexes with
-      #   names that have this prefix. (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of indexes to return. The default is +100+. (+Integer+)
+      # @return [Array<Gcloud::Search::Index>] (See
+      #   {Gcloud::Search::Index::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Search::Index (See Gcloud::Search::Index::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -157,9 +143,7 @@ module Gcloud
       #     puts index.index_id
       #   end
       #
-      # If you have a significant number of indexes, you may need to paginate
-      # through them: (See Gcloud::Search::Index::List)
-      #
+      # @example Using pagination: (See {Gcloud::Search::Index::List})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/search/result.rb
+++ b/lib/gcloud/search/result.rb
@@ -21,23 +21,27 @@ module Gcloud
     ##
     # = Result
     #
-    # See Gcloud#search
+    # See {Gcloud#search}
     class Result
       ##
-      # Creates a new Result instance.
-      def initialize #:nodoc:
+      # @private Creates a new Result instance.
+      def initialize
         @fields = Fields.new
         @raw = {}
       end
 
       ##
       # The unique identifier of the document referenced in the search result.
+      #
+      # @return [String]
       def doc_id
         @raw["docId"]
       end
 
       ##
       # The token for the next page of results.
+      #
+      # @return [String]
       def token
         @raw["nextPageToken"]
       end
@@ -45,18 +49,12 @@ module Gcloud
       ##
       # Retrieve the field values associated to a field name.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @return [FieldValue]
       #
-      # === Returns
-      #
-      # FieldValue
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -80,7 +78,7 @@ module Gcloud
 
       ##
       # The fields in the search result. Each field has a name (String) and a
-      # list of values (FieldValues). (See Fields)
+      # list of values ({FieldValues}). (See {Fields})
       def fields
         @fields
       end
@@ -90,10 +88,9 @@ module Gcloud
       ##
       # Calls block once for each field, passing the field name and values pair
       # as parameters. If no block is given an enumerator is returned instead.
-      # (See Fields#each)
+      # (See {Fields#each})
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -116,8 +113,11 @@ module Gcloud
 
       ##
       # Returns a new array populated with all the field names.
-      # (See Fields#names)
+      # (See {Fields#names})
       #
+      # @return [Array<String>]
+      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -136,8 +136,8 @@ module Gcloud
       end
 
       ##
-      # Override to keep working in interactive shells manageable.
-      def inspect #:nodoc:
+      # @private Override to keep working in interactive shells manageable.
+      def inspect
         insp_token = ""
         if token
           trunc_token = "#{token[0, 8]}...#{token[-5..-1]}"
@@ -149,8 +149,8 @@ module Gcloud
       end
 
       ##
-      # New Result from a raw data object.
-      def self.from_hash hash #:nodoc:
+      # @private New Result from a raw data object.
+      def self.from_hash hash
         result = new
         result.instance_variable_set "@raw", hash
         result.instance_variable_set "@fields", Fields.from_raw(hash["fields"])
@@ -158,8 +158,8 @@ module Gcloud
       end
 
       ##
-      # Returns the Result data as a hash
-      def to_hash #:nodoc:
+      # @private Returns the Result data as a hash
+      def to_hash
         hash = @raw.dup
         hash["fields"] = @fields.to_raw
         hash

--- a/lib/gcloud/search/result/list.rb
+++ b/lib/gcloud/search/result/list.rb
@@ -28,11 +28,11 @@ module Gcloud
         # The number of documents that match the query. It is greater than or
         # equal to the number of documents actually returned. This is an
         # approximation and not an exact count unless it is less than or equal
-        # to the Index#search +matched_count_accuracy+ option.
+        # to the {Index#search} +matched_count_accuracy+ option.
         attr_reader :matched_count
 
         ##
-        # Create a new Result::List with an array of Result instances.
+        # Create a new Result::List with an array of {Result} instances.
         def initialize arr = []
           super arr
         end
@@ -52,7 +52,7 @@ module Gcloud
         end
 
         ##
-        # Retrieves all results by repeatedly loading pages until #next?
+        # Retrieves all results by repeatedly loading pages until {#next?}
         # returns false. Returns the list instance for method chaining.
         def all
           while next?
@@ -64,8 +64,8 @@ module Gcloud
         end
 
         ##
-        # New Result::List from a response object.
-        def self.from_response resp, index, query, search_options #:nodoc:
+        # @private New Result::List from a response object.
+        def self.from_response resp, index, query, search_options
           data = JSON.parse resp.body
           results = new(Array(data["results"]).map do |raw|
             Result.from_hash raw


### PR DESCRIPTION
This PR converts Search code comments to YARD tags for the purpose of:

1. Building HTML-based API documentation.
2. Building gcloud-common JSON-based documentation.

[closes #474]