### PR TITLE
Convert BigQuery docs to YARD

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -21,17 +21,17 @@ require "digest/md5"
 module Gcloud
   module Bigquery
     ##
-    # Represents the connection to Bigquery,
+    # @private Represents the connection to Bigquery,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v2"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
-      def initialize project, credentials #:nodoc:
+      def initialize project, credentials
         @project = project
         @credentials = credentials
         @client = Google::APIClient.new application_name:    "gcloud-ruby",
@@ -338,7 +338,7 @@ module Gcloud
         default_table_ref.merge str_table_ref
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
 
@@ -554,7 +554,7 @@ module Gcloud
         }
       end
 
-      def create_disposition str #:nodoc:
+      def create_disposition str
         { "create_if_needed" => "CREATE_IF_NEEDED",
           "createifneeded" => "CREATE_IF_NEEDED",
           "if_needed" => "CREATE_IF_NEEDED",
@@ -564,7 +564,7 @@ module Gcloud
           "never" => "CREATE_NEVER" }[str.to_s.downcase]
       end
 
-      def write_disposition str #:nodoc:
+      def write_disposition str
         { "write_truncate" => "WRITE_TRUNCATE",
           "writetruncate" => "WRITE_TRUNCATE",
           "truncate" => "WRITE_TRUNCATE",

--- a/lib/gcloud/bigquery/copy_job.rb
+++ b/lib/gcloud/bigquery/copy_job.rb
@@ -18,19 +18,18 @@ module Gcloud
     ##
     # = CopyJob
     #
-    # A Job subclass representing a copy operation that may be performed on a
-    # Table. A CopyJob instance is created when you call Table#copy.
+    # A {Job} subclass representing a copy operation that may be performed on a
+    # {Table}. A CopyJob instance is created when you call {Table#copy}.
     #
-    # See {Copying an Existing
-    # Table}[https://cloud.google.com/bigquery/docs/tables#copyingtable]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/docs/tables#copyingtable Copying an
+    #   Existing Table
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class CopyJob < Job
       ##
       # The table from which data is copied. This is the table on
-      # which Table#copy was called. Returns a Table instance.
+      # which {Table#copy} was called. Returns a {Table} instance.
       def source
         table = config["copy"]["sourceTable"]
         return nil unless table
@@ -40,7 +39,7 @@ module Gcloud
       end
 
       ##
-      # The table to which data is copied. Returns a Table instance.
+      # The table to which data is copied. Returns a {Table} instance.
       def destination
         table = config["copy"]["destinationTable"]
         return nil unless table

--- a/lib/gcloud/bigquery/credentials.rb
+++ b/lib/gcloud/bigquery/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Bigquery
     ##
-    # Represents the Oauth2 signing logic for Bigquery.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the Oauth2 signing logic for Bigquery.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/bigquery"]
       PATH_ENV_VARS = %w(BIGQUERY_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(BIGQUERY_KEYFILE_JSON GCLOUD_KEYFILE_JSON

--- a/lib/gcloud/bigquery/data.rb
+++ b/lib/gcloud/bigquery/data.rb
@@ -20,18 +20,19 @@ module Gcloud
     ##
     # = Data
     #
-    # Represents Table Data as a list of name/value pairs.
+    # Represents {Table} Data as a list of name/value pairs.
     # Also contains metadata such as +etag+ and +total+.
     class Data < DelegateClass(::Array)
       ##
-      # The Table object the data belongs to.
-      attr_accessor :table #:nodoc:
+      # @private The {Table} object the data belongs to.
+      attr_accessor :table
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
-      def initialize arr = [] #:nodoc:
+      # @private
+      def initialize arr = []
         @table = nil
         @gapi = {}
         super arr
@@ -79,8 +80,8 @@ module Gcloud
       end
 
       ##
-      # New Data from a response object.
-      def self.from_response resp, table #:nodoc:
+      # @private New Data from a response object.
+      def self.from_response resp, table
         formatted_rows = format_rows resp.data["rows"], table.fields
 
         data = new formatted_rows

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -30,6 +30,7 @@ module Gcloud
     # cannot control access at the table level. A dataset is contained within a
     # specific project.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -41,16 +42,16 @@ module Gcloud
     #
     class Dataset
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Dataset object.
-      def initialize #:nodoc:
+      # @private Create an empty Dataset object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -60,7 +61,7 @@ module Gcloud
       # The ID must contain only letters (a-z, A-Z), numbers (0-9),
       # or underscores (_). The maximum length is 1,024 characters.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def dataset_id
         @gapi["datasetReference"]["datasetId"]
@@ -69,16 +70,17 @@ module Gcloud
       ##
       # The ID of the project containing this dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def project_id
         @gapi["datasetReference"]["projectId"]
       end
 
       ##
+      # @private
       # The gapi fragment containing the Project ID and Dataset ID as a
       # camel-cased hash.
-      def dataset_ref #:nodoc:
+      def dataset_ref
         dataset_ref = @gapi["datasetReference"]
         dataset_ref = dataset_ref.to_hash if dataset_ref.respond_to? :to_hash
         dataset_ref
@@ -87,7 +89,7 @@ module Gcloud
       ##
       # A descriptive name for the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name
         @gapi["friendlyName"]
@@ -96,7 +98,7 @@ module Gcloud
       ##
       # Updates the descriptive name for the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name= new_name
         patch_gapi! name: new_name
@@ -105,7 +107,7 @@ module Gcloud
       ##
       # A string hash of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def etag
         ensure_full_data!
@@ -115,7 +117,7 @@ module Gcloud
       ##
       # A URL that can be used to access the dataset using the REST API.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def api_url
         ensure_full_data!
@@ -125,7 +127,7 @@ module Gcloud
       ##
       # A user-friendly description of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description
         ensure_full_data!
@@ -135,7 +137,7 @@ module Gcloud
       ##
       # Updates the user-friendly description of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description= new_description
         patch_gapi! description: new_description
@@ -144,7 +146,7 @@ module Gcloud
       ##
       # The default lifetime of all tables in the dataset, in milliseconds.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def default_expiration
         ensure_full_data!
@@ -155,7 +157,7 @@ module Gcloud
       # Updates the default lifetime of all tables in the dataset, in
       # milliseconds.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def default_expiration= new_default_expiration
         patch_gapi! default_expiration: new_default_expiration
@@ -164,7 +166,7 @@ module Gcloud
       ##
       # The time when this dataset was created.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def created_at
         ensure_full_data!
@@ -174,7 +176,7 @@ module Gcloud
       ##
       # The date when this dataset or any of its tables was last modified.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def modified_at
         ensure_full_data!
@@ -185,7 +187,7 @@ module Gcloud
       # The geographic location where the dataset should reside. Possible
       # values include EU and US. The default value is US.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def location
         ensure_full_data!
@@ -195,13 +197,13 @@ module Gcloud
       ##
       # Retrieves the access rules for a Dataset using the Google Cloud
       # Datastore API data structure of an array of hashes. The rules can be
-      # updated when passing a block, see Dataset::Access for all the methods
-      # available. See {BigQuery Access
-      # Control}[https://cloud.google.com/bigquery/access-control] for more
-      # information.
+      # updated when passing a block, see {Dataset::Access} for all the methods
+      # available.
       #
-      # === Examples
+      # @see https://cloud.google.com/bigquery/access-control BigQuery Access
+      #   Control
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -217,8 +219,7 @@ module Gcloud
       #                  #    {"role"=>"OWNER",
       #                  #     "userByEmail"=>"123456789-...com"}]
       #
-      # Manage the access rules by passing a block.
-      #
+      # @example Manage the access rules by passing a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -251,11 +252,10 @@ module Gcloud
       # information.
       #
       # This method is provided for advanced usage of managing the access rules.
-      # Calling #access with a block is the preferred way to manage access
+      # Calling {#access} with a block is the preferred way to manage access
       # rules.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -279,19 +279,13 @@ module Gcloud
       # Permanently deletes the dataset. The dataset must be empty before it can
       # be deleted unless the +force+ option is set to +true+.
       #
-      # === Parameters
+      # @param [Boolean] force If +true+, delete all the tables in the dataset.
+      #   If +false+ and the dataset contains tables, the request will fail.
+      #   Default is +false+.
       #
-      # +force+::
-      #   If +true+, delete all the tables in the dataset. If +false+ and the
-      #   dataset contains tables, the request will fail. Default is +false+.
-      #   (+Boolean+)
+      # @return [Boolean] Returns +true+ if the dataset was deleted.
       #
-      # === Returns
-      #
-      # +true+ if the dataset was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -300,7 +294,7 @@ module Gcloud
       #   dataset = bigquery.dataset "my_dataset"
       #   dataset.delete
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def delete force: nil
         ensure_connection!
@@ -313,31 +307,25 @@ module Gcloud
       end
 
       ##
-      # Creates a new table.
+      # Creates a new table. If you are adapting existing code that was written
+      # for the {Rest API
+      # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource],
+      # you can pass the table's schema as a hash (see example.)
       #
-      # === Parameters
-      #
-      # +table_id+::
-      #   The ID of the table. The ID must contain only letters (a-z, A-Z),
-      #   numbers (0-9), or underscores (_). The maximum length is 1,024
-      #   characters. (+String+)
-      # +name+::
-      #   A descriptive name for the table. (+String+)
-      # +description+::
-      #   A user-friendly description of the table. (+String+)
-      # +schema+::
-      #   A hash specifying fields and data types for the table. A block may be
-      #   passed instead (see examples.) For the format of this hash, see the
-      #   {Tables resource
+      # @param [String] table_id The ID of the table. The ID must contain only
+      #   letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum
+      #   length is 1,024 characters.
+      # @param [String] name A descriptive name for the table.
+      # @param [String] description A user-friendly description of the table.
+      # @param [Hash] schema A hash specifying fields and data types for the
+      #   table. A block may be passed instead (see examples.) For the format of
+      #   this hash, see the {Tables resource
       #   }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
-      #   . (+Hash+)
+      #   .
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Table]
       #
-      # Gcloud::Bigquery::Table
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -345,8 +333,7 @@ module Gcloud
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.create_table "my_table"
       #
-      # You can also pass name and description options.
-      #
+      # @example You can also pass name and description options.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -356,8 +343,7 @@ module Gcloud
       #                                name: "My Table",
       #                                description: "A description of my table."
       #
-      # You can define the table's schema using a block.
-      #
+      # @example You can define the table's schema using a block.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -371,10 +357,7 @@ module Gcloud
       #     end
       #   end
       #
-      # Or, if you are adapting existing code that was written for the {Rest API
-      # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource],
-      # you can pass the table's schema as a hash.
-      #
+      # @example You can pass the table's schema as a hash.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -409,7 +392,7 @@ module Gcloud
       #   }
       #   table = dataset.create_table "my_table", schema: schema
       #
-      # :category: Table
+      # @!group Table
       #
       def create_table table_id, name: nil, description: nil, schema: nil
         ensure_connection!
@@ -428,26 +411,17 @@ module Gcloud
       ##
       # Creates a new view table from the given query.
       #
-      # === Parameters
+      # @param [String] table_id The ID of the view table. The ID must contain
+      #   only letters (a-z, A-Z), numbers (0-9), or underscores (_). The
+      #   maximum length is 1,024 characters.
+      # @param [String] query The query that BigQuery executes when the view is
+      #   referenced.
+      # @param [String] name A descriptive name for the table.
+      # @param [String] description A user-friendly description of the table.
       #
-      # +table_id+::
-      #   The ID of the view table. The ID must contain only letters (a-z, A-Z),
-      #   numbers (0-9), or underscores (_). The maximum length is 1,024
-      #   characters. (+String+)
-      # +query+::
-      #   The query that BigQuery executes when the view is referenced.
-      #   (+String+)
-      # +name+::
-      #   A descriptive name for the table. (+String+)
-      # +description+::
-      #   A user-friendly description of the table. (+String+)
+      # @return [Gcloud::Bigquery::View]
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::View
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -456,8 +430,7 @@ module Gcloud
       #   view = dataset.create_view "my_view",
       #             "SELECT name, age FROM [proj:dataset.users]"
       #
-      # A name and description can be provided:
-      #
+      # @example A name and description can be provided:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -467,7 +440,7 @@ module Gcloud
       #             "SELECT name, age FROM [proj:dataset.users]",
       #             name: "My View", description: "This is my view"
       #
-      # :category: Table
+      # @!group Table
       #
       def create_view table_id, query, name: nil, description: nil
         options = { query: query, name: name, description: description }
@@ -477,18 +450,12 @@ module Gcloud
       ##
       # Retrieves an existing table by ID.
       #
-      # === Parameters
+      # @param [String] table_id The ID of a table.
       #
-      # +table_id+::
-      #   The ID of a table. (+String+)
+      # @return [Gcloud::Bigquery::Table, Gcloud::Bigquery::View, nil] Returns
+      #   +nil+ if the table does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::Table or Gcloud::Bigquery::View or nil if the table
-      # does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -497,7 +464,7 @@ module Gcloud
       #   table = dataset.table "my_table"
       #   puts table.name
       #
-      # :category: Table
+      # @!group Table
       #
       def table table_id
         ensure_connection!
@@ -512,21 +479,14 @@ module Gcloud
       ##
       # Retrieves the list of tables belonging to the dataset.
       #
-      # === Parameters
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of tables to return.
       #
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of tables to return. (+Integer+)
+      # @return [Array<Gcloud::Bigquery::Table>, Array<Gcloud::Bigquery::View>]
+      #   (See {Gcloud::Bigquery::Table::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Bigquery::Table or Gcloud::Bigquery::View
-      # (See Gcloud::Bigquery::Table::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -537,9 +497,7 @@ module Gcloud
       #     puts table.name
       #   end
       #
-      # If you have a significant number of tables, you may need to paginate
-      # through them: (See Dataset::List#token)
-      #
+      # @example With pagination: (See {Dataset::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -558,7 +516,7 @@ module Gcloud
       #     tmp_tables = dataset.tables token: tmp_tables.token
       #   end
       #
-      # :category: Table
+      # @!group Table
       #
       def tables token: nil, max: nil
         ensure_connection!
@@ -578,55 +536,46 @@ module Gcloud
       # Sets the current dataset as the default dataset in the query. Useful for
       # using unqualified table names.
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +priority+::
-      #   Specifies a priority for the query. Possible values include
-      #   +INTERACTIVE+ and +BATCH+. The default value is +INTERACTIVE+.
-      #   (+String+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is +true+. (+Boolean+)
-      # +table+::
-      #   The destination table where the query results should be stored. If not
-      #   present, a new table will be created to store the results. (+Table+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [String] priority Specifies a priority for the query. Possible
+      #   values include +INTERACTIVE+ and +BATCH+. The default value is
+      #   +INTERACTIVE+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [Table] table The destination table where the query results
+      #   should be stored. If not present, a new table will be created to store
+      #   the results.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies the action that occurs if the destination table already
-      #   exists. (+String+)
+      # @param [String] write Specifies the action that occurs if the
+      #   destination table already exists.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - A 'duplicate' error is returned in the job result if the
       #     table exists and contains data.
-      # +large_results+::
-      #   If +true+, allows the query to produce arbitrarily large result tables
-      #   at a slight cost in performance. Requires +table+ parameter to be set.
-      #   (+Boolean+)
-      # +flatten+::
-      #   Flattens all nested and repeated fields in the query results. The
-      #   default value is +true+. +large_results+ parameter must be +true+ if
-      #   this is set to +false+. (+Boolean+)
+      # @param [Boolean] large_results If +true+, allows the query to produce
+      #   arbitrarily large result tables at a slight cost in performance.
+      #   Requires +table+ parameter to be set.
+      # @param [Boolean] flatten Flattens all nested and repeated fields in the
+      #   query results. The default value is +true+. +large_results+ parameter
+      #   must be +true+ if this is set to +false+.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryJob]
       #
-      # Gcloud::Bigquery::QueryJob
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -641,7 +590,7 @@ module Gcloud
       #     end
       #   end
       #
-      # :category: Data
+      # @!group Data
       #
       def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                     create: nil, write: nil, large_results: nil, flatten: nil
@@ -665,45 +614,35 @@ module Gcloud
       # Sets the current dataset as the default dataset in the query. Useful for
       # using unqualified table names.
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +max+::
-      #   The maximum number of rows of data to return per page of results.
-      #   Setting this flag to a small value such as 1000 and then paging
-      #   through results might improve reliability when the query result set is
-      #   large. In addition to this limit, responses are also limited to 10 MB.
-      #   By default, there is no maximum row count, and only the byte limit
-      #   applies. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   the request times out and returns. Note that this is only a timeout
-      #   for the request, not the query. If the query takes longer to run than
-      #   the timeout value, the call returns without any results and with
-      #   QueryData#complete? set to false. The default value is 10000
-      #   milliseconds (10 seconds). (+Integer+)
-      # +dryrun+::
-      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
-      #   is valid, BigQuery returns statistics about the job such as how many
-      #   bytes would be processed. If the query is invalid, an error returns.
-      #   The default value is +false+. (+Boolean+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is true. For more information, see
-      #   {query caching}[https://developers.google.com/bigquery/querying-data].
-      #   (+Boolean+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [Integer] max The maximum number of rows of data to return per
+      #   page of results. Setting this flag to a small value such as 1000 and
+      #   then paging through results might improve reliability when the query
+      #   result set is large. In addition to this limit, responses are also
+      #   limited to 10 MB. By default, there is no maximum row count, and only
+      #   the byte limit applies.
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      #   Instead, if the query is valid, BigQuery returns statistics about the
+      #   job such as how many bytes would be processed. If the query is
+      #   invalid, an error returns. The default value is +false+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -714,7 +653,7 @@ module Gcloud
       #     puts row["name"]
       #   end
       #
-      # :category: Data
+      # @!group Data
       #
       def query query, max: nil, timeout: 10000, dryrun: nil, cache: true
         options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache }
@@ -730,8 +669,8 @@ module Gcloud
       end
 
       ##
-      # New Dataset from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Dataset from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -19,9 +19,12 @@ module Gcloud
       ##
       # = Dataset Access Control
       #
-      # Represents the Access rules for a Dataset. See {BigQuery Access
-      # Control}[https://cloud.google.com/bigquery/access-control].
+      # Represents the Access rules for a {Dataset}.
       #
+      # @see https://cloud.google.com/bigquery/access-control BigQuery Access
+      #   Control
+      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -37,10 +40,12 @@ module Gcloud
       #   end
       #
       class Access
+        # @private
         ROLES = { "reader" => "READER",
                   "writer" => "WRITER",
-                  "owner"  => "OWNER" } #:nodoc:
+                  "owner"  => "OWNER" }
 
+        # @private
         SCOPES = { "user"           => "userByEmail",
                    "user_by_email"  => "userByEmail",
                    "userByEmail"    => "userByEmail",
@@ -51,8 +56,9 @@ module Gcloud
                    "special"        => "specialGroup",
                    "special_group"  => "specialGroup",
                    "specialGroup"   => "specialGroup",
-                   "view"           => "view" } #:nodoc:
+                   "view"           => "view" }
 
+        # @private
         GROUPS = { "owners"                  => "projectOwners",
                    "project_owners"          => "projectOwners",
                    "projectOwners"           => "projectOwners",
@@ -66,18 +72,21 @@ module Gcloud
                    "all_authenticated_users" => "allAuthenticatedUsers",
                    "allAuthenticatedUsers"   => "allAuthenticatedUsers" }
 
-        attr_reader :access #:nodoc:
+        # @private
+        attr_reader :access
 
         ##
+        # @private
         # Initialized a new Access object.
         # Must provide a valid Dataset object.
-        def initialize access, context #:nodoc:
+        def initialize access, context
           @original   = access.dup
           @access     = access.dup
           @context    = context
         end
 
-        def changed? #:nodoc:
+        # @private
+        def changed?
           @original != @access
         end
 
@@ -112,7 +121,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def add_reader_view view
           add_access_role_scope_value :reader, :view, view
         end
@@ -148,7 +157,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def add_writer_view view
           add_access_role_scope_value :writer, :view, view
         end
@@ -184,7 +193,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def add_owner_view view
           add_access_role_scope_value :owner, :view, view
         end
@@ -220,7 +229,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def remove_reader_view view
           remove_access_role_scope_value :reader, :view, view
         end
@@ -256,7 +265,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def remove_writer_view view
           remove_access_role_scope_value :writer, :view, view
         end
@@ -292,7 +301,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def remove_owner_view view
           remove_access_role_scope_value :owner, :view, view
         end
@@ -328,7 +337,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def reader_view? view
           lookup_access_role_scope_value :reader, :view, view
         end
@@ -364,7 +373,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def writer_view? view
           lookup_access_role_scope_value :writer, :view, view
         end
@@ -400,14 +409,15 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def owner_view? view
           lookup_access_role_scope_value :owner, :view, view
         end
 
         protected
 
-        def validate_role role #:nodoc:
+        # @private
+        def validate_role role
           good_role = ROLES[role.to_s]
           if good_role.nil?
             fail ArgumentError "Unable to determine role for #{role}"
@@ -415,7 +425,8 @@ module Gcloud
           good_role
         end
 
-        def validate_scope scope #:nodoc:
+        # @private
+        def validate_scope scope
           good_scope = SCOPES[scope.to_s]
           if good_scope.nil?
             fail ArgumentError "Unable to determine scope for #{scope}"
@@ -423,13 +434,15 @@ module Gcloud
           good_scope
         end
 
-        def validate_special_group value #:nodoc:
+        # @private
+        def validate_special_group value
           good_value = GROUPS[value.to_s]
           return good_value unless good_value.nil?
           scope
         end
 
-        def validate_view view #:nodoc:
+        # @private
+        def validate_view view
           if view.respond_to? :table_ref
             view.table_ref
           else
@@ -437,7 +450,8 @@ module Gcloud
           end
         end
 
-        def add_access_role_scope_value role, scope, value #:nodoc:
+        # @private
+        def add_access_role_scope_value role, scope, value
           role = validate_role role
           scope = validate_scope scope
           # If scope is special group, make sure value is in the list
@@ -450,7 +464,8 @@ module Gcloud
           access << { "role" => role, scope => value }
         end
 
-        def remove_access_role_scope_value role, scope, value #:nodoc:
+        # @private
+        def remove_access_role_scope_value role, scope, value
           role = validate_role role
           scope = validate_scope scope
           # If scope is special group, make sure value is in the list
@@ -461,7 +476,8 @@ module Gcloud
           access.reject! { |h| h["role"] == role && h[scope] == value }
         end
 
-        def lookup_access_role_scope_value role, scope, value #:nodoc:
+        # @private
+        def lookup_access_role_scope_value role, scope, value
           role = validate_role role
           scope = validate_scope scope
           # If scope is special group, make sure value is in the list

--- a/lib/gcloud/bigquery/dataset/list.rb
+++ b/lib/gcloud/bigquery/dataset/list.rb
@@ -36,8 +36,8 @@ module Gcloud
         end
 
         ##
-        # New Dataset::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Dataset::List from a response object.
+        def self.from_response resp, conn
           datasets = List.new(Array(resp.data["datasets"]).map do |gapi_object|
             Dataset.from_gapi gapi_object, conn
           end)

--- a/lib/gcloud/bigquery/errors.rb
+++ b/lib/gcloud/bigquery/errors.rb
@@ -33,13 +33,15 @@ module Gcloud
       # The errors encountered.
       attr_reader :errors
 
-      def initialize message, code, errors = [] #:nodoc:
+      # @private
+      def initialize message, code, errors = []
         super message
         @code   = code
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         if resp.data? && resp.data["error"]
           from_response_data resp.data["error"]
         else
@@ -47,11 +49,13 @@ module Gcloud
         end
       end
 
-      def self.from_response_data error #:nodoc:
+      # @private
+      def self.from_response_data error
         new error["message"], error["code"], error["errors"]
       end
 
-      def self.from_response_status resp #:nodoc:
+      # @private
+      def self.from_response_status resp
         if resp.status == 404
           new "#{resp.error_message}: #{resp.request.uri.request_uri}",
               resp.status

--- a/lib/gcloud/bigquery/extract_job.rb
+++ b/lib/gcloud/bigquery/extract_job.rb
@@ -18,14 +18,14 @@ module Gcloud
     ##
     # = ExtractJob
     #
-    # A Job subclass representing an export operation that may be performed
-    # on a Table. A ExtractJob instance is created when you call Table#extract.
+    # A {Job} subclass representing an export operation that may be performed
+    # on a {Table}. A ExtractJob instance is created when you call
+    # {Table#extract}.
     #
-    # See {Exporting Data From
-    # BigQuery}[https://cloud.google.com/bigquery/exporting-data-from-bigquery]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/exporting-data-from-bigquery
+    #   Exporting Data From BigQuery
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class ExtractJob < Job
       ##
@@ -37,7 +37,7 @@ module Gcloud
 
       ##
       # The table from which the data is exported. This is the table upon
-      # which Table#extract was called. Returns a Table instance.
+      # which {Table#extract} was called. Returns a {Table} instance.
       def source
         table = config["extract"]["sourceTable"]
         return nil unless table
@@ -99,7 +99,7 @@ module Gcloud
 
       ##
       # The count of files per destination URI or URI pattern specified in
-      # #destinations. Returns an Array of values in the same order as the URI
+      # {#destinations}. Returns an Array of values in the same order as the URI
       # patterns.
       def destinations_file_counts
         Array stats["extract"]["destinationUriFileCounts"]
@@ -107,7 +107,7 @@ module Gcloud
 
       ##
       # The count of files per destination URI or URI pattern specified in
-      # #destinations. Returns a Hash with the URI patterns as keys and the
+      # {#destinations}. Returns a Hash with the URI patterns as keys and the
       # counts as values.
       def destinations_counts
         Hash[destinations.zip destinations_file_counts]

--- a/lib/gcloud/bigquery/insert_response.rb
+++ b/lib/gcloud/bigquery/insert_response.rb
@@ -18,7 +18,8 @@ module Gcloud
     ##
     # InsertResponse
     class InsertResponse
-      def initialize rows, gapi #:nodoc:
+      # @private
+      def initialize rows, gapi
         @rows = rows
         @gapi = gapi
       end
@@ -59,7 +60,8 @@ module Gcloud
         []
       end
 
-      def self.from_gapi rows, gapi #:nodoc:
+      # @private
+      def self.from_gapi rows, gapi
         gapi = gapi.to_hash if gapi.respond_to? :to_hash
         new rows, gapi
       end
@@ -70,7 +72,8 @@ module Gcloud
         attr_reader :row
         attr_reader :errors
 
-        def initialize row, errors #:nodoc:
+        # @private
+        def initialize row, errors
           @row = row
           @errors = errors
         end

--- a/lib/gcloud/bigquery/job.rb
+++ b/lib/gcloud/bigquery/job.rb
@@ -22,20 +22,21 @@ module Gcloud
     ##
     # = Job
     #
-    # Represents a generic Job that may be performed on a Table.
+    # Represents a generic Job that may be performed on a {Table}.
     #
-    # See {Managing Jobs, Datasets, and Projects
-    # }[https://cloud.google.com/bigquery/docs/managing_jobs_datasets_projects]
-    # for an overview of BigQuery jobs, and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # The subclasses of Job represent the specific BigQuery job types:
+    # {CopyJob}, {ExtractJob}, {LoadJob}, and {QueryJob}.
     #
-    # The subclasses of Job represent the specific BigQuery job types: CopyJob,
-    # ExtractJob, LoadJob, and QueryJob.
+    # A job instance is created when you call {Project#query_job},
+    # {Dataset#query_job}, {Table#copy}, {Table#extract}, {Table#load}, or
+    # {View#data}.
     #
-    # A job instance is created when you call Project#query_job,
-    # Dataset#query_job, Table#copy, Table#extract, Table#load, or View#data.
+    # @see https://cloud.google.com/bigquery/docs/managing_jobs_datasets_projects
+    #   Managing Jobs, Datasets, and Projects
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -54,16 +55,16 @@ module Gcloud
     #
     class Job
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Job object.
-      def initialize #:nodoc:
+      # @private Create an empty Job object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -83,7 +84,7 @@ module Gcloud
       ##
       # The current state of the job. The possible values are +PENDING+,
       # +RUNNING+, and +DONE+. A +DONE+ state does not mean that the job
-      # completed successfully. Use #failed? to discover if an error occurred
+      # completed successfully. Use {#failed?} to discover if an error occurred
       # or if the job was successful.
       def state
         return nil if @gapi["status"].nil?
@@ -107,7 +108,7 @@ module Gcloud
       ##
       # Checks if the job's state is +DONE+. When +true+, the job has stopped
       # running. However, a +DONE+ state does not mean that the job completed
-      # successfully.  Use #failed? to detect if an error occurred or if the
+      # successfully.  Use {#failed?} to detect if an error occurred or if the
       # job was successful.
       def done?
         return false if state.nil?
@@ -148,8 +149,10 @@ module Gcloud
       end
 
       ##
-      # The configuration for the job. Returns a hash. See the {Jobs API
-      # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs].
+      # The configuration for the job. Returns a hash.
+      #
+      # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+      #   reference
       def configuration
         hash = @gapi["configuration"] || {}
         hash = hash.to_hash if hash.respond_to? :to_hash
@@ -158,8 +161,10 @@ module Gcloud
       alias_method :config, :configuration
 
       ##
-      # The statistics for the job. Returns a hash. See the {Jobs API
-      # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs].
+      # The statistics for the job. Returns a hash.
+      #
+      # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+      #   reference
       def statistics
         hash = @gapi["statistics"] || {}
         hash = hash.to_hash if hash.respond_to? :to_hash
@@ -169,7 +174,7 @@ module Gcloud
 
       ##
       # The job's status. Returns a hash. The values contained in the hash are
-      # also exposed by #state, #error, and #errors.
+      # also exposed by {#state}, {#error}, and {#errors}.
       def status
         hash = @gapi["status"] || {}
         hash = hash.to_hash if hash.respond_to? :to_hash
@@ -178,12 +183,12 @@ module Gcloud
 
       ##
       # The last error for the job, if any errors have occurred. Returns a
-      # hash. See the {Jobs API
-      # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs].
+      # hash.
       #
-      # === Returns
+      # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+      #   reference
       #
-      # +Hash+
+      # @return [Hash] Returns a hash containing +reason+ and +message+ keys:
       #
       #   {
       #     "reason"=>"notFound",
@@ -196,7 +201,7 @@ module Gcloud
 
       ##
       # The errors for the job, if any errors have occurred. Returns an array
-      # of hash objects. See #error.
+      # of hash objects. See {#error}.
       def errors
         Array status["errors"]
       end
@@ -230,8 +235,7 @@ module Gcloud
       # Refreshes the job until the job is +DONE+.
       # The delay between refreshes will incrementally increase.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -254,8 +258,8 @@ module Gcloud
       end
 
       ##
-      # New Job from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Job from a Google API Client object.
+      def self.from_gapi gapi, conn
         klass = klass_for gapi
         klass.new.tap do |f|
           f.gapi = gapi

--- a/lib/gcloud/bigquery/job/list.rb
+++ b/lib/gcloud/bigquery/job/list.rb
@@ -39,8 +39,8 @@ module Gcloud
         end
 
         ##
-        # New Job::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Job::List from a response object.
+        def self.from_response resp, conn
           jobs = List.new(Array(resp.data["jobs"]).map do |gapi_object|
             Job.from_gapi gapi_object, conn
           end)

--- a/lib/gcloud/bigquery/load_job.rb
+++ b/lib/gcloud/bigquery/load_job.rb
@@ -18,14 +18,13 @@ module Gcloud
     ##
     # = LoadJob
     #
-    # A Job subclass representing a load operation that may be performed
-    # on a Table. A LoadJob instance is created when you call Table#load.
+    # A {Job} subclass representing a load operation that may be performed
+    # on a {Table}. A LoadJob instance is created when you call {Table#load}.
     #
-    # See {Loading Data Into
-    # BigQuery}[https://cloud.google.com/bigquery/loading-data-into-bigquery]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/loading-data-into-bigquery Loading
+    #   Data Into BigQuery
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class LoadJob < Job
       ##
@@ -37,7 +36,7 @@ module Gcloud
 
       ##
       # The table into which the operation loads data. This is the table on
-      # which Table#load was invoked. Returns a Table instance.
+      # which {Table#load} was invoked. Returns a {Table} instance.
       def destination
         table = config["load"]["destinationTable"]
         return nil unless table
@@ -84,7 +83,7 @@ module Gcloud
       # The value that is used to quote data sections in a CSV file.
       # The default value is a double-quote (+"+). If your data does not contain
       # quoted sections, the value should be an empty string. If your data
-      # contains quoted newline characters, #quoted_newlines? should return
+      # contains quoted newline characters, {#quoted_newlines?} should return
       # +true+.
       def quote
         val = config["load"]["quote"]
@@ -161,8 +160,8 @@ module Gcloud
 
       ##
       # The schema for the data. Returns a hash. Can be empty if the table
-      # has already has the correct schema (see Table#schema= and Table#schema),
-      # or if the schema can be inferred from the loaded data.
+      # has already has the correct schema (see {Table#schema=} and
+      # {Table#schema}), or if the schema can be inferred from the loaded data.
       def schema
         val = config["load"]["schema"]
         val = {} if val.nil?

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -31,9 +31,12 @@ module Gcloud
     # data. Each project has a friendly name and a unique ID.
     #
     # Gcloud::Bigquery::Project is the main object for interacting with
-    # Google BigQuery. Gcloud::Bigquery::Dataset objects are created,
+    # Google BigQuery. {Gcloud::Bigquery::Dataset} objects are created,
     # accessed, and deleted by Gcloud::Bigquery::Project.
     #
+    # See {Gcloud#bigquery}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -41,16 +44,15 @@ module Gcloud
     #   dataset = bigquery.dataset "my_dataset"
     #   table = dataset.table "my_table"
     #
-    # See Gcloud#bigquery
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
       # Creates a new Connection instance.
       #
-      # See Gcloud.bigquery
+      # See {Gcloud.bigquery}
       def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
@@ -60,8 +62,7 @@ module Gcloud
       ##
       # The BigQuery project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project", "/path/to/keyfile.json"
@@ -74,8 +75,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["BIGQUERY_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -86,58 +87,48 @@ module Gcloud
       # Queries data using the {asynchronous
       # method}[https://cloud.google.com/bigquery/querying-data].
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +priority+::
-      #   Specifies a priority for the query. Possible values include
-      #   +INTERACTIVE+ and +BATCH+. The default value is +INTERACTIVE+.
-      #   (+String+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is +true+. (+Boolean+)
-      # +table+::
-      #   The destination table where the query results should be stored. If not
-      #   present, a new table will be created to store the results. (+Table+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [String] priority Specifies a priority for the query. Possible
+      #   values include +INTERACTIVE+ and +BATCH+. The default value is
+      #   +INTERACTIVE+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [Table] table The destination table where the query results
+      #   should be stored. If not present, a new table will be created to store
+      #   the results.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies the action that occurs if the destination table already
-      #   exists. (+String+)
+      # @param [String] write Specifies the action that occurs if the
+      #   destination table already exists.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - A 'duplicate' error is returned in the job result if the
       #     table exists and contains data.
-      # +large_results+::
-      #   If +true+, allows the query to produce arbitrarily large result tables
-      #   at a slight cost in performance. Requires +table+ parameter to be set.
-      #   (+Boolean+)
-      # +flatten+::
-      #   Flattens all nested and repeated fields in the query results. The
-      #   default value is +true+. +large_results+ parameter must be +true+ if
-      #   this is set to +false+. (+Boolean+)
-      # +dataset+::
-      #   Specifies the default dataset to use for unqualified table names in
-      #   the query. (+Dataset+ or +String+)
+      # @param [Boolean] large_results If +true+, allows the query to produce
+      #   arbitrarily large result tables at a slight cost in performance.
+      #   Requires +table+ parameter to be set.
+      # @param [Boolean] flatten Flattens all nested and repeated fields in the
+      #   query results. The default value is +true+. +large_results+ parameter
+      #   must be +true+ if this is set to +false+.
+      # @param [Dataset, String] dataset Specifies the default dataset to use
+      #   for unqualified table names in the query.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryJob]
       #
-      # Gcloud::Bigquery::QueryJob
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -171,53 +162,42 @@ module Gcloud
       # Queries data using the {synchronous
       # method}[https://cloud.google.com/bigquery/querying-data].
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +max+::
-      #   The maximum number of rows of data to return per page of results.
-      #   Setting this flag to a small value such as 1000 and then paging
-      #   through results might improve reliability when the query result set is
-      #   large. In addition to this limit, responses are also limited to 10 MB.
-      #   By default, there is no maximum row count, and only the byte limit
-      #   applies. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   the request times out and returns. Note that this is only a timeout
-      #   for the request, not the query. If the query takes longer to run than
-      #   the timeout value, the call returns without any results and with
-      #   QueryData#complete? set to false. The default value is 10000
-      #   milliseconds (10 seconds). (+Integer+)
-      # +dryrun+::
-      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
-      #   is valid, BigQuery returns statistics about the job such as how many
-      #   bytes would be processed. If the query is invalid, an error returns.
-      #   The default value is +false+. (+Boolean+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is true. For more information, see
-      #   {query caching}[https://developers.google.com/bigquery/querying-data].
-      #   (+Boolean+)
-      # +dataset+::
-      #   Specifies the default datasetId and projectId to assume for any
-      #   unqualified table names in the query. If not set, all table names in
-      #   the query string must be qualified in the format 'datasetId.tableId'.
-      #   (+String+)
-      # +project+::
-      #   Specifies the default projectId to assume for any unqualified table
-      #   names in the query. Only used if +dataset+ option is set. (+String+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      #   Instead, if the query is valid, BigQuery returns statistics about the
+      #   job such as how many bytes would be processed. If the query is
+      #   invalid, an error returns. The default value is +false+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [String] dataset Specifies the default datasetId and projectId to
+      #   assume for any unqualified table names in the query. If not set, all
+      #   table names in the query string must be qualified in the format
+      #   'datasetId.tableId'.
+      # @param [String] project Specifies the default projectId to assume for
+      #   any unqualified table names in the query. Only used if +dataset+
+      #   option is set.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -244,17 +224,12 @@ module Gcloud
       ##
       # Retrieves an existing dataset by ID.
       #
-      # === Parameters
+      # @param [String] dataset_id The ID of a dataset.
       #
-      # +dataset_id+::
-      #   The ID of a dataset. (+String+)
+      # @return [Gcloud::Bigquery::Dataset, nil] Returns +nil+ if the dataset
+      #   does not exist.
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::Dataset or nil if dataset does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -277,31 +252,23 @@ module Gcloud
       ##
       # Creates a new dataset.
       #
-      # === Parameters
-      #
-      # +dataset_id+::
-      #   A unique ID for this dataset, without the project name.
-      #   The ID must contain only letters (a-z, A-Z), numbers (0-9), or
-      #   underscores (_). The maximum length is 1,024 characters. (+String+)
-      # +name+::
-      #   A descriptive name for the dataset. (+String+)
-      # +description+::
-      #   A user-friendly description of the dataset. (+String+)
-      # +expiration+::
-      #   The default lifetime of all tables in the dataset, in milliseconds.
-      #   The minimum value is 3600000 milliseconds (one hour). (+Integer+)
-      # +access+::
-      #   The access rules for a Dataset using the Google Cloud Datastore API
-      #   data structure of an array of hashes. See {BigQuery Access
+      # @param [String] dataset_id A unique ID for this dataset, without the
+      #   project name. The ID must contain only letters (a-z, A-Z), numbers
+      #   (0-9), or underscores (_). The maximum length is 1,024 characters.
+      # @param [String] name A descriptive name for the dataset.
+      # @param [String] description A user-friendly description of the dataset.
+      # @param [Integer] expiration The default lifetime of all tables in the
+      #   dataset, in milliseconds. The minimum value is 3600000 milliseconds
+      #   (one hour).
+      # @param [Array<Hash>] access The access rules for a Dataset using the
+      #   Google Cloud Datastore API data structure of an array of hashes. See
+      #   {BigQuery Access
       #   Control}[https://cloud.google.com/bigquery/access-control] for more
-      #   information. (+Array of Hashes+)
+      #   information.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Dataset]
       #
-      # Gcloud::Bigquery::Dataset
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -309,8 +276,7 @@ module Gcloud
       #
       #   dataset = bigquery.create_dataset "my_dataset"
       #
-      # A name and description can be provided:
-      #
+      # @example A name and description can be provided:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -320,8 +286,7 @@ module Gcloud
       #                                     name: "My Dataset",
       #                                     description: "This is my Dataset"
       #
-      # Access rules can be provided with the +access+ option:
-      #
+      # @example Access rules can be provided with the +access+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -330,9 +295,7 @@ module Gcloud
       #   dataset = bigquery.create_dataset "my_dataset",
       #     access: [{"role"=>"WRITER", "userByEmail"=>"writers@example.com"}]
       #
-      # Or access rules can be configured by using the block syntax:
-      # (See Dataset::Access)
-      #
+      # @example Or, configure access with a block: (See {Dataset::Access})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -362,23 +325,16 @@ module Gcloud
       ##
       # Retrieves the list of datasets belonging to the project.
       #
-      # === Parameters
+      # @param [Boolean] all Whether to list all datasets, including hidden
+      #   ones. The default is +false+.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of datasets to return.
       #
-      # +all+::
-      #   Whether to list all datasets, including hidden ones. The default is
-      #   +false+. (+Boolean+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of datasets to return. (+Integer+)
+      # @return [Array<Gcloud::Bigquery::Dataset>] (See
+      #   {Gcloud::Bigquery::Dataset::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Bigquery::Dataset (See Gcloud::Bigquery::Dataset::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -389,9 +345,7 @@ module Gcloud
       #     puts dataset.name
       #   end
       #
-      # You can also retrieve all datasets, including hidden ones, by providing
-      # the +:all+ option:
-      #
+      # @example Retrieve all datasets, including hidden ones, with +:all+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -399,9 +353,7 @@ module Gcloud
       #
       #   all_datasets = bigquery.datasets, all: true
       #
-      # If you have a significant number of datasets, you may need to paginate
-      # through them: (See Dataset::List#token)
-      #
+      # @example With pagination: (See {Dataset::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -433,17 +385,12 @@ module Gcloud
       ##
       # Retrieves an existing job by ID.
       #
-      # === Parameters
+      # @param [String] job_id The ID of a job.
       #
-      # +job_id+::
-      #   The ID of a job. (+String+)
+      # @return [Gcloud::Bigquery::Job, nil] Returns +nil+ if the job does not
+      #   exist.
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::Job or nil if job does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -465,30 +412,22 @@ module Gcloud
       ##
       # Retrieves the list of jobs belonging to the project.
       #
-      # === Parameters
-      #
-      # +all+::
-      #   Whether to display jobs owned by all users in the project.
-      #   The default is +false+. (+Boolean+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of jobs to return. (+Integer+)
-      # +filter+::
-      #   A filter for job state. (+String+)
+      # @param [Boolean] all Whether to display jobs owned by all users in the
+      #   project. The default is +false+.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of jobs to return.
+      # @param [String] filter A filter for job state.
       #
       #   Acceptable values are:
       #   * +done+ - Finished jobs
       #   * +pending+ - Pending jobs
       #   * +running+ - Running jobs
       #
-      # === Returns
+      # @return [Array<Gcloud::Bigquery::Job>] (See
+      #   {Gcloud::Bigquery::Job::List})
       #
-      # Array of Gcloud::Bigquery::Job (See Gcloud::Bigquery::Job::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -496,7 +435,7 @@ module Gcloud
       #
       #   jobs = bigquery.jobs
       #
-      # You can also retrieve only running jobs using the +:filter+ option:
+      # @example Retrieve only running jobs using the +:filter+ option:
       #
       #   require "gcloud"
       #
@@ -505,8 +444,7 @@ module Gcloud
       #
       #   running_jobs = bigquery.jobs filter: "running"
       #
-      # If you have a significant number of jobs, you may need to paginate
-      # through them: (See Job::List#token)
+      # @example With pagination: (See {Job::List#token})
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/bigquery/query_data.rb
+++ b/lib/gcloud/bigquery/query_data.rb
@@ -23,10 +23,11 @@ module Gcloud
     # Represents Data returned from a query a a list of name/value pairs.
     class QueryData < Data
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
-      def initialize arr = [] #:nodoc:
+      # @private
+      def initialize arr = []
         @job = nil
         super
       end
@@ -89,7 +90,7 @@ module Gcloud
       end
 
       ##
-      # The BigQuery Job that was created to run the query.
+      # The BigQuery {Job} that was created to run the query.
       def job
         return @job if @job
         return nil unless job?
@@ -104,8 +105,8 @@ module Gcloud
       end
 
       ##
-      # New Data from a response object.
-      def self.from_gapi gapi, connection #:nodoc:
+      # @private New Data from a response object.
+      def self.from_gapi gapi, connection
         formatted_rows = format_rows gapi["rows"],
                                      gapi["schema"]["fields"]
 

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -18,14 +18,13 @@ module Gcloud
     ##
     # = QueryJob
     #
-    # A Job subclass representing a query operation that may be performed
-    # on a Table. A QueryJob instance is created when you call
-    # Project#query_job, Dataset#query_job, or View#data.
+    # A {Job} subclass representing a query operation that may be performed
+    # on a {Table}. A QueryJob instance is created when you call
+    # {Project#query_job}, {Dataset#query_job}, or {View#data}.
     #
-    # See {Querying Data}[https://cloud.google.com/bigquery/querying-data]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/querying-data Querying Data
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class QueryJob < Job
       ##
@@ -97,25 +96,17 @@ module Gcloud
       ##
       # Retrieves the query results for the job.
       #
-      # === Parameters
+      # @param [String] token Page token, returned by a previous call,
+      #   identifying the result set.
+      # @param [Integer] max Maximum number of results to return.
+      # @param [Integer] start Zero-based index of the starting row to read.
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before returning. Default is 10,000 milliseconds (10
+      #   seconds).
       #
-      # +token+::
-      #   Page token, returned by a previous call, identifying the result set.
-      #   (+String+)
-      # +max+::
-      #   Maximum number of results to return. (+Integer+)
-      # +start+::
-      #   Zero-based index of the starting row to read. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   returning. Default is 10,000 milliseconds (10 seconds). (+Integer+)
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -27,11 +27,13 @@ module Gcloud
     # = Table
     #
     # A named resource representing a BigQuery table that holds zero or more
-    # records. Every table is defined by a schema
-    # that may contain nested and repeated fields. (For more information
-    # about nested and repeated fields, see {Preparing Data for
-    # BigQuery}[https://cloud.google.com/bigquery/preparing-data-for-bigquery].)
+    # records. Every table is defined by a schema that may contain nested and
+    # repeated fields.
     #
+    # @see https://cloud.google.com/bigquery/preparing-data-for-bigquery
+    #   Preparing Data for BigQuery
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -63,16 +65,16 @@ module Gcloud
     #
     class Table
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Table object.
-      def initialize #:nodoc:
+      # @private Create an empty Table object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -82,7 +84,7 @@ module Gcloud
       # The ID must contain only letters (a-z, A-Z), numbers (0-9),
       # or underscores (_). The maximum length is 1,024 characters.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table_id
         @gapi["tableReference"]["tableId"]
@@ -91,7 +93,7 @@ module Gcloud
       ##
       # The ID of the +Dataset+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def dataset_id
         @gapi["tableReference"]["datasetId"]
@@ -100,16 +102,17 @@ module Gcloud
       ##
       # The ID of the +Project+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def project_id
         @gapi["tableReference"]["projectId"]
       end
 
       ##
+      # @private
       # The gapi fragment containing the Project ID, Dataset ID, and Table ID as
       # a camel-cased hash.
-      def table_ref #:nodoc:
+      def table_ref
         table_ref = @gapi["tableReference"]
         table_ref = table_ref.to_hash if table_ref.respond_to? :to_hash
         table_ref
@@ -120,22 +123,21 @@ module Gcloud
       # format specified by the {Query
       # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
       # +project_name:datasetId.tableId+. To use this value in queries see
-      # #query_id.
+      # {#query_id}.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def id
         @gapi["id"]
       end
 
       ##
-      # The value returned by #id, wrapped in square brackets if the Project ID
-      # contains dashes, as specified by the {Query
+      # The value returned by {#id}, wrapped in square brackets if the Project
+      # ID contains dashes, as specified by the {Query
       # Reference}[https://cloud.google.com/bigquery/query-reference#from].
       # Useful in queries.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -145,7 +147,7 @@ module Gcloud
       #
       #   data = bigquery.query "SELECT name FROM #{table.query_id}"
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def query_id
         project_id["-"] ? "[#{id}]" : id
@@ -154,7 +156,7 @@ module Gcloud
       ##
       # The name of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name
         @gapi["friendlyName"]
@@ -163,7 +165,7 @@ module Gcloud
       ##
       # Updates the name of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name= new_name
         patch_gapi! name: new_name
@@ -172,7 +174,7 @@ module Gcloud
       ##
       # A string hash of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def etag
         ensure_full_data!
@@ -182,7 +184,7 @@ module Gcloud
       ##
       # A URL that can be used to access the dataset using the REST API.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def api_url
         ensure_full_data!
@@ -192,7 +194,7 @@ module Gcloud
       ##
       # The description of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description
         ensure_full_data!
@@ -202,7 +204,7 @@ module Gcloud
       ##
       # Updates the description of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description= new_description
         patch_gapi! description: new_description
@@ -211,7 +213,7 @@ module Gcloud
       ##
       # The number of bytes in the table.
       #
-      # :category: Data
+      # @!group Data
       #
       def bytes_count
         ensure_full_data!
@@ -221,7 +223,7 @@ module Gcloud
       ##
       # The number of rows in the table.
       #
-      # :category: Data
+      # @!group Data
       #
       def rows_count
         ensure_full_data!
@@ -231,7 +233,7 @@ module Gcloud
       ##
       # The time when this table was created.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def created_at
         ensure_full_data!
@@ -243,7 +245,7 @@ module Gcloud
       # If not present, the table will persist indefinitely.
       # Expired tables will be deleted and their storage reclaimed.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def expires_at
         ensure_full_data!
@@ -254,7 +256,7 @@ module Gcloud
       ##
       # The date when this table was last modified.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def modified_at
         ensure_full_data!
@@ -264,7 +266,7 @@ module Gcloud
       ##
       # Checks if the table's type is "TABLE".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table?
         @gapi["type"] == "TABLE"
@@ -273,7 +275,7 @@ module Gcloud
       ##
       # Checks if the table's type is "VIEW".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def view?
         @gapi["type"] == "VIEW"
@@ -283,7 +285,7 @@ module Gcloud
       # The geographic location where the table should reside. Possible
       # values include EU and US. The default value is US.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def location
         ensure_full_data!
@@ -295,20 +297,16 @@ module Gcloud
       # returned by the Google Cloud BigQuery {Rest API
       # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource].
       # This method can also be used to set, replace, or add to the schema by
-      # passing a block. See Table::Schema for available methods. To set the
-      # schema by passing a hash instead, use #schema=.
+      # passing a block. See {Table::Schema} for available methods. To set the
+      # schema by passing a hash instead, use {#schema=}.
       #
-      # === Parameters
-      #
-      # +replace+::
-      #   Whether to replace the existing schema with the new schema. If
-      #   +true+, the fields will replace the existing schema. If
+      # @param [Boolean] replace Whether to replace the existing schema with the
+      #   new schema. If +true+, the fields will replace the existing schema. If
       #   +false+, the fields will be added to the existing schema. When a table
       #   already contains data, schema changes must be additive. Thus, the
-      #   default value is +false+. (+Boolean+)
+      #   default value is +false+.
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -324,7 +322,7 @@ module Gcloud
       #     end
       #   end
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def schema replace: false
         ensure_full_data!
@@ -342,16 +340,12 @@ module Gcloud
       # Updates the schema of the table.
       # To update the schema using a block instead, use #schema.
       #
-      # === Parameters
-      #
-      # +schema+::
-      #   A hash containing keys and values as specified by the Google Cloud
-      #   BigQuery {Rest API
+      # @param [Hash] new_schema A hash containing keys and values as specified
+      #   by the Google Cloud BigQuery {Rest API
       #   }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
-      #   . (+Hash+)
+      #   .
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -375,7 +369,7 @@ module Gcloud
       #   }
       #   table.schema = schema
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def schema= new_schema
         patch_gapi! schema: new_schema
@@ -384,7 +378,7 @@ module Gcloud
       ##
       # The fields of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def fields
         f = schema["fields"]
@@ -396,7 +390,7 @@ module Gcloud
       ##
       # The names of the columns in the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def headers
         fields.map { |f| f["name"] }
@@ -405,22 +399,15 @@ module Gcloud
       ##
       # Retrieves data from the table.
       #
-      # === Parameters
+      # @param [String] token Page token, returned by a previous call,
+      #   identifying the result set.
       #
-      # +token+::
-      #   Page token, returned by a previous call, identifying the result set.
-      #   (+String+)
-      # +max+::
-      #   Maximum number of results to return. (+Integer+)
-      # +start+::
-      #   Zero-based index of the starting row to read. (+Integer+)
+      # @param [Integer] max Maximum number of results to return.
+      # @param [Integer] start Zero-based index of the starting row to read.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Data]
       #
-      # Gcloud::Bigquery::Data
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -434,7 +421,7 @@ module Gcloud
       #   end
       #   more_data = table.data token: data.token
       #
-      # :category: Data
+      # @!group Data
       #
       def data token: nil, max: nil, start: nil
         ensure_connection!
@@ -449,21 +436,23 @@ module Gcloud
 
       ##
       # Copies the data from the table to another table.
+      # The destination table argument can also be a string identifier as
+      # specified by the {Query
+      # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+      # +project_name:datasetId.tableId+. This is useful for referencing tables
+      # in other projects and datasets.
       #
-      # === Parameters
-      #
-      # +destination_table+::
-      #   The destination for the copied data. (+Table+ or +String+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      # @param [Table, String] destination_table The destination for the copied
+      #   data.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies how to handle data already present in the destination table.
-      #   The default value is +empty+. (+String+)
+      # @param [String] write Specifies how to handle data already present in
+      #   the destination table. The default value is +empty+.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
@@ -471,12 +460,9 @@ module Gcloud
       #   * +empty+ - An error will be returned if the destination table already
       #     contains data.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::CopyJob]
       #
-      # Gcloud::Bigquery::CopyJob
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -487,12 +473,7 @@ module Gcloud
       #
       #   copy_job = table.copy destination_table
       #
-      # The destination table argument can also be a string identifier as
-      # specified by the {Query
-      # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-      # +project_name:datasetId.tableId+. This is useful for referencing tables
-      # in other projects and datasets.
-      #
+      # @example Passing a string identifier for the destination table:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -502,7 +483,7 @@ module Gcloud
       #
       #   copy_job = table.copy "other-project:other_dataset.other_table"
       #
-      # :category: Data
+      # @!group Data
       #
       def copy destination_table, create: nil, write: nil, dryrun: nil
         ensure_connection!
@@ -518,36 +499,31 @@ module Gcloud
       end
 
       ##
+      # @private
       # Links the table to a source table identified by a URI.
       #
-      # === Parameters
-      #
-      # +source_url+::
-      #   The URI of source table to link. (+String+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      # @param [String] source_url The URI of source table to link.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies how to handle data already present in the table.
-      #   The default value is +empty+. (+String+)
+      # @param [String] write Specifies how to handle data already present in
+      #   the destination table. The default value is +empty+.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
-      #   * +empty+ - An error will be returned if the table already contains
-      #     data.
+      #   * +empty+ - An error will be returned if the destination table already
+      #     contains data.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Job]
       #
-      # Gcloud::Bigquery::Job
+      # @!group Data
       #
-      # :category: Data
-      #
-      def link source_url, create: nil, write: nil, dryrun: nil #:nodoc:
+      def link source_url, create: nil, write: nil, dryrun: nil
         ensure_connection!
         options = { create: create, write: write, dryrun: dryrun }
         resp = connection.link_table table_ref, source_url, options
@@ -559,39 +535,33 @@ module Gcloud
       end
 
       ##
-      # Extract the data from the table to a Google Cloud Storage file. For
-      # more information, see {Exporting Data From BigQuery
-      # }[https://cloud.google.com/bigquery/exporting-data-from-bigquery].
+      # Extract the data from the table to a Google Cloud Storage file.
       #
-      # === Parameters
+      # @see https://cloud.google.com/bigquery/exporting-data-from-bigquery
+      #   Exporting Data From BigQuery
       #
-      # +extract_url+::
-      #   The Google Storage file or file URI pattern(s) to which BigQuery
-      #   should extract the table data.
-      #   (+Gcloud::Storage::File+ or +String+ or +Array+)
-      # +format+::
-      #   The exported file format. The default value is +csv+. (+String+)
+      # @param [Gcloud::Storage::File, String, Array<String>] extract_url The
+      #   Google Storage file or file URI pattern(s) to which BigQuery should
+      #   extract the table data.
+      # @param [String] format The exported file format. The default value is
+      #   +csv+.
       #
       #   The following values are supported:
       #   * +csv+ - CSV
       #   * +json+ - {Newline-delimited JSON}[http://jsonlines.org/]
       #   * +avro+ - {Avro}[http://avro.apache.org/]
-      # +compression+::
-      #   The compression type to use for exported files. Possible values
-      #   include +GZIP+ and +NONE+. The default value is +NONE+. (+String+)
-      # +delimiter+::
-      #   Delimiter to use between fields in the exported data. Default is
-      #   <code>,</code>. (+String+)
-      # +header+::
-      #   Whether to print out a header row in the results. Default is +true+.
-      #   (+Boolean+)
+      # @param [String] compression The compression type to use for exported
+      #   files. Possible values include +GZIP+ and +NONE+. The default value is
+      #   +NONE+.
+      # @param [String] delimiter Delimiter to use between fields in the
+      #   exported data. Default is <code>,</code>.
+      # @param [Boolean] header Whether to print out a header row in the
+      #   results. Default is +true+.
       #
-      # === Returns
       #
-      # Gcloud::Bigquery::ExtractJob
+      # @return [Gcloud::Bigquery::ExtractJob]
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -602,7 +572,7 @@ module Gcloud
       #   extract_job = table.extract "gs://my-bucket/file-name.json",
       #                               format: "json"
       #
-      # :category: Data
+      # @!group Data
       #
       def extract extract_url, format: nil, compression: nil, delimiter: nil,
                   header: nil, dryrun: nil
@@ -618,100 +588,90 @@ module Gcloud
       end
 
       ##
-      # Loads data into the table.
+      # Loads data into the table. You can pass a gcloud storage file path or
+      # a gcloud storage file instance. Or, you can upload a file directly.
+      # See {Loading Data with a POST Request}[
+      # https://cloud.google.com/bigquery/loading-data-post-request#multipart].
       #
-      # === Parameters
-      #
-      # +file+::
-      #   A file or the URI of a Google Cloud Storage file containing
-      #   data to load into the table.
-      #   (+File+ or +Gcloud::Storage::File+ or +String+)
-      # +format+::
-      #   The exported file format. The default value is +csv+. (+String+)
+      # @param [File, Gcloud::Storage::File, String] file A file or the URI of a
+      #   Google Cloud Storage file containing data to load into the table.
+      # @param [String] format The exported file format. The default value is
+      #   +csv+.
       #
       #   The following values are supported:
       #   * +csv+ - CSV
       #   * +json+ - {Newline-delimited JSON}[http://jsonlines.org/]
       #   * +avro+ - {Avro}[http://avro.apache.org/]
       #   * +datastore_backup+ - Cloud Datastore backup
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies how to handle data already present in the table.
-      #   The default value is +empty+. (+String+)
+      # @param [String] write Specifies how to handle data already present in
+      #   the table. The default value is +empty+.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - An error will be returned if the table already contains
       #     data.
-      # +projection_fields+::
-      #   If the +format+ option is set to +datastore_backup+, indicates which
-      #   entity properties to load from a Cloud Datastore backup. Property
-      #   names are case sensitive and must be top-level properties. If not set,
-      #   BigQuery loads all properties. If any named property isn't found in
-      #   the Cloud Datastore backup, an invalid error is returned. (+Array+)
-      # +jagged_rows+::
-      #   Accept rows that are missing trailing optional columns. The missing
-      #   values are treated as nulls. If +false+, records with missing trailing
-      #   columns are treated as bad records, and if there are too many bad
-      #   records, an invalid error is returned in the job result. The default
-      #   value is +false+. Only applicable to CSV, ignored for other formats.
-      #   (+Boolean+)
-      # +quoted_newlines+::
-      #   Indicates if BigQuery should allow quoted data sections that contain
-      #   newline characters in a CSV file. The default value is +false+.
-      #   (+Boolean+)
-      # +encoding+::
-      #   The character encoding of the data. The supported values are +UTF-8+
-      #   or +ISO-8859-1+. The default value is +UTF-8+. (+String+)
-      # +delimiter+::
-      #   Specifices the separator for fields in a CSV file. BigQuery converts
-      #   the string to +ISO-8859-1+ encoding, and then uses the first byte of
-      #   the encoded string to split the data in its raw, binary state. Default
-      #   is <code>,</code>. (+String+)
-      # +ignore_unknown+::
-      #   Indicates if BigQuery should allow extra values that are not
-      #   represented in the table schema. If true, the extra values are
-      #   ignored. If false, records with extra columns are treated as bad
-      #   records, and if there are too many bad records, an invalid error is
-      #   returned in the job result. The default value is +false+. (+Boolean+)
+      # @param [Array<String>] projection_fields If the +format+ option is set
+      #   to +datastore_backup+, indicates which entity properties to load from
+      #   a Cloud Datastore backup. Property names are case sensitive and must
+      #   be top-level properties. If not set, BigQuery loads all properties. If
+      #   any named property isn't found in the Cloud Datastore backup, an
+      #   invalid error is returned.
+      # @param [Boolean] jagged_rows Accept rows that are missing trailing
+      #   optional columns. The missing values are treated as nulls. If +false+,
+      #   records with missing trailing columns are treated as bad records, and
+      #   if there are too many bad records, an invalid error is returned in the
+      #   job result. The default value is +false+. Only applicable to CSV,
+      #   ignored for other formats.
+      # @param [Boolean] quoted_newlines Indicates if BigQuery should allow
+      #   quoted data sections that contain newline characters in a CSV file.
+      #   The default value is +false+.
+      # @param [String] encoding The character encoding of the data. The
+      #   supported values are +UTF-8+ or +ISO-8859-1+. The default value is
+      #   +UTF-8+.
+      # @param [String] delimiter Specifices the separator for fields in a CSV
+      #   file. BigQuery converts the string to +ISO-8859-1+ encoding, and then
+      #   uses the first byte of the encoded string to split the data in its
+      #   raw, binary state. Default is <code>,</code>.
+      # @param [Boolean] ignore_unknown Indicates if BigQuery should allow extra
+      #   values that are not represented in the table schema. If true, the
+      #   extra values are ignored. If false, records with extra columns are
+      #   treated as bad records, and if there are too many bad records, an
+      #   invalid error is returned in the job result. The default value is
+      #   +false+.
       #
       #   The +format+ property determines what BigQuery treats as an extra
       #   value:
       #
       #   * +CSV+: Trailing columns
       #   * +JSON+: Named values that don't match any column names
-      # +max_bad_records+::
-      #   The maximum number of bad records that BigQuery can ignore when
-      #   running the job. If the number of bad records exceeds this value, an
-      #   invalid error is returned in the job result. The default value is +0+,
-      #   which requires that all records are valid. (+Integer+)
-      # +quote+::
-      #   The value that is used to quote data sections in a CSV file. BigQuery
-      #   converts the string to ISO-8859-1 encoding, and then uses the first
-      #   byte of the encoded string to split the data in its raw, binary state.
-      #   The default value is a double-quote <code>"</code>. If your data does
-      #   not contain quoted sections, set the property value to an empty
-      #   string. If your data contains quoted newline characters, you must also
-      #   set the allowQuotedNewlines property to true. (+String+)
-      # +skip_leading+::
-      #   The number of rows at the top of a CSV file that BigQuery will skip
-      #   when loading the data. The default value is +0+. This property is
-      #   useful if you have header rows in the file that should be skipped.
-      #   (+Integer+)
+      # @param [Integer] max_bad_records The maximum number of bad records that
+      #   BigQuery can ignore when running the job. If the number of bad records
+      #   exceeds this value, an invalid error is returned in the job result.
+      #   The default value is +0+, which requires that all records are valid.
+      # @param [String] quote The value that is used to quote data sections in a
+      #   CSV file. BigQuery converts the string to ISO-8859-1 encoding, and
+      #   then uses the first byte of the encoded string to split the data in
+      #   its raw, binary state. The default value is a double-quote
+      #   <code>"</code>. If your data does not contain quoted sections, set the
+      #   property value to an empty string. If your data contains quoted
+      #   newline characters, you must also set the allowQuotedNewlines property
+      #   to true.
+      # @param [Integer] skip_leading The number of rows at the top of a CSV
+      #   file that BigQuery will skip when loading the data. The default value
+      #   is +0+. This property is useful if you have header rows in the file
+      #   that should be skipped.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::LoadJob]
       #
-      # Gcloud::Bigquery::LoadJob
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -721,7 +681,7 @@ module Gcloud
       #
       #   load_job = table.load "gs://my-bucket/file-name.csv"
       #
-      # You can also pass a gcloud storage file instance.
+      # @example Pass a gcloud storage file instance:
       #
       #   require "gcloud"
       #   require "gcloud/storage"
@@ -736,10 +696,7 @@ module Gcloud
       #   file = bucket.file "file-name.csv"
       #   load_job = table.load file
       #
-      # Or, you can upload a file directly.
-      # See {Loading Data with a POST Request}[
-      # https://cloud.google.com/bigquery/loading-data-post-request#multipart].
-      #
+      # @example Upload a file directly:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -776,7 +733,7 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   bigquery = gcloud.bigquery
       #
-      # :category: Data
+      # @!group Data
       #
       def load file, format: nil, create: nil, write: nil,
                projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
@@ -798,29 +755,23 @@ module Gcloud
       ##
       # Inserts data into the table for near-immediate querying, without the
       # need to complete a #load operation before the data can appear in query
-      # results. See {Streaming Data Into BigQuery
-      # }[https://cloud.google.com/bigquery/streaming-data-into-bigquery].
+      # results.
       #
-      # === Parameters
+      # @see https://cloud.google.com/bigquery/streaming-data-into-bigquery
+      #   Streaming Data Into BigQuery
       #
-      # +rows+::
-      #   A hash object or array of hash objects containing the data.
-      #   (+Array+ or +Hash+)
-      # +skip_invalid+::
-      #   Insert all valid rows of a request, even if invalid rows exist. The
-      #   default value is +false+, which causes the entire request to fail if
-      #   any invalid rows exist. (+Boolean+)
-      # +ignore_unknown+::
-      #   Accept rows that contain values that do not match the schema. The
-      #   unknown values are ignored. Default is false, which treats unknown
-      #   values as errors. (+Boolean+)
+      # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
+      #   containing the data.
+      # @param [Boolean] skip_invalid Insert all valid rows of a request, even
+      #   if invalid rows exist. The default value is +false+, which causes the
+      #   entire request to fail if any invalid rows exist.
+      # @param [Boolean] ignore_unknown Accept rows that contain values that do
+      #   not match the schema. The unknown values are ignored. Default is
+      #   false, which treats unknown values as errors.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::InsertResponse]
       #
-      # Gcloud::Bigquery::InsertResponse
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -834,7 +785,7 @@ module Gcloud
       #   ]
       #   table.insert rows
       #
-      # :category: Data
+      # @!group Data
       #
       def insert rows, skip_invalid: nil, ignore_unknown: nil
         rows = [rows] if rows.is_a? Hash
@@ -851,12 +802,9 @@ module Gcloud
       ##
       # Permanently deletes the table.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the table was deleted.
       #
-      # +true+ if the table was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -866,7 +814,7 @@ module Gcloud
       #
       #   table.delete
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def delete
         ensure_connection!
@@ -881,7 +829,7 @@ module Gcloud
       ##
       # Reloads the table with current data from the BigQuery service.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def reload!
         ensure_connection!
@@ -895,8 +843,8 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # New Table from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Table from a Google API Client object.
+      def self.from_gapi gapi, conn
         klass = class_for gapi
         klass.new.tap do |f|
           f.gapi = gapi
@@ -967,8 +915,8 @@ module Gcloud
       end
 
       ##
-      # Determines if a resumable upload should be used.
-      def resumable_upload? file #:nodoc:
+      # @private Determines if a resumable upload should be used.
+      def resumable_upload? file
         ::File.size?(file).to_i > Upload.resumable_threshold
       end
 

--- a/lib/gcloud/bigquery/table/list.rb
+++ b/lib/gcloud/bigquery/table/list.rb
@@ -39,8 +39,8 @@ module Gcloud
         end
 
         ##
-        # New Table::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Table::List from a response object.
+        def self.from_response resp, conn
           tables = List.new(Array(resp.data["tables"]).map do |gapi_object|
             Table.from_gapi gapi_object, conn
           end)

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -20,11 +20,13 @@ module Gcloud
       # = Table Schema
       #
       # A builder for BigQuery table schemas, passed to block arguments to
-      # Dataset#create_table and Table#schema. Supports nested and
-      # repeated fields via a nested block. For more information about BigQuery
-      # schema definitions, see {Preparing Data for BigQuery
-      # }[https://cloud.google.com/bigquery/preparing-data-for-bigquery].
+      # {Dataset#create_table} and {Table#schema}. Supports nested and
+      # repeated fields via a nested block.
       #
+      # @see https://cloud.google.com/bigquery/preparing-data-for-bigquery
+      #   Preparing Data for BigQuery
+      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -41,13 +43,17 @@ module Gcloud
       #   end
       #
       class Schema
+        # @private
         MODES = %w( NULLABLE REQUIRED REPEATED ) #:nodoc:
+
+        # @private
         TYPES = %w( STRING INTEGER FLOAT BOOLEAN TIMESTAMP RECORD ) #:nodoc:
 
+        # @private
         attr_reader :fields #:nodoc:
 
         ##
-        # Initializes a new schema object with an existing schema.
+        # @private  Initializes a new schema object with an existing schema.
         def initialize schema = nil, nested = false #:nodoc:
           fields = (schema && schema["fields"]) || []
           @original_fields = fields.dup
@@ -55,16 +61,18 @@ module Gcloud
           @nested = nested
         end
 
-        def changed? #:nodoc:
+        # @private
+        def changed?
           @original_fields != @fields
         end
 
         ##
+        # @private
         # Returns the schema as hash containing the keys and values specified by
         # the Google Cloud BigQuery {Rest API
         # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
         # .
-        def schema #:nodoc:
+        def schema
           {
             "fields" => @fields
           }
@@ -73,17 +81,14 @@ module Gcloud
         ##
         # Adds a string field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def string name, description: nil, mode: nil
           add_field name, :string, nil, description: description, mode: mode
         end
@@ -91,17 +96,14 @@ module Gcloud
         ##
         # Adds an integer field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def integer name, description: nil, mode: nil
           add_field name, :integer, nil, description: description, mode: mode
         end
@@ -109,17 +111,14 @@ module Gcloud
         ##
         # Adds a floating-point number field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def float name, description: nil, mode: nil
           add_field name, :float, nil, description: description, mode: mode
         end
@@ -127,17 +126,14 @@ module Gcloud
         ##
         # Adds a boolean field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def boolean name, description: nil, mode: nil
           add_field name, :boolean, nil, description: description, mode: mode
         end
@@ -145,17 +141,14 @@ module Gcloud
         ##
         # Adds a timestamp field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def timestamp name, description: nil, mode: nil
           add_field name, :timestamp, nil, description: description, mode: mode
         end
@@ -166,20 +159,16 @@ module Gcloud
         # and repeated records, see {Preparing Data for BigQuery
         # }[https://cloud.google.com/bigquery/preparing-data-for-bigquery].
         #
-        # === Parameters
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -30,6 +30,7 @@ module Gcloud
     # queried. Queries are billed according to the total amount of data in all
     # table fields referenced directly or indirectly by the top-level query.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -40,16 +41,16 @@ module Gcloud
     #
     class View
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Table object.
-      def initialize #:nodoc:
+      # @private Create an empty Table object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -59,7 +60,7 @@ module Gcloud
       # The ID must contain only letters (a-z, A-Z), numbers (0-9),
       # or underscores (_). The maximum length is 1,024 characters.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table_id
         @gapi["tableReference"]["tableId"]
@@ -68,7 +69,7 @@ module Gcloud
       ##
       # The ID of the +Dataset+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def dataset_id
         @gapi["tableReference"]["datasetId"]
@@ -77,16 +78,17 @@ module Gcloud
       ##
       # The ID of the +Project+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def project_id
         @gapi["tableReference"]["projectId"]
       end
 
       ##
+      # @private
       # The gapi fragment containing the Project ID, Dataset ID, and Table ID as
       # a camel-cased hash.
-      def table_ref #:nodoc:
+      def table_ref
         table_ref = @gapi["tableReference"]
         table_ref = table_ref.to_hash if table_ref.respond_to? :to_hash
         table_ref
@@ -95,7 +97,7 @@ module Gcloud
       ##
       # The name of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name
         @gapi["friendlyName"]
@@ -104,7 +106,7 @@ module Gcloud
       ##
       # Updates the name of the table.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def name= new_name
         patch_gapi! name: new_name
@@ -113,7 +115,7 @@ module Gcloud
       ##
       # A string hash of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def etag
         ensure_full_data!
@@ -123,7 +125,7 @@ module Gcloud
       ##
       # A URL that can be used to access the dataset using the REST API.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def api_url
         ensure_full_data!
@@ -133,7 +135,7 @@ module Gcloud
       ##
       # The description of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description
         ensure_full_data!
@@ -143,7 +145,7 @@ module Gcloud
       ##
       # Updates the description of the table.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def description= new_description
         patch_gapi! description: new_description
@@ -152,7 +154,7 @@ module Gcloud
       ##
       # The time when this table was created.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def created_at
         ensure_full_data!
@@ -164,7 +166,7 @@ module Gcloud
       # If not present, the table will persist indefinitely.
       # Expired tables will be deleted and their storage reclaimed.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def expires_at
         ensure_full_data!
@@ -175,7 +177,7 @@ module Gcloud
       ##
       # The date when this table was last modified.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def modified_at
         ensure_full_data!
@@ -185,7 +187,7 @@ module Gcloud
       ##
       # Checks if the table's type is "TABLE".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table?
         @gapi["type"] == "TABLE"
@@ -194,7 +196,7 @@ module Gcloud
       ##
       # Checks if the table's type is "VIEW".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def view?
         @gapi["type"] == "VIEW"
@@ -204,7 +206,7 @@ module Gcloud
       # The geographic location where the table should reside. Possible
       # values include EU and US. The default value is US.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def location
         ensure_full_data!
@@ -214,7 +216,7 @@ module Gcloud
       ##
       # The schema of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def schema
         ensure_full_data!
@@ -227,7 +229,7 @@ module Gcloud
       ##
       # The fields of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def fields
         f = schema["fields"]
@@ -239,7 +241,7 @@ module Gcloud
       ##
       # The names of the columns in the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def headers
         fields.map { |f| f["name"] }
@@ -248,7 +250,7 @@ module Gcloud
       ##
       # The query that executes each time the view is loaded.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def query
         @gapi["view"]["query"] if @gapi["view"]
@@ -256,16 +258,13 @@ module Gcloud
 
       ##
       # Updates the query that executes each time the view is loaded.
-      # See the BigQuery {Query Reference
-      # }[https://cloud.google.com/bigquery/query-reference].
       #
-      # === Parameters
+      # @see https://cloud.google.com/bigquery/query-reference BigQuery Query
+      #   Reference
       #
-      # +new_query+::
-      #   The query that defines the view. (+String+)
+      # @param [String] new_query The query that defines the view.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -275,7 +274,7 @@ module Gcloud
       #
       #   view.query = "SELECT first_name FROM [my_project:my_dataset.my_table]"
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def query= new_query
         patch_gapi! query: new_query
@@ -284,40 +283,31 @@ module Gcloud
       ##
       # Runs a query to retrieve all data from the view.
       #
-      # === Parameters
+      # @param [Integer] max The maximum number of rows of data to return per
+      #   page of results. Setting this flag to a small value such as 1000 and
+      #   then paging through results might improve reliability when the query
+      #   result set is large. In addition to this limit, responses are also
+      #   limited to 10 MB. By default, there is no maximum row count, and only
+      #   the byte limit applies.
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      #   Instead, if the query is valid, BigQuery returns statistics about the
+      #   job such as how many bytes would be processed. If the query is
+      #   invalid, an error returns. The default value is +false+.
       #
-      # +max+::
-      #   The maximum number of rows of data to return per page of results.
-      #   Setting this flag to a small value such as 1000 and then paging
-      #   through results might improve reliability when the query result set is
-      #   large. In addition to this limit, responses are also limited to 10 MB.
-      #   By default, there is no maximum row count, and only the byte limit
-      #   applies. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   the request times out and returns. Note that this is only a timeout
-      #   for the request, not the query. If the query takes longer to run than
-      #   the timeout value, the call returns without any results and with
-      #   QueryData#complete? set to false. The default value is 10000
-      #   milliseconds (10 seconds). (+Integer+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is true. For more information, see
-      #   {query caching}[https://developers.google.com/bigquery/querying-data].
-      #   (+Boolean+)
-      # +dryrun+::
-      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
-      #   is valid, BigQuery returns statistics about the job such as how many
-      #   bytes would be processed. If the query is invalid, an error returns.
-      #   The default value is +false+. (+Boolean+)
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -331,7 +321,7 @@ module Gcloud
       #   end
       #   more_data = data.next if data.next?
       #
-      # :category: Data
+      # @!group Data
       #
       def data max: nil, timeout: nil, cache: nil, dryrun: nil
         sql = "SELECT * FROM #{@gapi['id']}"
@@ -348,12 +338,9 @@ module Gcloud
       ##
       # Permanently deletes the table.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the table was deleted.
       #
-      # +true+ if the table was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -363,7 +350,7 @@ module Gcloud
       #
       #   table.delete
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def delete
         ensure_connection!
@@ -378,7 +365,7 @@ module Gcloud
       ##
       # Reloads the table with current data from the BigQuery service.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def reload!
         ensure_connection!
@@ -392,8 +379,8 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # New Table from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Table from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn


### PR DESCRIPTION
This PR converts BigQuery code comments to YARD tags for the purpose of:

1. Building HTML-based API documentation.
2. Building [gcloud-common JSON-based documentation](https://github.com/GoogleCloudPlatform/gcloud-common/issues/33).

[closes #455]