### PR TITLE
Convert Resource Manager docs to YARD

### DIFF
--- a/lib/gcloud/resource_manager/connection.rb
+++ b/lib/gcloud/resource_manager/connection.rb
@@ -19,16 +19,17 @@ require "google/api_client"
 module Gcloud
   module ResourceManager
     ##
+    # @private
     # Represents the connection to Resource Manager, as well as expose the API
     # calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1beta1"
 
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
-      def initialize credentials #:nodoc:
+      def initialize credentials
         @credentials = credentials
         @client = Google::APIClient.new application_name:    "gcloud-ruby",
                                         application_version: Gcloud::VERSION
@@ -116,7 +117,7 @@ module Gcloud
         )
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
     end

--- a/lib/gcloud/resource_manager/credentials.rb
+++ b/lib/gcloud/resource_manager/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module ResourceManager
     ##
-    # Represents the Oauth2 signing logic for Resource Manager.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the Oauth2 signing logic for Resource Manager.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/cloud-platform"]
       PATH_ENV_VARS = %w(RESOURCE_MANAGER_KEYFILE
                          GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)

--- a/lib/gcloud/resource_manager/errors.rb
+++ b/lib/gcloud/resource_manager/errors.rb
@@ -33,13 +33,15 @@ module Gcloud
       # The errors encountered.
       attr_reader :errors
 
-      def initialize message, code, errors = [] #:nodoc:
+      # @private
+      def initialize message, code, errors = []
         super message
         @code   = code
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         if resp.data? && resp.data["error"]
           from_response_data resp.data["error"]
         else
@@ -47,11 +49,13 @@ module Gcloud
         end
       end
 
-      def self.from_response_data error #:nodoc:
+      # @private
+      def self.from_response_data error
         new error["message"], error["code"], error["errors"]
       end
 
-      def self.from_response_status resp #:nodoc:
+      # @private
+      def self.from_response_status resp
         if resp.status == 404
           new "#{resp.error_message}: #{resp.request.uri.request_uri}",
               resp.status

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -33,17 +33,17 @@ module Gcloud
     #     puts projects.project_id
     #   end
     #
-    # See Gcloud#resource_manager
+    # See {Gcloud#resource_manager}
     class Manager
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Connection instance.
+      # @private Creates a new Connection instance.
       #
-      # See Gcloud.resource_manager
-      def initialize credentials #:nodoc:
+      # See {Gcloud.resource_manager}
+      def initialize credentials
         @connection = Connection.new credentials
       end
 
@@ -52,11 +52,8 @@ module Gcloud
       # specified filter. This method returns projects in an unspecified order.
       # New projects do not necessarily appear at the end of the list.
       #
-      # === Parameters
-      #
-      # +filter+::
-      #   An expression for filtering the results of the request. Filter rules
-      #   are case insensitive. (+String+)
+      # @param [String] filter An expression for filtering the results of the
+      #   request. Filter rules are case insensitive.
       #
       #   The fields eligible for filtering are:
       #   * +name+
@@ -72,19 +69,14 @@ module Gcloud
       #   * +labels.color:red+ - The project's label color has the value red.
       #   * <code>labels.color:red labels.size:big</code> - The project's label
       #     color has the value red and its label size has the value big.
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of projects to return. (+Integer+)
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of projects to return.
       #
-      # === Returns
+      # @return [Array<Gcloud::ResourceManager::Project>] (See
+      #   {Gcloud::ResourceManager::Project::List})
       #
-      # Array of Gcloud::ResourceManager::Project
-      # (See Gcloud::ResourceManager::Project::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -94,8 +86,7 @@ module Gcloud
       #     puts project.project_id
       #   end
       #
-      # Projects can be filtered using the +filter+ option:
-      #
+      # @example Projects can be filtered using the +filter+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -105,9 +96,7 @@ module Gcloud
       #     puts project.project_id
       #   end
       #
-      # If you have a significant number of projects, you may need to paginate
-      # through them: (See Gcloud::ResourceManager::Project::List)
-      #
+      # @example With pagination: (See {Gcloud::ResourceManager::Project::List})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -129,17 +118,12 @@ module Gcloud
       ##
       # Retrieves the project identified by the specified +project_id+.
       #
-      # === Parameters
+      # @param [String] project_id The ID of the project.
       #
-      # +project_id+::
-      #   The ID of the project. (+String+)
+      # @return [Gcloud::ResourceManager::Project, nil] Returns +nil+ if the
+      #   project does not exist
       #
-      # === Returns
-      #
-      # Gcloud::ResourceManager::Project, or +nil+ if the project does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -166,21 +150,15 @@ module Gcloud
       # Several APIs are activated automatically for the project, including
       # Google Cloud Storage.
       #
-      # === Parameters
-      #
-      # +project_id+::
-      #   The unique, user-assigned ID of the project. It must be 6 to 30
-      #   lowercase letters, digits, or hyphens. It must start with a letter.
-      #   Trailing hyphens are prohibited. (+String+)
-      # +name+::
-      #   The user-assigned name of the project. This field is optional and can
-      #   remain unset.
+      # @param [String] project_id The unique, user-assigned ID of the project.
+      #   It must be 6 to 30 lowercase letters, digits, or hyphens. It must
+      #   start with a letter. Trailing hyphens are prohibited.
+      # @param [String] name The user-assigned name of the project. This field
+      #   is optional and can remain unset.
       #
       #   Allowed characters are: lowercase and uppercase letters, numbers,
       #   hyphen, single-quote, double-quote, space, and exclamation point.
-      #   (+String+)
-      # +labels+::
-      #   The labels associated with this project.
+      # @param [Hash] labels The labels associated with this project.
       #
       #   Label keys must be between 1 and 63 characters long and must conform
       #   to the following regular expression:
@@ -190,22 +168,17 @@ module Gcloud
       #   to the regular expression <code>([a-z]([-a-z0-9]*[a-z0-9])?)?</code>.
       #
       #   No more than 256 labels can be associated with a given resource.
-      #   (+Hash+)
       #
-      # === Returns
+      # @return [Gcloud::ResourceManager::Project]
       #
-      # Gcloud::ResourceManager::Project
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   resource_manager = gcloud.resource_manager
       #   project = resource_manager.create_project "tokyo-rain-123"
       #
-      # A project can also be created with a +name+ and +labels+.
-      #
+      # @example A project can also be created with a +name+ and +labels+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -244,13 +217,9 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Parameters
+      # @param [String] project_id The ID of the project.
       #
-      # +project_id+::
-      #   The ID of the project. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -274,13 +243,9 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Parameters
+      # @param [String] project_id The ID of the project.
       #
-      # +project_id+::
-      #   The ID of the project. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -27,6 +27,7 @@ module Gcloud
     # for ACLs, APIs, AppEngine Apps, VMs, and other Google Cloud Platform
     # resources.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -39,16 +40,16 @@ module Gcloud
     #
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Project object.
-      def initialize #:nodoc:
+      # @private Create an empty Project object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -83,8 +84,7 @@ module Gcloud
       # Allowed characters are: lowercase and uppercase letters, numbers,
       # hyphen, single-quote, double-quote, space, and exclamation point.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -115,10 +115,7 @@ module Gcloud
       # No more than 256 labels can be associated with a given resource.
       # (+Hash+)
       #
-      # === Examples
-      #
-      # Labels are read-only and cannot be changed by direct assignment.
-      #
+      # @example Labels are read-only and cannot be changed:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -127,9 +124,7 @@ module Gcloud
       #   project.labels["env"] #=> "dev" # read only
       #   project.labels["env"] = "production" # raises error
       #
-      # Labels can be updated by passing a block, or by calling the #labels=
-      # method.
-      #
+      # @example Labels can be updated by passing a block, or with {#labels=}:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -163,8 +158,7 @@ module Gcloud
       # No more than 256 labels can be associated with a given resource.
       # (+Hash+)
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -238,10 +232,9 @@ module Gcloud
       end
 
       ##
-      # Updates the project in a single API call. See Project::Updater
+      # Updates the project in a single API call. See {Project::Updater}
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -267,8 +260,7 @@ module Gcloud
       # Reloads the project (with updated state) from the Google Cloud Resource
       # Manager service.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -306,8 +298,7 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -336,8 +327,7 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -360,20 +350,7 @@ module Gcloud
 
       ##
       # Gets the {Cloud IAM}[https://cloud.google.com/iam/] access control
-      # policy. See {Managing
-      # Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
-      #
-      # === Parameters
-      #
-      # +force+::
-      #   Force load the latest policy when +true+. Otherwise the policy will be
-      #   memoized to reduce the number of API calls made. The default is
-      #   +false+. (+Boolean+)
-      #
-      # === Returns
-      #
-      # A hash that conforms to the following structure:
+      # policy. Returns a hash that conforms to the following structure:
       #
       #   {
       #     "bindings" => [{
@@ -384,11 +361,16 @@ module Gcloud
       #     "etag" => "CAE="
       #   }
       #
-      # === Examples
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # By default the policy values are memoized to reduce the number of API
-      # calls made.
+      # @param [Boolean] force Force load the latest policy when +true+.
+      #   Otherwise the policy will be memoized to reduce the number of API
+      #   calls made. The default is +false+.
       #
+      # @return [Hash] See description
+      #
+      # @example Policy values are memoized by default:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -400,8 +382,7 @@ module Gcloud
       #   puts policy["version"]
       #   puts policy["etag"]
       #
-      # Use the +force+ option to retrieve the latest policy from the service.
-      #
+      # @example Use the +force+ option to retrieve the latest policy:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -409,7 +390,7 @@ module Gcloud
       #   project = resource_manager.project "tokyo-rain-123"
       #   policy = project.policy force: true
       #
-      def policy force: nil
+      def policy force: false
         @policy = nil if force
         @policy ||= begin
           ensure_connection!
@@ -423,14 +404,13 @@ module Gcloud
 
       ##
       # Sets the {Cloud IAM}[https://cloud.google.com/iam/] access control
-      # policy. See {Managing
-      # Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +new_policy+::
-      #   A hash that conforms to the following structure:
+      # @param [String] new_policy A hash that conforms to the following
+      #   structure:
       #
       #     {
       #       "bindings" => [{
@@ -439,8 +419,7 @@ module Gcloud
       #       }]
       #     }
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -468,23 +447,18 @@ module Gcloud
 
       ##
       # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy. See
-      # {Managing Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # IAM}[https://cloud.google.com/iam/] access control policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +permissions+::
-      #   The set of permissions to check access for. Permissions with wildcards
-      #   (such as +*+ or +storage.*+) are not allowed.
-      #   (String or Array of Strings)
+      # @param [String, Array<String>] permissions The set of permissions to
+      #   check access for. Permissions with wildcards (such as +*+ or
+      #   +storage.*+) are not allowed.
       #
-      # === Returns
+      # @return [Array<String>] The permissions that have access
       #
-      # The permissions that have access. (Array of Strings)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -507,8 +481,8 @@ module Gcloud
       end
 
       ##
-      # New Change from a Google API Client object.
-      def self.from_gapi gapi, connection #:nodoc:
+      # @private New Change from a Google API Client object.
+      def self.from_gapi gapi, connection
         new.tap do |p|
           p.gapi = gapi
           p.connection = connection

--- a/lib/gcloud/resource_manager/project/list.rb
+++ b/lib/gcloud/resource_manager/project/list.rb
@@ -48,8 +48,7 @@ module Gcloud
         # Retrieves all projects by repeatedly loading pages until #next?
         # returns false. Returns the list instance for method chaining.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -66,8 +65,8 @@ module Gcloud
         end
 
         ##
-        # New Projects::List from a response object.
-        def self.from_response resp, manager #:nodoc:
+        # @private New Projects::List from a response object.
+        def self.from_response resp, manager
           projects = new(Array(resp.data["projects"]).map do |gapi_object|
             Project.from_gapi gapi_object, manager.connection
           end)

--- a/lib/gcloud/resource_manager/project/updater.rb
+++ b/lib/gcloud/resource_manager/project/updater.rb
@@ -37,8 +37,8 @@ module Gcloud
       #
       class Updater < DelegateClass(Project)
         ##
-        # Create an Updater object.
-        def initialize project #:nodoc:
+        # @private Create an Updater object.
+        def initialize project
           super project
         end
 
@@ -49,8 +49,7 @@ module Gcloud
         # Allowed characters are: lowercase and uppercase letters, numbers,
         # hyphen, single-quote, double-quote, space, and exclamation point.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -77,8 +76,7 @@ module Gcloud
         # No more than 256 labels can be associated with a given resource.
         # (+Hash+)
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -105,8 +103,7 @@ module Gcloud
         # No more than 256 labels can be associated with a given resource.
         # (+Hash+)
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -121,8 +118,8 @@ module Gcloud
         end
 
         ##
-        # Create an Updater object.
-        def self.from_project project #:nodoc:
+        # @private Create an Updater object.
+        def self.from_project project
           dupe_gapi = project.gapi.dup
           dupe_gapi = dupe_gapi.to_hash if dupe_gapi.respond_to? :to_hash
           if dupe_gapi["labels"].respond_to? :to_hash

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -88,7 +88,6 @@ module Gcloud
       # +:datetime+ or +:number+, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
-      # @param [String] name The name of the field.
       # @param [String, Datetime, Float] value The value to add to the field.
       # @param [Symbol] type The type of the field value. An attempt is made to
       #   set the correct type when this option is missing, although it must be


### PR DESCRIPTION
This PR converts Resource Manager code comments to YARD tags for the purpose of:

1. Building HTML-based API documentation.
2. Building [gcloud-common JSON-based documentation](https://github.com/GoogleCloudPlatform/gcloud-common/issues/33).

[closes #459]

It also includes a small fix for PR #473.