### PR TITLE
Yard datastore

### DIFF
--- a/lib/gcloud/datastore/connection.rb
+++ b/lib/gcloud/datastore/connection.rb
@@ -18,12 +18,14 @@ require "faraday"
 module Gcloud
   module Datastore
     ##
+    # @private
+    #
     # Represent the HTTP connection to the Datastore,
     # as well as the Datastore API calls.
     #
     # This class only deals with Protocol Buffer objects,
     # and is not part of the public API.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1beta2"
       API_URL = "https://www.googleapis.com"
 
@@ -33,13 +35,15 @@ module Gcloud
 
       ##
       # The Credentials object for signing HTTP requests.
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Create a new Connection instance.
       #
+      # @example
       #   conn = Gcloud::Datastore.Connection.new "my-todo-project",
       #     Gcloud::Datastore::Credentials.new("/path/to/keyfile.json")
+      #
       def initialize dataset_id, credentials
         @dataset_id = dataset_id
         @credentials = credentials
@@ -114,24 +118,24 @@ module Gcloud
 
       ##
       # The default HTTP headers to be sent on all API calls.
-      def default_http_headers #:nodoc:
+      def default_http_headers
         @default_http_headers ||= {
           "User-Agent"   => "gcloud-node/#{Gcloud::VERSION}",
           "Content-Type" => "application/x-protobuf" }
       end
       ##
       # Update the default HTTP headers.
-      attr_writer :default_http_headers #:nodoc:
+      attr_writer :default_http_headers
 
       ##
       # The HTTP object that makes calls to Datastore.
       # This must be a Faraday object.
-      def http #:nodoc:
+      def http
         @http ||= Faraday.new url: http_host
       end
       ##
       # Update the HTTP object.
-      attr_writer :http #:nodoc:
+      attr_writer :http
 
       ##
       # The Datastore API URL.
@@ -146,7 +150,7 @@ module Gcloud
         @http_host = new_http_host
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@dataset_id})"
       end
 

--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -18,12 +18,14 @@ require "gcloud/credentials"
 module Gcloud
   module Datastore
     ##
+    # @private
+    #
     # Authentication credentials to Google Cloud.
     # The most common way to create this object is to provide the path
     # to the JSON keyfile downloaded from Google Cloud.
     #
-    # https://developers.google.com/accounts/docs/application-default-credentials
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @see https://developers.google.com/accounts/docs/application-default-credentials
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/datastore",
                "https://www.googleapis.com/auth/userinfo.email"]
       PATH_ENV_VARS = %w(DATASTORE_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
@@ -32,7 +34,7 @@ module Gcloud
 
       ##
       # Sign OAuth 2.0 API calls.
-      def sign_http_request request #:nodoc:
+      def sign_http_request request
         if @client
           @client.fetch_access_token! if @client.expired?
           @client.generate_authenticated_request request: request

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -31,9 +31,12 @@ module Gcloud
     # Dataset is analogous to a database in relational database world.
     #
     # Gcloud::Datastore::Dataset is the main object for interacting with
-    # Google Datastore. Gcloud::Datastore::Entity objects are created,
+    # Google Datastore. {Gcloud::Datastore::Entity} objects are created,
     # read, updated, and deleted by Gcloud::Datastore::Dataset.
     #
+    # See {Gcloud#datastore}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -44,15 +47,15 @@ module Gcloud
     #
     #   tasks = dataset.run query
     #
-    # See Gcloud#datastore
     class Dataset
-      attr_accessor :connection #:nodoc:
+      # @private
+      attr_accessor :connection
 
       ##
-      # Creates a new Dataset instance.
+      # @private Creates a new Dataset instance.
       #
-      # See Gcloud#datastore
-      def initialize project, credentials #:nodoc:
+      # See {Gcloud#datastore}
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -61,8 +64,7 @@ module Gcloud
       ##
       # The Datastore project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -76,8 +78,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["DATASTORE_DATASET"] ||
           ENV["DATASTORE_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
@@ -88,19 +90,12 @@ module Gcloud
       ##
       # Generate IDs for a Key before creating an entity.
       #
-      # === Parameters
+      # @param [Key] incomplete_key A Key without +id+ or +name+ set.
+      # @param [String] count The number of new key IDs to create.
       #
-      # +incomplete_key+::
-      #   A Key without +id+ or +name+ set. (+Key+)
-      # +count+::
-      #   The number of new key IDs to create. (+Integer+)
+      # @return [Array<Gcloud::Datastore::Key>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Datastore::Key
-      #
-      # === Example
-      #
+      # @example
       #   empty_key = dataset.key "Task"
       #   task_keys = dataset.allocate_ids empty_key, 5
       #
@@ -119,18 +114,12 @@ module Gcloud
       ##
       # Persist one or more entities to the Datastore.
       #
-      # === Parameters
+      # @param [Entity] *entities One or more entity objects to be saved without
+      #   +id+ or +name+ set.
       #
-      # +entities+::
-      #   One or more entity objects to be saved without +id+ or +name+ set.
-      #   (+Entity+)
+      # @return [Array<Gcloud::Datastore::Entity>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Datastore::Entity
-      #
-      # === Example
-      #
+      # @example
       #   dataset.save task1, task2
       #
       def save *entities
@@ -144,27 +133,17 @@ module Gcloud
       ##
       # Retrieve an entity by providing key information.
       #
-      # === Parameters
+      # @param [Key, String] key_or_kind A Key object or +kind+ string value.
+      # @param [Integer, String, nil] id_or_name The Key's +id+ or +name+ value
+      #   if a +kind+ was provided in the first parameter.
       #
-      # +key_or_kind+::
-      #   A Key object or +kind+ string value. (+Key+ or +String+)
-      # +id_or_name+::
-      #   The Key's +id+ or +name+ value if a +kind+ was provided in the first
-      #   parameter. (+Integer+ or +String+ or +nil+)
+      # @return [Gcloud::Datastore::Entity, nil]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Entity or +nil+
-      #
-      # === Example
-      #
-      # Finding an entity with a key:
-      #
+      # @example Finding an entity with a key:
       #   key = dataset.key "Task", 123456
       #   task = dataset.find key
       #
-      # Finding an entity with a +kind+ and +id+/+name+:
-      #
+      # @example Finding an entity with a +kind+ and +id+/+name+:
       #   task = dataset.find "Task", 123456
       #
       def find key_or_kind, id_or_name = nil
@@ -179,17 +158,11 @@ module Gcloud
       ##
       # Retrieve the entities for the provided keys.
       #
-      # === Parameters
+      # @param [Key] *keys One or more Key objects to find records for.
       #
-      # +keys+::
-      #   One or more Key objects to find records for. (+Key+)
+      # @return [Gcloud::Datastore::Dataset::LookupResults]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Dataset::LookupResults
-      #
-      # === Example
-      #
+      # @example
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
       #   key1 = dataset.key "Task", 123456
@@ -208,17 +181,12 @@ module Gcloud
       ##
       # Remove entities from the Datastore.
       #
-      # === Parameters
+      # @param [Entity, Key] *entities_or_keys One or more Entity or Key objects
+      #   to remove.
       #
-      # +entities_or_keys+::
-      #   One or more Entity or Key objects to remove. (+Entity+ or +Key+)
+      # @return [Boolean] Returns +true+ if successful
       #
-      # === Returns
-      #
-      # +true+ if successful
-      #
-      # === Example
-      #
+      # @example
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
       #   dataset.delete entity1, entity2
@@ -237,26 +205,17 @@ module Gcloud
       ##
       # Retrieve entities specified by a Query.
       #
-      # === Parameters
+      # @param [Query] query The Query object with the search criteria.
+      # @param [String] namespace The namespace the query is to run within.
       #
-      # +query+::
-      #   The Query object with the search criteria. (+Query+)
-      # +namespace+::
-      #   The namespace the query is to run within. (+String+)
+      # @return [Gcloud::Datastore::Dataset::QueryResults]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Dataset::QueryResults
-      #
-      # === Examples
-      #
+      # @example
       #   query = dataset.query("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query
       #
-      # The query can optionally run within namespace when the +namespace+
-      # option is provided:
-      #
+      # @example Run the query within a namespace with the +namespace+ option:
       #   query = Gcloud::Datastore::Query.new.kind("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query, namespace: "ns~todo-project"
@@ -274,10 +233,7 @@ module Gcloud
       ##
       # Creates a Datastore Transaction.
       #
-      # === Example
-      #
-      # Runs the given block in a database transaction:
-      #
+      # @example Runs the given block in a database transaction:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -294,8 +250,7 @@ module Gcloud
       #     end
       #   end
       #
-      # Alternatively, if no block is given a Transaction object is returned:
-      #
+      # @example If no block is given, a Transaction object is returned:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -333,23 +288,16 @@ module Gcloud
       # Create a new Query instance. This is a convenience method to make the
       # creation of Query objects easier.
       #
-      # === Parameters
+      # @param [String] *kinds The kind of entities to query. This is optional.
       #
-      # +kinds+::
-      #   The kind of entities to query. This is optional. (+String+)
+      # @return [Gcloud::Datastore::Query]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Query
-      #
-      # === Example
-      #
+      # @example
       #   query = dataset.query("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   query = Gcloud::Datastore::Query.new.
       #     kind("Task").
       #     where("completed", "=", true)
@@ -365,23 +313,16 @@ module Gcloud
       # Create a new Key instance. This is a convenience method to make the
       # creation of Key objects easier.
       #
-      # === Parameters
+      # @param [String] kind The kind of the Key. This is optional.
+      # @param [Integer, String] id_or_name The id or name of the Key. This is
+      #   optional.
       #
-      # +kind+::
-      #   The kind of the Key. This is optional. (+String+)
-      # +id_or_name+::
-      #   The id or name of the Key. This is optional. (+Integer+ or +String+)
+      # @return [Gcloud::Datastore::Key]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Key
-      #
-      # === Example
-      #
+      # @example
       #   key = dataset.key "User", "heidi@example.com"
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
       def key kind = nil, id_or_name = nil
@@ -392,50 +333,37 @@ module Gcloud
       # Create a new empty Entity instance. This is a convenience method to make
       # the creation of Entity objects easier.
       #
-      # === Parameters
+      # @param [Key, String, nil] key_or_kind A Key object or +kind+ string
+      #   value. This is optional.
+      # @param [Integer, String, nil] id_or_name The Key's +id+ or +name+ value
+      #   if a +kind+ was provided in the first parameter.
       #
-      # +key_or_kind+::
-      #   A Key object or +kind+ string value. This is optional. (+Key+ or
-      #   +String+ or +nil+)
-      # +id_or_name+::
-      #   The Key's +id+ or +name+ value if a +kind+ was provided in the first
-      #   parameter. (+Integer+ or +String+ or +nil+)
+      # @return [Gcloud::Datastore::Entity]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Entity
-      #
-      # === Examples
-      #
+      # @example
       #   entity = dataset.entity
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   entity = Gcloud::Datastore::Entity.new
       #
-      # The key can also be passed in as an object:
-      #
+      # @example The key can also be passed in as an object:
       #   key = dataset.key "User", "heidi@example.com"
       #   entity = dataset.entity key
       #
-      # Or the key values can be passed in as parameters:
-      #
+      # @example Or the key values can be passed in as parameters:
       #   entity = dataset.entity "User", "heidi@example.com"
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   entity = Gcloud::Datastore::Entity.new
       #   entity.key = key
       #
-      # The newly created entity object can also be configured using a block:
-      #
+      # @example The newly created entity can also be configured using a block:
       #   user = dataset.entity "User", "heidi@example.com" do |u|
       #     u["name"] = "Heidi Henderson"
       #  end
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   entity = Gcloud::Datastore::Entity.new
       #   entity.key = key
@@ -477,15 +405,15 @@ module Gcloud
       end
 
       ##
-      # Save a key to be given an ID when comitted.
-      def auto_id_register entity #:nodoc:
+      # @private Save a key to be given an ID when comitted.
+      def auto_id_register entity
         @_auto_id_entities ||= []
         @_auto_id_entities << entity
       end
 
       ##
-      # Update saved keys with new IDs post-commit.
-      def auto_id_assign_ids auto_ids #:nodoc:
+      # @private Update saved keys with new IDs post-commit.
+      def auto_id_assign_ids auto_ids
         @_auto_id_entities ||= []
         Array(auto_ids).each_with_index do |key, index|
           entity = @_auto_id_entities[index]
@@ -495,9 +423,9 @@ module Gcloud
       end
 
       ##
-      # Add entities to a Mutation, and register they key to be
+      # @private Add entities to a Mutation, and register they key to be
       # updated with an auto ID if needed.
-      def save_entities_to_mutation entities, mutation #:nodoc:
+      def save_entities_to_mutation entities, mutation
         entities.each do |entity|
           if entity.key.id.nil? && entity.key.name.nil?
             mutation.insert_auto_id << entity.to_proto

--- a/lib/gcloud/datastore/dataset/lookup_results.rb
+++ b/lib/gcloud/datastore/dataset/lookup_results.rb
@@ -24,14 +24,16 @@ module Gcloud
       # contains the entities as well as the Keys that were deferred from
       # the results and the Entities that were missing in the dataset.
       #
+      # Please be cautious when treating the QueryResults as an Array.
+      # Many common Array methods will return a new Array instance.
+      #
+      # @example
       #   entities = dataset.find_all key1, key2, key3
       #   entities.size #=> 3
       #   entities.deferred #=> []
       #   entities.missing #=> []
       #
-      # Please be cautious when treating the LookupResults as an Array. Many
-      # common Array methods will return a new Array instance.
-      #
+      # @example Caution, many Array methods will return a new Array instance:
       #   entities = dataset.find_all key1, key2, key3
       #   entities.size #=> 3
       #   entities.deferred #=> []

--- a/lib/gcloud/datastore/dataset/query_results.rb
+++ b/lib/gcloud/datastore/dataset/query_results.rb
@@ -24,13 +24,15 @@ module Gcloud
       # the Entities from the query as well as the query's cursor and
       # more_results value.
       #
+      # Please be cautious when treating the QueryResults as an Array.
+      # Many common Array methods will return a new Array instance.
+      #
+      # @example
       #   entities = dataset.run query
       #   entities.size #=> 3
       #   entities.cursor #=> "c3VwZXJhd2Vzb21lIQ"
       #
-      # Please be cautious when treating the QueryResults as an Array.
-      # Many common Array methods will return a new Array instance.
-      #
+      # @example Caution, many Array methods will return a new Array instance:
       #   entities = dataset.run query
       #   entities.size #=> 3
       #   entities.end_cursor #=> "c3VwZXJhd2Vzb21lIQ"

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -23,8 +23,9 @@ module Gcloud
     # = Entity
     #
     # Entity represents a Datastore record.
-    # Every Entity has a Key, and a list of properties.
+    # Every Entity has a {Key}, and a list of properties.
     #
+    # @example
     #   entity = Gcloud::Datastore::Entity.new
     #   entity.key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
     #   entity["name"] = "Heidi Henderson"
@@ -45,19 +46,11 @@ module Gcloud
       ##
       # Retrieve a property value by providing the name.
       #
-      # === Parameters
+      # @param [String, Symbol] prop_name The name of the property.
       #
-      # +prop_name+::
-      #   The name of the property. (+String+ or +Symbol+)
+      # @return [Object, nil] Returns +nil+ if the property doesn't exist
       #
-      # === Returns
-      #
-      # Object if the property exists, +nil+ if the property doesn't exist
-      #
-      # === Example
-      #
-      # Properties can be retrieved with a string name:
-      #
+      # @example Properties can be retrieved with a string name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -65,8 +58,7 @@ module Gcloud
       #   user = dataset.find "User", "heidi@example.com"
       #   user["name"] #=> "Heidi Henderson"
       #
-      # Or with a symbol name:
-      #
+      # @example Or with a symbol name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -81,17 +73,10 @@ module Gcloud
       ##
       # Set a property value by name.
       #
-      # === Parameters
+      # @param [String, Symbol] prop_name The name of the property.
+      # @param [Object] prop_value The value of the property.
       #
-      # +prop_name+::
-      #   The name of the property. (+String+ or +Symbol+)
-      # +prop_value+::
-      #   The value of the property. (+Object+)
-      #
-      # === Example
-      #
-      # Properties can be set with a string name:
-      #
+      # @example Properties can be set with a string name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -99,8 +84,7 @@ module Gcloud
       #   user = dataset.find "User", "heidi@example.com"
       #   user["name"] = "Heidi H. Henderson"
       #
-      # Or with a symbol name:
-      #
+      # @example Or with a symbol name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -116,12 +100,9 @@ module Gcloud
       # Retrieve properties in a hash-like structure.
       # Properties can be accessed or set by string or symbol.
       #
-      # === Returns
+      # @return [Gcloud::Datastore::Properties]
       #
-      # Gcloud::Datastore::Properties
-      #
-      # === Example
-      #
+      # @example
       #   entity.properties[:name] = "Heidi H. Henderson"
       #   entity.properties["name"] #=> "Heidi H. Henderson"
       #
@@ -129,19 +110,16 @@ module Gcloud
       #     puts "property #{name} has a value of #{value}"
       #   end
       #
-      # A property's existance can be determined by calling exist?
-      #
+      # @example A property's existence can be determined by calling +exist?+:
       #   entity.properties.exist? :name #=> true
       #   entity.properties.exist? "name" #=> true
       #   entity.properties.exist? :expiration #=> false
       #
-      # A property can be removed from the entity.
-      #
+      # @example A property can be removed from the entity:
       #   entity.properties.delete :name
       #   entity.save
       #
-      # The properties can be converted to a hash:
-      #
+      # @example The properties can be converted to a hash:
       #   prop_hash = entity.properties.to_h
       #
       attr_reader :properties
@@ -149,10 +127,10 @@ module Gcloud
       ##
       # Sets the Key that identifies the entity.
       #
-      # === Example
+      # Once the entity is saved, the key is frozen and immutable. Trying to set
+      # a key when immutable will raise a +RuntimeError+.
       #
-      # The Key can be set before the entity is saved.
-      #
+      # @example The Key can be set before the entity is saved:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -161,9 +139,7 @@ module Gcloud
       #   entity.key = Gcloud::Datastore::Key.new "User"
       #   dataset.save entity
       #
-      # Once the entity is saved, the key is frozen and immutable.
-      # Trying to set a key when immutable will raise a +RuntimeError+.
-      #
+      # @example Once the entity is saved, the key is frozen and immutable:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -182,8 +158,7 @@ module Gcloud
       ##
       # Indicates if the record is persisted. Default is false.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -203,15 +178,14 @@ module Gcloud
       # Indicates if a property is flagged to be excluded from the
       # Datastore indexes. The default value is false.
       #
-      # Single property values will return a single flag setting.
-      #
+      # @example Single property values will return a single flag setting:
       #   entity["age"] = 21
       #   entity.exclude_from_indexes? "age" #=> false
       #
-      # Array property values will return an array of flag settings.
-      #
+      # @example Array property values will return an array of flag settings:
       #   entity["tags"] = ["ruby", "code"]
       #   entity.exclude_from_indexes? "tags" #=> [false, false]
+      #
       def exclude_from_indexes? name
         value = self[name]
         flag = @_exclude_indexes[name.to_s]
@@ -255,9 +229,8 @@ module Gcloud
       end
 
       ##
-      # Convert the Entity to a protocol buffer object.
-      # This is not part of the public API.
-      def to_proto #:nodoc:
+      # @private Convert the Entity to a protocol buffer object.
+      def to_proto
         entity = Proto::Entity.new.tap do |e|
           e.key = @key.to_proto
           e.property = Proto.to_proto_properties @properties.to_h
@@ -267,9 +240,8 @@ module Gcloud
       end
 
       ##
-      # Create a new Entity from a protocol buffer object.
-      # This is not part of the public API.
-      def self.from_proto proto #:nodoc:
+      # @private Create a new Entity from a protocol buffer object.
+      def self.from_proto proto
         entity = Entity.new
         entity.key = Key.from_proto proto.key
         Array(proto.property).each do |p|
@@ -285,11 +257,11 @@ module Gcloud
       # Disabled rubocop because this is intentionally complex.
 
       ##
-      # Map the exclude flag object to value.
+      # @private Map the exclude flag object to value.
       # The flag object can be a boolean, Proc, or Array.
       # Procs will be called and passed in the value.
       # This will return an array of flags for an array value.
-      def map_exclude_flag_to_value flag, value #:nodoc:
+      def map_exclude_flag_to_value flag, value
         if value.is_a? Array
           if flag.is_a? Proc
             value.map { |v| !!flag.call(v) }
@@ -310,8 +282,8 @@ module Gcloud
       end
 
       ##
-      # Update the exclude data after a new object is created.
-      def update_exclude_indexes! entity #:nodoc:
+      # @private Update the exclude data after a new object is created.
+      def update_exclude_indexes! entity
         @_exclude_indexes = {}
         Array(entity.property).each do |property|
           @_exclude_indexes[property.name] = property.value.indexed
@@ -323,8 +295,8 @@ module Gcloud
       end
 
       ##
-      # Update the indexed values before the object is saved.
-      def update_properties_indexed! entity #:nodoc:
+      # @private Update the indexed values before the object is saved.
+      def update_properties_indexed! entity
         Array(entity.property).each do |property|
           excluded = exclude_from_indexes? property.name
           if excluded.is_a? Array

--- a/lib/gcloud/datastore/errors.rb
+++ b/lib/gcloud/datastore/errors.rb
@@ -44,7 +44,8 @@ module Gcloud
       # The response object of the failed HTTP request.
       attr_reader :response
 
-      def initialize method, response = nil #:nodoc:
+      # @private
+      def initialize method, response = nil
         super("API call to #{method} was not successful")
         @method = method
         @response = response
@@ -67,7 +68,8 @@ module Gcloud
       # An error that occurred within the transaction. (optional)
       attr_reader :inner
 
-      def initialize message, inner = nil #:nodoc:
+      # @private
+      def initialize message, inner = nil
         super(message)
         @inner = inner
       end

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -25,17 +25,16 @@ module Gcloud
     # name string, assigned explicitly by the application, or an integer numeric
     # ID, assigned automatically by Datastore.
     #
+    # @example
     #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
+    #
     class Key
       ##
       # The kind of the Key.
       #
-      # === Returns
+      # @return [String]
       #
-      # +String+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User"
       #   key.kind #=> "User"
       #   key.kind = "Task"
@@ -45,12 +44,9 @@ module Gcloud
       ##
       # The dataset_id of the Key.
       #
-      # === Returns
+      # @return [String]
       #
-      # +String+
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -65,12 +61,9 @@ module Gcloud
       ##
       # The namespace of the Key.
       #
-      # === Returns
+      # @return [String, nil]
       #
-      # +String+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -85,19 +78,13 @@ module Gcloud
       ##
       # Create a new Key instance.
       #
-      # === Parameters
+      # @param [String] kind The kind of the Key. This is optional.
+      # @param [Integer, String] id_or_name The id or name of the Key. This is
+      #   optional.
       #
-      # +kind+::
-      #   The kind of the Key. This is optional. (+String+)
-      # +id_or_name+::
-      #   The id or name of the Key. This is optional. (+Integer+ or +String+)
+      # @return [Gcloud::Datastore::Dataset::Key]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Dataset::Key
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
       def initialize kind = nil, id_or_name = nil
@@ -110,15 +97,12 @@ module Gcloud
       end
 
       ##
-      # Set the id of the Key.
+      # @private Set the id of the Key.
       # If a name is already present it will be removed.
       #
-      # === Returns
+      # @return [Integer, nil]
       #
-      # +Integer+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   key.id #=> nil
       #   key.name #=> "heidi@example.com"
@@ -126,7 +110,7 @@ module Gcloud
       #   key.id #=> 654321
       #   key.name #=> nil
       #
-      def id= new_id #:nodoc:
+      def id= new_id
         @name = nil if new_id
         @id = new_id
       end
@@ -134,27 +118,21 @@ module Gcloud
       ##
       # The id of the Key.
       #
-      # === Returns
+      # @return [Integer, nil]
       #
-      # +Integer+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", 123456
       #   key.id #=> 123456
       #
       attr_reader :id
 
       ##
-      # Set the name of the Key.
+      # @private Set the name of the Key.
       # If an id is already present it will be removed.
       #
-      # === Returns
+      # @return [String, nil]
       #
-      # +String+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", 123456
       #   key.id #=> 123456
       #   key.name #=> nil
@@ -162,7 +140,7 @@ module Gcloud
       #   key.id #=> nil
       #   key.name #=> "heidi@example.com"
       #
-      def name= new_name #:nodoc:
+      def name= new_name
         @id = nil if new_name
         @name = new_name
       end
@@ -170,30 +148,24 @@ module Gcloud
       ##
       # The name of the Key.
       #
-      # === Returns
+      # @return [String, nil]
       #
-      # +String+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   key.name #=> "heidi@example.com"
       #
       attr_reader :name
 
       ##
-      # Set the parent of the Key.
+      # @private Set the parent of the Key.
       #
-      # === Returns
+      # @return [Key, nil]
       #
-      # +Key+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "List", "todos"
       #   key.parent = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
-      def parent= new_parent #:nodoc:
+      def parent= new_parent
         # store key if given an entity
         new_parent = new_parent.key if new_parent.respond_to? :key
         @parent = new_parent
@@ -202,12 +174,9 @@ module Gcloud
       ##
       # The parent of the Key.
       #
-      # === Returns
+      # @return [Key, nil]
       #
-      # +Key+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -226,12 +195,9 @@ module Gcloud
       # Each inner array contains two values, the kind and the id or name.
       # If neither an id or name exist then nil will be returned.
       #
-      # === Returns
+      # @return [Array<Array<(String, String)>>]
       #
-      # Array of arrays
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "List", "todos"
       #   key.parent = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   key.path #=> [["User", "heidi@example.com"], ["List", "todos"]]
@@ -245,7 +211,7 @@ module Gcloud
       # Determine if the key is complete.
       # A complete key has either an id or a name.
       #
-      # Inverse of #incomplete?
+      # Inverse of {#incomplete?}
       def complete?
         !incomplete?
       end
@@ -254,15 +220,14 @@ module Gcloud
       # Determine if the key is incomplete.
       # An incomplete key has neither an id nor a name.
       #
-      # Inverse of #complete?
+      # Inverse of {#complete?}
       def incomplete?
         kind.nil? || (id.nil? && (name.nil? || name.empty?))
       end
 
       ##
-      # Convert the Key to a protocol buffer object.
-      # This is not part of the public API.
-      def to_proto #:nodoc:
+      # @private Convert the Key to a protocol buffer object.
+      def to_proto
         Proto::Key.new.tap do |k|
           k.path_element = path.map do |pe_kind, pe_id_or_name|
             Proto.new_path_element pe_kind, pe_id_or_name
@@ -274,9 +239,8 @@ module Gcloud
       # rubocop:disable all
 
       ##
-      # Create a new Key from a protocol buffer object.
-      # This is not part of the public API.
-      def self.from_proto proto #:nodoc:
+      # @private Create a new Key from a protocol buffer object.
+      def self.from_proto proto
         # Disable rules because the complexity here is neccessary.
         key_proto = proto.dup
         key = Key.new

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -20,7 +20,7 @@ module Gcloud
     #
     # Hash-like data structure for Datastore properties.
     #
-    # See Entity#properties
+    # See {Entity#properties}
     class Properties
       def initialize properties = {}
         @hash = {}

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -21,6 +21,8 @@ module Gcloud
     # rubocop:disable all
 
     ##
+    # @private
+    #
     # Proto is the namespace that contains all Protocol Buffer objects.
     #
     # The methods in this module are for convenience in using the
@@ -30,7 +32,7 @@ module Gcloud
     # this module's existance, may change in the future.
     #
     # You have been warned.
-    module Proto #:nodoc:
+    module Proto
       def self.from_proto_value proto_value
         if !proto_value.timestamp_microseconds_value.nil?
           microseconds = proto_value.timestamp_microseconds_value
@@ -111,7 +113,7 @@ module Gcloud
         Time.at(microseconds / 1000000, microseconds % 1000000).utc
       end
 
-      #:nodoc:
+      @private
       PROP_FILTER_OPS = {
         "<"   => PropertyFilter::Operator::LESS_THAN,
         "lt"  => PropertyFilter::Operator::LESS_THAN,
@@ -245,7 +247,8 @@ module Gcloud
         end
       end
 
-      class Key #:nodoc:
+      # @private
+      class Key
         def dup
           proto_request_body = ""
           self.encode proto_request_body

--- a/lib/gcloud/datastore/query.rb
+++ b/lib/gcloud/datastore/query.rb
@@ -24,16 +24,20 @@ module Gcloud
     #
     # Represents the search criteria against a Datastore.
     #
+    # @example
     #   query = Gcloud::Datastore::Query.new
     #   query.kind("Task").
     #     where("completed", "=", true)
     #
     #   entities = dataset.run query
+    #
     class Query
       ##
       # Returns a new query object.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
+      #
       def initialize
         @_query = Proto::Query.new
       end
@@ -41,10 +45,12 @@ module Gcloud
       ##
       # Add the kind of entities to query.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind "Task"
       #
       #   all_tasks = dataset.run query
+      #
       def kind *kinds
         @_query.kind ||= Proto::KindExpression.new
         @_query.kind.name ||= []
@@ -55,11 +61,13 @@ module Gcloud
       ##
       # Add a property filter to the query.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     where("completed", "=", true)
       #
       #   completed_tasks = dataset.run query
+      #
       def where name, operator, value
         # Initialize filter
         @_query.filter ||= Proto.new_filter.tap do |f|
@@ -78,11 +86,13 @@ module Gcloud
       ##
       # Add a filter for entities that inherit from a key.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     ancestor(parent.key)
       #
       #   completed_tasks = dataset.run query
+      #
       def ancestor parent
         # Use key if given an entity
         parent = parent.key if parent.respond_to? :key
@@ -95,11 +105,13 @@ module Gcloud
       # To sort in descending order, provide a second argument
       # of a string or symbol that starts with "d".
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     order("due", :desc)
       #
       #   sorted_tasks = dataset.run query
+      #
       def order name, direction = :asc
         @_query.order ||= []
         po = Proto::PropertyOrder.new
@@ -113,11 +125,13 @@ module Gcloud
       ##
       # Set a limit on the number of results to be returned.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     limit(10)
       #
       #   paginated_tasks = dataset.run query
+      #
       def limit num
         @_query.limit = num
         self
@@ -126,12 +140,14 @@ module Gcloud
       ##
       # Set an offset for the results to be returned.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     limit(10).
       #     offset(20)
       #
       #   paginated_tasks = dataset.run query
+      #
       def offset num
         @_query.offset = num
         self
@@ -140,12 +156,14 @@ module Gcloud
       ##
       # Set the cursor to start the results at.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     limit(10).
       #     cursor(task_cursor)
       #
       #   paginated_tasks = dataset.run query
+      #
       def start cursor
         @_query.start_cursor = Proto.decode_cursor cursor
         self
@@ -155,11 +173,13 @@ module Gcloud
       ##
       # Retrieve only select properties from the matched entities.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     select("completed", "due")
       #
       #   partial_tasks = dataset.run query
+      #
       def select *names
         @_query.projection ||= []
         @_query.projection += Proto.new_property_expressions(*names)
@@ -170,18 +190,21 @@ module Gcloud
       ##
       # Group results by a list of properties.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     group_by("completed")
       #
       #   grouped_tasks = dataset.run query
+      #
       def group_by *names
         @_query.group_by ||= []
         @_query.group_by += Proto.new_property_references(*names)
         self
       end
 
-      def to_proto #:nodoc:
+      # @private
+      def to_proto
         @_query
       end
     end

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -20,14 +20,14 @@ module Gcloud
     #
     # Special Connection instance for running transactions.
     #
-    # See Gcloud::Datastore::Dataset.transaction
+    # See {Gcloud::Datastore::Dataset.transaction}
     class Transaction < Dataset
       attr_reader :id
 
       ##
-      # Creates a new Transaction instance.
+      # @private Creates a new Transaction instance.
       # Takes a Connection instead of project and Credentials.
-      def initialize connection #:nodoc:
+      def initialize connection
         @connection = connection
         reset!
         start
@@ -36,11 +36,13 @@ module Gcloud
       ##
       # Persist entities in a transaction.
       #
+      # @example
       #   dataset.transaction do |tx|
       #     if tx.find(user.key).nil?
       #       tx.save task1, task2
       #     end
       #   end
+      #
       def save *entities
         save_entities_to_mutation entities, shared_mutation
         # Do not save or assign auto_ids yet
@@ -50,11 +52,13 @@ module Gcloud
       ##
       # Remove entities in a transaction.
       #
+      # @example
       #   dataset.transaction do |tx|
       #     if tx.find(user.key).nil?
       #       tx.delete task1, task2
       #     end
       #   end
+      #
       def delete *entities
         shared_mutation.tap do |m|
           m.delete = entities.map { |entity| entity.key.to_proto }
@@ -99,7 +103,7 @@ module Gcloud
 
       ##
       # Reset the transaction.
-      # Transaction#start must be called afterwards.
+      # {Transaction#start} must be called afterwards.
       def reset!
         @shared_mutation = nil
         @id = nil
@@ -109,9 +113,9 @@ module Gcloud
       protected
 
       ##
-      # Mutation to be shared across save, delete, and commit calls.
+      # @private Mutation to be shared across save, delete, and commit calls.
       # This enables updates to happen when commit is called.
-      def shared_mutation #:nodoc:
+      def shared_mutation
         @shared_mutation ||= Proto.new_mutation
       end
     end

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -113,11 +113,11 @@ module Gcloud
       # This indicates that more time is needed to process the message, or to
       # make the message available for redelivery.
       #
-      # @param [Integer] deadline The new ack deadline in seconds from the time
-      #   this request is sent to the Pub/Sub system. Must be >= 0. For example,
-      #   if the value is +10+, the new ack deadline will expire 10 seconds
-      #   after the call is made. Specifying +0+ may immediately make the
-      #   message available for another pull request.
+      # @param [Integer] new_deadline The new ack deadline in seconds from the
+      #   time this request is sent to the Pub/Sub system. Must be >= 0. For
+      #   example, if the value is +10+, the new ack deadline will expire 10
+      #   seconds after the call is made. Specifying +0+ may immediately make
+      #   the message available for another pull request.
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -342,7 +342,7 @@ module Gcloud
       # Acknowledging a message more than once will not result in an error.
       # This is only used for messages received via pull.
       #
-      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      # @param [ReceivedMessage, String] *messages One or more {ReceivedMessage}
       #   objects or ack_id values.
       #
       # @example
@@ -379,7 +379,7 @@ module Gcloud
       #   example, if the value is +10+, the new ack deadline will expire 10
       #   seconds after the call is made. Specifying +0+ may immediately make
       #   the message available for another pull request.
-      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      # @param [ReceivedMessage, String] *messages One or more {ReceivedMessage}
       #   objects or ack_id values.
       #
       # @example
@@ -500,7 +500,7 @@ module Gcloud
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies
       #
-      # @param [String, Array<String>] permissions The set of permissions to
+      # @param [String, Array<String>] *permissions The set of permissions to
       #   check access for. Permissions with wildcards (such as +*+ or
       #   +storage.*+) are not allowed.
       #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -403,7 +403,7 @@ module Gcloud
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies
       #
-      # @param [String, Array<String>] permissions The set of permissions to
+      # @param [String, Array<String>] *permissions The set of permissions to
       #   check access for. Permissions with wildcards (such as +*+ or
       #   +storage.*+) are not allowed.
       #


### PR DESCRIPTION
This PR converts Datastore code comments to YARD tags for the purpose of:

1. Building HTML-based API documentation.
2. Building [gcloud-common JSON-based documentation](https://github.com/GoogleCloudPlatform/gcloud-common/issues/33).

[closes #456]

It also includes a small fix for PR #479.