### PR TITLE
Convert Pub/Sub docs to YARD

### DIFF
--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -19,13 +19,13 @@ require "google/api_client"
 module Gcloud
   module Pubsub
     ##
-    # Represents the connection to Pub/Sub,
+    # @private Represents the connection to Pub/Sub,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
@@ -271,7 +271,7 @@ module Gcloud
         "#{project_path(options)}/subscriptions/#{subscription_name}"
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
 

--- a/lib/gcloud/pubsub/credentials.rb
+++ b/lib/gcloud/pubsub/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Pubsub
     ##
-    # Represents the OAuth 2.0 signing logic for Pub/Sub.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the OAuth 2.0 signing logic for Pub/Sub.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/pubsub"]
       PATH_ENV_VARS = %w(PUBSUB_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(PUBSUB_KEYFILE_JSON GCLOUD_KEYFILE_JSON

--- a/lib/gcloud/pubsub/errors.rb
+++ b/lib/gcloud/pubsub/errors.rb
@@ -26,7 +26,8 @@ module Gcloud
       # The response object of the failed HTTP request.
       attr_reader :response
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         new.tap do |e|
           e.response = resp
         end
@@ -59,7 +60,8 @@ module Gcloud
         @response = response
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         klass = klass_for resp.data["error"]["status"]
         klass.new resp.data["error"]["message"], resp
       rescue

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -22,11 +22,12 @@ module Gcloud
     #
     # Represents a Pub/Sub Message.
     #
-    # Message objects are created by Topic#publish.
-    # Subscription#pull returns an array of ReceivedMessage objects, each of
-    # which contains a Message object. Each ReceivedMessage object can be
+    # Message objects are created by {Topic#publish}.
+    # {Subscription#pull} returns an array of {ReceivedMessage} objects, each of
+    # which contains a Message object. Each {ReceivedMessage} object can be
     # acknowledged and/or delayed.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -44,8 +45,8 @@ module Gcloud
     #
     class Message
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
       # Create an empty Message object.
@@ -79,8 +80,8 @@ module Gcloud
       alias_method :msg_id, :message_id
 
       ##
-      # New Topic from a Google API Client object.
-      def self.from_gapi gapi #:nodoc:
+      # @private New {Topic} from a Google API Client object.
+      def self.from_gapi gapi
         new.tap do |f|
           f.gapi = gapi
         end

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -25,12 +25,15 @@ module Gcloud
     # = Project
     #
     # Represents the project that pubsub messages are pushed to and pulled from.
-    # Topic is a named resource to which messages are sent by publishers.
-    # Subscription is a named resource representing the stream of messages from
-    # a single, specific topic, to be delivered to the subscribing application.
-    # Message is a combination of data and attributes that a publisher sends to
-    # a topic and is eventually delivered to subscribers.
+    # {Topic} is a named resource to which messages are sent by publishers.
+    # {Subscription} is a named resource representing the stream of messages
+    # from a single, specific topic, to be delivered to the subscribing
+    # application. {Message} is a combination of data and attributes that a
+    # publisher sends to a topic and is eventually delivered to subscribers.
     #
+    # See {Gcloud#pubsub}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -39,15 +42,14 @@ module Gcloud
     #   topic = pubsub.topic "my-topic"
     #   topic.publish "task completed"
     #
-    # See Gcloud#pubsub
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Connection instance.
-      def initialize project, credentials #:nodoc:
+      # @private Creates a new Connection instance.
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -55,8 +57,7 @@ module Gcloud
 
       # The Pub/Sub project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -70,8 +71,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["PUBSUB_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -81,67 +82,54 @@ module Gcloud
       ##
       # Retrieves topic by name.
       #
-      # === Parameters
+      # The topic will be created if the topic does not exist and the
+      # +autocreate+ option is set to true.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
-      # +autocreate+::
-      #   Flag to control whether the requested topic will be created if it does
-      #   not exist. Ignored if +skip_lookup+ is +true+. The default value is
-      #   +false+. (+Boolean+)
-      # +project+::
-      #   If the topic belongs to a project other than the one currently
-      #   connected to, the alternate project ID can be specified here.
-      #   (+String+)
-      # +skip_lookup+::
-      #   Optionally create a Topic object without verifying the topic resource
-      #   exists on the Pub/Sub service. Calls made on this object will raise
-      #   errors if the topic resource does not exist. Default is +false+.
-      #   (+Boolean+)
+      # @param [String] topic_name Name of a topic.
+      # @param [Boolean] autocreate Flag to control whether the requested topic
+      #   will be created if it does not exist. Ignored if +skip_lookup+ is
+      #   +true+. The default value is +false+.
+      # @param [String] project If the topic belongs to a project other than the
+      #   one currently connected to, the alternate project ID can be specified
+      #   here.
+      # @param [Boolean] skip_lookup Optionally create a {Topic} object without
+      #   verifying the topic resource exists on the Pub/Sub service. Calls made
+      #   on this object will raise errors if the topic resource does not exist.
+      #   Default is +false+.
       #
-      # === Returns
+      # @return [Gcloud::Pubsub::Topic, nil] Returns +nil+ if topic does not
+      #   exist. Will return a newly created{ Gcloud::Pubsub::Topic} if the
+      #   topic does not exist and +autocreate+ is set to +true+.
       #
-      # Gcloud::Pubsub::Topic or nil if topic does not exist. Will return a
-      # newly created Gcloud::Pubsub::Topic if the topic does not exist and
-      # +autocreate+ is set to +true+.
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "existing-topic"
       #
-      # By default +nil+ will be returned if the topic does not exist.
-      # the topic will be created in Pub/Sub when needed.
-      #
+      # @example By default +nil+ will be returned if the topic does not exist.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic" #=> nil
       #
-      # The topic will be created if the topic does not exist and the
-      # +autocreate+ option is set to true.
-      #
+      # @example With the +autocreate+ option set to +true+.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic", autocreate: true
       #
-      # A topic in a different project can be created using the +project+ flag.
-      #
+      # @example Create a topic in a different project with the +project+ flag.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "another-topic", project: "another-project"
       #
-      # The lookup against the Pub/Sub service can be skipped using the
-      # +skip_lookup+ option:
-      #
+      # @example Skip the lookup against the service with +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -166,17 +154,11 @@ module Gcloud
       ##
       # Creates a new topic.
       #
-      # === Parameters
+      # @param [String] topic_name Name of a topic.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
+      # @return [Gcloud::Pubsub::Topic]
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Topic
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -197,21 +179,15 @@ module Gcloud
       ##
       # Retrieves a list of topics for the given project.
       #
-      # === Parameters
+      # @param [String] token The +token+ value returned by the last call to
+      #   +topics+; indicates that this is a continuation of a call, and that
+      #   the system should return the next page of data.
+      # @param [Integer] max Maximum number of topics to return.
       #
-      # +token+::
-      #   The +token+ value returned by the last call to +topics+; indicates
-      #   that this is a continuation of a call, and that the system should
-      #   return the next page of data. (+String+)
-      # +max+::
-      #   Maximum number of topics to return. (+Integer+)
+      # @return [Array<Gcloud::Pubsub::Topic>] (See
+      #   {Gcloud::Pubsub::Topic::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::Topic (See Gcloud::Pubsub::Topic::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -222,9 +198,7 @@ module Gcloud
       #     puts topic.name
       #   end
       #
-      # If you have a significant number of topics, you may need to paginate
-      # through them: (See Topic::List#token)
-      #
+      # @example With pagination: (See {Topic::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -256,27 +230,24 @@ module Gcloud
       alias_method :list_topics, :topics
 
       ##
-      # Publishes one or more messages to the given topic.
+      # Publishes one or more messages to the given topic. The topic will be
+      # created if the topic does previously not exist and the +autocreate+
+      # option is provided.
       #
-      # === Parameters
+      # A note about auto-creating the topic: Any message published to a topic
+      # without a subscription will be lost.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
-      # +data+::
-      #   The message data. (+String+)
-      # +attributes+::
-      #   Optional attributes for the message. (+Hash+)
-      # <code>attributes[:autocreate]</code>::
-      #   Flag to control whether the provided topic will be created if it does
-      #   not exist.
+      # @param [String] topic_name Name of a topic.
+      # @param [String] data The message data.
+      # @param [Hash] attributes Optional attributes for the message.
+      # @option attributes [Boolean] :autocreate Flag to control whether the
+      #   provided topic will be created if it does not exist.
       #
-      # === Returns
+      # @return [Message, Array<Message>] Returns the published message when
+      #   called without a block, or an array of messages when called with a
+      #   block.
       #
-      # Message object when called without a block,
-      # Array of Message objects when called with a block
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -284,8 +255,7 @@ module Gcloud
       #
       #   msg = pubsub.publish "my-topic", "new-message"
       #
-      # Additionally, a message can be published with attributes:
-      #
+      # @example Additionally, a message can be published with attributes:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -294,8 +264,7 @@ module Gcloud
       #   msg = pubsub.publish "my-topic", "new-message", foo: :bar,
       #                                                   this: :that
       #
-      # Multiple messages can be published at the same time by passing a block:
-      #
+      # @example Multiple messages can be sent at the same time using a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -307,18 +276,13 @@ module Gcloud
       #     batch.publish "new-message-3", foo: :bif
       #   end
       #
-      # Additionally, the topic will be created if the topic does previously not
-      # exist and the +autocreate+ option is provided.
-      #
+      # @example With +autocreate+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #
       #   msg = pubsub.publish "new-topic", "new-message", autocreate: true
-      #
-      # A note about auto-creating the topic: Any message published to a topic
-      # without a subscription will be lost.
       #
       def publish topic_name, data = nil, attributes = {}
         # Fix parameters
@@ -336,34 +300,27 @@ module Gcloud
       end
 
       ##
-      # Creates a new Subscription object for the provided topic.
+      # Creates a new {Subscription} object for the provided topic. The topic
+      # will be created if the topic does previously not exist and the
+      # +autocreate+ option is provided.
       #
-      # === Parameters
+      # @param [String] topic_name Name of a topic.
+      # @param [String] subscription_name Name of the new subscription. Must
+      #   start with a letter, and contain only letters ([A-Za-z]), numbers
+      #   ([0-9], dashes (-), underscores (_), periods (.), tildes (~), plus (+)
+      #   or percent signs (%). It must be between 3 and 255 characters in
+      #   length, and it must not start with "goog".
+      # @param [Integer] deadline The maximum number of seconds after a
+      #   subscriber receives a message before the subscriber should acknowledge
+      #   the message.
+      # @param [String] endpoint A URL locating the endpoint to which messages
+      #   should be pushed.
+      # @param [String] autocreate Flag to control whether the topic will be
+      #   created if it does not exist.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
-      # +subscription_name+::
-      #   Name of the new subscription. Must start with a letter, and contain
-      #   only letters ([A-Za-z]), numbers ([0-9], dashes (-), underscores (_),
-      #   periods (.), tildes (~), plus (+) or percent signs (%). It must be
-      #   between 3 and 255 characters in length, and it must not start with
-      #   "goog". (+String+)
-      # +deadline+::
-      #   The maximum number of seconds after a subscriber receives a message
-      #   before the subscriber should acknowledge the message. (+Integer+)
-      # +endpoint+::
-      #   A URL locating the endpoint to which messages should be pushed.
-      #   e.g. "https://example.com/push" (+String+)
-      # +autocreate+::
-      #   Flag to control whether the topic will be created if it does not
-      #   exist.
+      # @return [Gcloud::Pubsub::Subscription]
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -372,8 +329,7 @@ module Gcloud
       #   sub = pubsub.subscribe "my-topic", "my-topic-sub"
       #   puts sub.name # => "my-topic-sub"
       #
-      # The name is optional, and will be generated if not given.
-      #
+      # @example The name is optional, and will be generated if not given.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -382,9 +338,7 @@ module Gcloud
       #   sub = pubsub.subscribe "my-topic"
       #   puts sub.name # => "generated-sub-name"
       #
-      # The subscription can be created that waits two minutes for
-      # acknowledgement and pushed all messages to an endpoint
-      #
+      # @example Wait 2 minutes for acknowledgement and push all to an endpoint:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -394,9 +348,7 @@ module Gcloud
       #                          deadline: 120,
       #                          endpoint: "https://example.com/push"
       #
-      # Additionally, the topic will be created if the topic does previously not
-      # exist and the +autocreate+ option is provided.
-      #
+      # @example With +autocreate+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -425,26 +377,19 @@ module Gcloud
       ##
       # Retrieves subscription by name.
       #
-      # === Parameters
+      # @param [String] subscription_name Name of a subscription.
+      # @param [String] project If the subscription belongs to a project other
+      #   than the one currently connected to, the alternate project ID can be
+      #   specified here.
+      # @param [Boolean] skip_lookup Optionally create a {Subscription} object
+      #   without verifying the subscription resource exists on the Pub/Sub
+      #   service. Calls made on this object will raise errors if the service
+      #   resource does not exist. Default is +false+.
       #
-      # +subscription_name+::
-      #   Name of a subscription. (+String+)
-      # +project+::
-      #   If the subscription belongs to a project other than the one currently
-      #   connected to, the alternate project ID can be specified here.
-      #   (+String+)
-      # +skip_lookup+::
-      #   Optionally create a Subscription object without verifying the
-      #   subscription resource exists on the Pub/Sub service. Calls made on
-      #   this object will raise errors if the service resource does not exist.
-      #   Default is +false+. (+Boolean+)
+      # @return [Gcloud::Pubsub::Subscription, nil] Returns +nil+ if the
+      #   subscription does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription or +nil+ if the subscription does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -453,9 +398,7 @@ module Gcloud
       #   subscription = pubsub.subscription "my-sub"
       #   puts subscription.name
       #
-      # The lookup against the Pub/Sub service can be skipped using the
-      # +skip_lookup+ option:
-      #
+      # @example Skip the lookup against the service with +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -482,24 +425,16 @@ module Gcloud
       ##
       # Retrieves a list of subscriptions for the given project.
       #
-      # === Parameters
+      # @param [String] prefix Filter results to subscriptions whose names begin
+      #   with this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of subscriptions to return.
       #
-      # +prefix+::
-      #   Filter results to subscriptions whose names begin with this prefix.
-      #   (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of subscriptions to return. (+Integer+)
+      # @return [Array<Gcloud::Pubsub::Subscription>] (See
+      #   {Gcloud::Pubsub::Subscription::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::Subscription
-      # (See Gcloud::Pubsub::Subscription::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -510,8 +445,7 @@ module Gcloud
       #     puts subscription.name
       #   end
       #
-      # If you have a significant number of subscriptions, you may need to
-      # paginate through them: (See Subscription::List#token)
+      # @example With pagination: (See {Subscription::List#token})
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -21,8 +21,9 @@ module Gcloud
     ##
     # = ReceivedMessage
     #
-    # Represents a Pub/Sub Message that can be acknowledged or delayed.
+    # Represents a Pub/Sub {Message} that can be acknowledged or delayed.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -37,16 +38,16 @@ module Gcloud
     #
     class ReceivedMessage
       ##
-      # The Subscription object.
-      attr_accessor :subscription #:nodoc:
+      # @private The {Subscription} object.
+      attr_accessor :subscription
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Subscription object.
-      def initialize #:nodoc:
+      # @private Create an empty {Subscription} object.
+      def initialize
         @subscription = nil
         @gapi = {}
       end
@@ -87,8 +88,7 @@ module Gcloud
       ##
       # Acknowledges receipt of the message.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -113,17 +113,13 @@ module Gcloud
       # This indicates that more time is needed to process the message, or to
       # make the message available for redelivery.
       #
-      # === Parameters
+      # @param [Integer] deadline The new ack deadline in seconds from the time
+      #   this request is sent to the Pub/Sub system. Must be >= 0. For example,
+      #   if the value is +10+, the new ack deadline will expire 10 seconds
+      #   after the call is made. Specifying +0+ may immediately make the
+      #   message available for another pull request.
       #
-      # +deadline+::
-      #   The new ack deadline in seconds from the time this request is sent
-      #   to the Pub/Sub system. Must be >= 0. For example, if the value is
-      #   +10+, the new ack deadline will expire 10 seconds after the call is
-      #   made. Specifying +0+ may immediately make the message available for
-      #   another pull request. (+Integer+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -150,8 +146,8 @@ module Gcloud
       end
 
       ##
-      # New ReceivedMessage from a Google API Client object.
-      def self.from_gapi gapi, subscription #:nodoc:
+      # @private New ReceivedMessage from a Google API Client object.
+      def self.from_gapi gapi, subscription
         new.tap do |f|
           f.gapi         = gapi
           f.subscription = subscription

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -23,8 +23,9 @@ module Gcloud
     # = Subscription
     #
     # A named resource representing the stream of messages from a single,
-    # specific topic, to be delivered to the subscribing application.
+    # specific {Topic}, to be delivered to the subscribing application.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -36,16 +37,16 @@ module Gcloud
     #
     class Subscription
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Subscription object.
-      def initialize #:nodoc:
+      # @private Create an empty {Subscription} object.
+      def initialize
         @connection = nil
         @gapi = {}
         @name = nil
@@ -53,8 +54,8 @@ module Gcloud
       end
 
       ##
-      # New lazy Topic object without making an HTTP request.
-      def self.new_lazy name, conn, options = {} #:nodoc:
+      # @private New lazy {Topic} object without making an HTTP request.
+      def self.new_lazy name, conn, options = {}
         sub = new.tap do |f|
           f.gapi = nil
           f.connection = conn
@@ -72,14 +73,11 @@ module Gcloud
       end
 
       ##
-      # The Topic from which this subscription receives messages.
+      # The {Topic} from which this subscription receives messages.
       #
-      # === Returns
+      # @return [Topic]
       #
-      # Topic
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -124,8 +122,7 @@ module Gcloud
       ##
       # Determines whether the subscription exists in the Pub/Sub service.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -146,11 +143,11 @@ module Gcloud
       end
 
       ##
+      # @private
       # Determines whether the subscription object was created with an
       # HTTP call.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -159,7 +156,7 @@ module Gcloud
       #   sub = pubsub.get_subscription "my-topic-sub"
       #   sub.lazy? #=> false
       #
-      def lazy? #:nodoc:
+      def lazy?
         @gapi.nil?
       end
 
@@ -167,12 +164,9 @@ module Gcloud
       # Deletes an existing subscription.
       # All pending messages in the subscription are immediately dropped.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the subscription was deleted.
       #
-      # +true+ if the subscription was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -197,27 +191,20 @@ module Gcloud
       # +UNAVAILABLE+ if there are too many concurrent pull requests pending
       # for the given subscription.
       #
-      # === Parameters
+      # @param [Boolean] immediate When +true+ the system will respond
+      #   immediately even if it is not able to return messages. When +false+
+      #   the system is allowed to wait until it can return least one message.
+      #   No messages are returned when a request times out. The default value
+      #   is +true+.
+      # @param [Integer] max The maximum number of messages to return for this
+      #   request. The Pub/Sub system may return fewer than the number
+      #   specified. The default value is +100+, the maximum value is +1000+.
+      # @param [Boolean] autoack Automatically acknowledge the message as it is
+      #   pulled. The default value is +false+.
       #
-      # +immediate+::
-      #   When +true+ the system will respond immediately even if it is not able
-      #   to return messages. When +false+ the system is allowed to wait until
-      #   it can return least one message. No messages are returned when a
-      #   request times out. The default value is +true+. (+Boolean+)
-      # +max+::
-      #   The maximum number of messages to return for this request. The Pub/Sub
-      #   system may return fewer than the number specified. The default value
-      #   is +100+, the maximum value is +1000+. (+Integer+)
-      # +autoack+::
-      #   Automatically acknowledge the message as it is pulled. The default
-      #   value is +false+. (+Boolean+)
+      # @return [Array<Gcloud::Pubsub::ReceivedMessage>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::ReceivedMessage
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -226,8 +213,7 @@ module Gcloud
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.pull.each { |msg| msg.acknowledge! }
       #
-      # A maximum number of messages returned can also be specified:
-      #
+      # @example A maximum number of messages returned can also be specified:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -236,9 +222,7 @@ module Gcloud
       #   sub = pubsub.subscription "my-topic-sub", max: 10
       #   sub.pull.each { |msg| msg.acknowledge! }
       #
-      # The call can block until messages are available by setting the
-      # +:immediate+ option to +false+:
-      #
+      # @example The call can block until messages are available:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -271,22 +255,15 @@ module Gcloud
       #
       #   subscription.pull immediate: false
       #
-      # === Parameters
+      # @param [Integer] max The maximum number of messages to return for this
+      #   request. The Pub/Sub system may return fewer than the number
+      #   specified. The default value is +100+, the maximum value is +1000+.
+      # @param [Boolean] autoack Automatically acknowledge the message as it is
+      #   pulled. The default value is +false+.
       #
-      # +max+::
-      #   The maximum number of messages to return for this request. The Pub/Sub
-      #   system may return fewer than the number specified. The default value
-      #   is +100+, the maximum value is +1000+. (+Integer+)
-      # +autoack+::
-      #   Automatically acknowledge the message as it is pulled. The default
-      #   value is +false+. (+Boolean+)
+      # @return [Array<Gcloud::Pubsub::ReceivedMessage>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::ReceivedMessage
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -304,22 +281,16 @@ module Gcloud
       # Poll the backend for new messages. This runs a loop to ping the API,
       # blocking indefinitely, yielding retrieved messages as they are received.
       #
-      # === Parameters
+      # @param [Integer] max The maximum number of messages to return for this
+      #   request. The Pub/Sub system may return fewer than the number
+      #   specified. The default value is +100+, the maximum value is +1000+.
+      # @param [Boolean] autoack Automatically acknowledge the message as it is
+      #   pulled. The default value is +false+.
+      # @param [Number] delay The number of seconds to pause between requests
+      #   when the Google Cloud service has no messages to return. The default
+      #   value is +1+.
       #
-      # +max+::
-      #   The maximum number of messages to return for this request. The Pub/Sub
-      #   system may return fewer than the number specified. The default value
-      #   is +100+, the maximum value is +1000+. (+Integer+)
-      # +autoack+::
-      #   Automatically acknowledge the message as it is pulled. The default
-      #   value is +false+. (+Boolean+)
-      # +delay+::
-      #   The number of seconds to pause between requests when the Google Cloud
-      #   service has no messages to return. The default value is +1+.
-      #   (+Number+)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -330,9 +301,7 @@ module Gcloud
       #     # process msg
       #   end
       #
-      # The number of messages pulled per batch can be set with the +max+
-      # option:
-      #
+      # @example Limit the number of messages pulled per batch with +max+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -343,9 +312,7 @@ module Gcloud
       #     # process msg
       #   end
       #
-      # Messages can be automatically acknowledged as they are pulled with the
-      # +autoack+ option:
-      #
+      # @example Automatically acknowledge messages with +autoack+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -375,14 +342,10 @@ module Gcloud
       # Acknowledging a message more than once will not result in an error.
       # This is only used for messages received via pull.
       #
-      # === Parameters
+      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      #   objects or ack_id values.
       #
-      # +messages+::
-      #   One or more ReceivedMessage objects or ack_id values.
-      #   (+ReceivedMessage+ or +ack_id+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -411,20 +374,15 @@ module Gcloud
       # make the messages available for redelivery if the processing was
       # interrupted.
       #
-      # === Parameters
+      # @param [Integer] new_deadline The new ack deadline in seconds from the
+      #   time this request is sent to the Pub/Sub system. Must be >= 0. For
+      #   example, if the value is +10+, the new ack deadline will expire 10
+      #   seconds after the call is made. Specifying +0+ may immediately make
+      #   the message available for another pull request.
+      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      #   objects or ack_id values.
       #
-      # +new_deadline+::
-      #   The new ack deadline in seconds from the time this request is sent
-      #   to the Pub/Sub system. Must be >= 0. For example, if the value is
-      #   +10+, the new ack deadline will expire 10 seconds after the call is
-      #   made. Specifying +0+ may immediately make the messages available for
-      #   another pull request. (+Integer+)
-      # +messages+::
-      #   One or more ReceivedMessage objects or ack_id values.
-      #   (+ReceivedMessage+ or +ack_id+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -448,17 +406,15 @@ module Gcloud
       ##
       # Gets the access control policy.
       #
-      # === Parameters
+      # By default, the policy values are memoized to reduce the number of API
+      # calls to the Pub/Sub service.
       #
-      # +force+::
-      #   Force the latest policy to be retrieved from the Pub/Sub service when
-      #   +true. Otherwise the policy will be memoized to reduce the number of
-      #   API calls made to the Pub/Sub service. The default is +false+.
-      #   (+Boolean+)
+      # @param [Boolean] force Force the latest policy to be retrieved from the
+      #   Pub/Sub service when +true. Otherwise the policy will be memoized to
+      #   reduce the number of API calls made to the Pub/Sub service. The
+      #   default is +false+.
       #
-      # === Returns
-      #
-      # A hash that conforms to the following structure:
+      # @return [Hash] Returns a hash that conforms to the following structure:
       #
       #   {
       #     "etag"=>"CAE=",
@@ -468,11 +424,7 @@ module Gcloud
       #     }]
       #   }
       #
-      # === Examples
-      #
-      # By default, the policy values are memoized to reduce the number of API
-      # calls to the Pub/Sub service.
-      #
+      # @example Policy values are memoized to reduce the number of API calls:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -482,9 +434,7 @@ module Gcloud
       #   puts subscription.policy["bindings"]
       #   puts subscription.policy["rules"]
       #
-      # To retrieve the latest policy from the Pub/Sub service, use the +force+
-      # flag.
-      #
+      # @example Use +force+ to retrieve the latest policy from the service:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -507,10 +457,8 @@ module Gcloud
       ##
       # Sets the access control policy.
       #
-      # === Parameters
-      #
-      # +new_policy+::
-      #   A hash that conforms to the following structure:
+      # @param [String] new_policy A hash that conforms to the following
+      #   structure:
       #
       #     {
       #       "bindings" => [{
@@ -519,8 +467,7 @@ module Gcloud
       #       }]
       #     }
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -548,23 +495,18 @@ module Gcloud
 
       ##
       # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy. See
-      # {Managing Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # IAM}[https://cloud.google.com/iam/] access control policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +permissions+::
-      #   The set of permissions to check access for. Permissions with wildcards
-      #   (such as +*+ or +storage.*+) are not allowed.
-      #   (String or Array of Strings)
+      # @param [String, Array<String>] permissions The set of permissions to
+      #   check access for. Permissions with wildcards (such as +*+ or
+      #   +storage.*+) are not allowed.
       #
-      # === Returns
+      # @return [Array<String>] The permissions that have access.
       #
-      # The permissions that have access. (Array of Strings)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -587,8 +529,8 @@ module Gcloud
       end
 
       ##
-      # New Subscription from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New {Subscription} from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -618,7 +560,7 @@ module Gcloud
 
       ##
       # Makes sure the values are the +ack_id+.
-      # If given several ReceivedMessage objects extract the +ack_id+ values.
+      # If given several {ReceivedMessage} objects extract the +ack_id+ values.
       def coerce_ack_ids messages
         Array(messages).flatten.map do |msg|
           msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s

--- a/lib/gcloud/pubsub/subscription/list.rb
+++ b/lib/gcloud/pubsub/subscription/list.rb
@@ -24,7 +24,7 @@ module Gcloud
         ##
         # If not empty, indicates that there are more subscriptions
         # that match the request and this value should be passed to
-        # the next Gcloud::PubSub::Topic#subscriptions to continue.
+        # the next {Gcloud::PubSub::Topic#subscriptions} to continue.
         attr_accessor :token
 
         ##
@@ -35,8 +35,8 @@ module Gcloud
         end
 
         ##
-        # New Subscription::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Subscription::List from a response object.
+        def self.from_response resp, conn
           subs = Array(resp.data["subscriptions"]).map do |gapi_object|
             if gapi_object.is_a? String
               Subscription.new_lazy gapi_object, conn

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -25,6 +25,7 @@ module Gcloud
     #
     # A named resource to which messages are published.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -35,16 +36,16 @@ module Gcloud
     #
     class Topic
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Topic object.
-      def initialize #:nodoc:
+      # @private Create an empty {Topic} object.
+      def initialize
         @connection = nil
         @gapi = {}
         @name = nil
@@ -52,8 +53,8 @@ module Gcloud
       end
 
       ##
-      # New lazy Topic object without making an HTTP request.
-      def self.new_lazy name, conn, options = {} #:nodoc:
+      # @private New lazy {Topic} object without making an HTTP request.
+      def self.new_lazy name, conn, options = {}
         new.tap do |t|
           t.gapi = nil
           t.connection = conn
@@ -73,12 +74,9 @@ module Gcloud
       ##
       # Permanently deletes the topic.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the topic was deleted.
       #
-      # +true+ if the topic was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -98,29 +96,22 @@ module Gcloud
       end
 
       ##
-      # Creates a new Subscription object on the current Topic.
+      # Creates a new {Subscription} object on the current Topic.
       #
-      # === Parameters
+      # @param [String] subscription_name Name of the new subscription. Must
+      #   start with a letter, and contain only letters ([A-Za-z]), numbers
+      #   ([0-9], dashes (-), underscores (_), periods (.), tildes (~), plus (+)
+      #   or percent signs (%). It must be between 3 and 255 characters in
+      #   length, and it must not start with "goog".
+      # @param [Integer] deadline The maximum number of seconds after a
+      #   subscriber receives a message before the subscriber should acknowledge
+      #   the message.
+      # @param [String] endpoint A URL locating the endpoint to which messages
+      #   should be pushed.
       #
-      # +subscription_name+::
-      #   Name of the new subscription. Must start with a letter, and contain
-      #   only letters ([A-Za-z]), numbers ([0-9], dashes (-), underscores (_),
-      #   periods (.), tildes (~), plus (+) or percent signs (%). It must be
-      #   between 3 and 255 characters in length, and it must not start with
-      #   "goog". (+String+)
-      # +deadline+::
-      #   The maximum number of seconds after a subscriber receives a message
-      #   before the subscriber should acknowledge the message. (+Integer+)
-      # +endpoint+::
-      #   A URL locating the endpoint to which messages should be pushed.
-      #   e.g. "https://example.com/push" (+String+)
+      # @return [Gcloud::Pubsub::Subscription]
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -130,7 +121,7 @@ module Gcloud
       #   sub = topic.subscribe "my-topic-sub"
       #   puts sub.name # => "my-topic-sub"
       #
-      # The name is optional, and will be generated if not given.
+      # @example The name is optional, and will be generated if not given:
       #
       #   require "gcloud"
       #
@@ -141,8 +132,7 @@ module Gcloud
       #   sub = topic.subscribe "my-topic-sub"
       #   puts sub.name # => "generated-sub-name"
       #
-      # The subscription can be created that waits two minutes for
-      # acknowledgement and pushed all messages to an endpoint
+      # @example Wait 2 minutes for acknowledgement and push all to an endpoint:
       #
       #   require "gcloud"
       #
@@ -170,22 +160,16 @@ module Gcloud
       ##
       # Retrieves subscription by name.
       #
-      # === Parameters
+      # @param [String] subscription_name Name of a subscription.
+      # @param [Boolean] skip_lookup Optionally create a {Subscription} object
+      #   without verifying the subscription resource exists on the Pub/Sub
+      #   service. Calls made on this object will raise errors if the service
+      #   resource does not exist. Default is +false+.
       #
-      # +subscription_name+::
-      #   Name of a subscription. (+String+)
-      # +skip_lookup+::
-      #   Optionally create a Subscription object without verifying the
-      #   subscription resource exists on the Pub/Sub service. Calls made on
-      #   this object will raise errors if the service resource does not exist.
-      #   Default is +false+. (+Boolean+)
+      # @return [Gcloud::Pubsub::Subscription, nil] Returns +nil+ if
+      #   the subscription does not exist.
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription or nil if subscription does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -195,9 +179,7 @@ module Gcloud
       #   subscription = topic.subscription "my-topic-subscription"
       #   puts subscription.name
       #
-      # The lookup against the Pub/Sub service can be skipped using the
-      # +skip_lookup+ option:
-      #
+      # @example Skip the lookup against the service with +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -223,21 +205,14 @@ module Gcloud
       ##
       # Retrieves a list of subscription names for the given project.
       #
-      # === Parameters
+      # @param [String] token The +token+ value returned by the last call to
+      #   +subscriptions+; indicates that this is a continuation of a call, and
+      #   that the system should return the next page of data.
+      # @param [Integer] max Maximum number of subscriptions to return.
       #
-      # +token+::
-      #   The +token+ value returned by the last call to +subscriptions+;
-      #   indicates that this is a continuation of a call, and that the system
-      #   should return the next page of data. (+String+)
-      # +max+::
-      #   Maximum number of subscriptions to return. (+Integer+)
+      # @return [Array<Subscription>] (See {Subscription::List})
       #
-      # === Returns
-      #
-      # Array of Subscription objects (See Subscription::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -249,8 +224,7 @@ module Gcloud
       #     puts subscription.name
       #   end
       #
-      # If you have a significant number of subscriptions, you may need to
-      # paginate through them: (See Subscription::List#token)
+      # @example With pagination: (See {Subscription::List#token})
       #
       #   require "gcloud"
       #
@@ -286,20 +260,14 @@ module Gcloud
       ##
       # Publishes one or more messages to the topic.
       #
-      # === Parameters
+      # @param [String] data The message data.
+      # @param [Hash] attributes Optional attributes for the message.
       #
-      # +data+::
-      #   The message data. (+String+)
-      # +attributes+::
-      #   Optional attributes for the message. (+Hash+)
+      # @return [Message, Array<Message>] Returns the published message when
+      #   called without a block, or an array of messages when called with a
+      #   block.
       #
-      # === Returns
-      #
-      # Message object when called without a block,
-      # Array of Message objects when called with a block
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -308,7 +276,7 @@ module Gcloud
       #   topic = pubsub.topic "my-topic"
       #   msg = topic.publish "new-message"
       #
-      # Additionally, a message can be published with attributes:
+      # @example Additionally, a message can be published with attributes:
       #
       #   require "gcloud"
       #
@@ -320,8 +288,7 @@ module Gcloud
       #                       foo: :bar,
       #                       this: :that
       #
-      # Multiple messages can be published at the same time by passing a block:
-      #
+      # @example Multiple messages can be sent at the same time using a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -345,17 +312,12 @@ module Gcloud
       ##
       # Gets the access control policy.
       #
-      # === Parameters
+      # @param [Boolean] force Force the latest policy to be retrieved from the
+      #   Pub/Sub service when +true. Otherwise the policy will be memoized to
+      #   reduce the number of API calls made to the Pub/Sub service. The
+      #   default is +false+.
       #
-      # +force+::
-      #   Force the latest policy to be retrieved from the Pub/Sub service when
-      #   +true. Otherwise the policy will be memoized to reduce the number of
-      #   API calls made to the Pub/Sub service. The default is +false+.
-      #   (+Boolean+)
-      #
-      # === Returns
-      #
-      # A hash that conforms to the following structure:
+      # @return [Hash] Returns a hash that conforms to the following structure:
       #
       #   {
       #     "etag"=>"CAE=",
@@ -365,11 +327,7 @@ module Gcloud
       #     }]
       #   }
       #
-      # === Examples
-      #
-      # By default, the policy values are memoized to reduce the number of API
-      # calls to the Pub/Sub service.
-      #
+      # @example Policy values are memoized to reduce the number of API calls:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -379,9 +337,7 @@ module Gcloud
       #   puts topic.policy["bindings"]
       #   puts topic.policy["rules"]
       #
-      # To retrieve the latest policy from the Pub/Sub service, use the +force+
-      # flag.
-      #
+      # @example Use +force+ to retrieve the latest policy from the service:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -404,10 +360,8 @@ module Gcloud
       ##
       # Sets the access control policy.
       #
-      # === Parameters
-      #
-      # +new_policy+::
-      #   A hash that conforms to the following structure:
+      # @param [String] new_policy A hash that conforms to the following
+      #   structure:
       #
       #     {
       #       "bindings" => [{
@@ -416,8 +370,7 @@ module Gcloud
       #       }]
       #     }
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -445,23 +398,18 @@ module Gcloud
 
       ##
       # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy. See
-      # {Managing Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # IAM}[https://cloud.google.com/iam/] access control policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +permissions+::
-      #   The set of permissions to check access for. Permissions with wildcards
-      #   (such as +*+ or +storage.*+) are not allowed.
-      #   (String or Array of Strings)
+      # @param [String, Array<String>] permissions The set of permissions to
+      #   check access for. Permissions with wildcards (such as +*+ or
+      #   +storage.*+) are not allowed.
       #
-      # === Returns
+      # @return [Array<Strings>] The permissions that have access.
       #
-      # The permissions that have access. (Array of Strings)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -486,8 +434,7 @@ module Gcloud
       ##
       # Determines whether the topic exists in the Pub/Sub service.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -506,10 +453,10 @@ module Gcloud
       end
 
       ##
+      # @private
       # Determines whether the topic object was created with an HTTP call.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -518,13 +465,13 @@ module Gcloud
       #   topic = pubsub.topic "my-topic"
       #   topic.lazy? #=> false
       #
-      def lazy? #:nodoc:
+      def lazy?
         @gapi.nil?
       end
 
       ##
-      # New Topic from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New {Topic} from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -563,12 +510,12 @@ module Gcloud
       # Batch object used to publish multiple messages at once.
       class Batch
         ##
-        # The messages to publish
-        attr_reader :messages #:nodoc:
+        # @private The messages to publish
+        attr_reader :messages
 
         ##
-        # Create a new instance of the object.
-        def initialize data = nil, attributes = {} #:nodoc:
+        # @private Create a new instance of the object.
+        def initialize data = nil, attributes = {}
           @messages = []
           @mode = :batch
           return if data.nil?
@@ -579,14 +526,14 @@ module Gcloud
         ##
         # Add multiple messages to the topic.
         # All messages added will be published at once.
-        # See Gcloud::Pubsub::Topic#publish
+        # See {Gcloud::Pubsub::Topic#publish}
         def publish data, attributes = {}
           @messages << [data, attributes]
         end
 
         ##
-        # Create Message objects with message ids.
-        def to_gcloud_messages message_ids #:nodoc:
+        # @private Create Message objects with message ids.
+        def to_gcloud_messages message_ids
           msgs = @messages.zip(Array(message_ids)).map do |arr, id|
             Message.from_gapi "data"       => arr[0],
                               "attributes" => jsonify_hash(arr[1]),

--- a/lib/gcloud/pubsub/topic/list.rb
+++ b/lib/gcloud/pubsub/topic/list.rb
@@ -24,7 +24,7 @@ module Gcloud
         ##
         # If not empty, indicates that there are more topics
         # that match the request and this value should be passed to
-        # the next Gcloud::PubSub::Project#topics to continue.
+        # the next {Gcloud::PubSub::Project#topics} to continue.
         attr_accessor :token
 
         ##
@@ -35,8 +35,8 @@ module Gcloud
         end
 
         ##
-        # New Topic::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Topic::List from a response object.
+        def self.from_response resp, conn
           topics = Array(resp.data["topics"]).map do |gapi_object|
             Topic.from_gapi gapi_object, conn
           end


### PR DESCRIPTION
This PR converts Pub/Sub code comments to YARD tags for the purpose of:

1. Building HTML-based API documentation.
2. Building gcloud-common JSON-based documentation.

[closes #458]