### PR TITLE
Convert Storage docs to YARD

### DIFF
--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -26,6 +26,7 @@ module Gcloud
     #
     # Represents a Storage bucket. Belongs to a Project and has many Files.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -36,16 +37,16 @@ module Gcloud
     #
     class Bucket
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Bucket object.
-      def initialize #:nodoc:
+      # @private Create an empty Bucket object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -83,19 +84,19 @@ module Gcloud
 
       ##
       # Returns the current CORS configuration for a static website served from
-      # the bucket. For more information, see {Cross-Origin Resource
-      # Sharing (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # the bucket.
+      #
       # The return value is a frozen (unmodifiable) array of hashes containing
       # the attributes specified for the Bucket resource field
       # {cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
       #
       # This method also accepts a block for updating the bucket's CORS rules.
-      # See Bucket::Cors for details.
+      # See {Bucket::Cors} for details.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
       #
-      # Retrieving the bucket's CORS rules.
-      #
+      # @example Retrieving the bucket's CORS rules.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -107,8 +108,7 @@ module Gcloud
       #               #     "responseHeader"=>["X-My-Custom-Header"],
       #               #     "maxAgeSeconds"=>3600}]
       #
-      # Updating the bucket's CORS rules inside a block.
-      #
+      # @example Updating the bucket's CORS rules inside a block.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -135,11 +135,14 @@ module Gcloud
 
       ##
       # Updates the CORS configuration for a static website served from the
-      # bucket. For more information, see {Cross-Origin Resource
-      # Sharing (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # bucket.
+      #
       # Accepts an array of hashes containing the attributes specified for the
       # {resource description of
       # cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
+      #
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
       def cors= new_cors
         patch_gapi! cors: new_cors
       end
@@ -150,29 +153,36 @@ module Gcloud
       # storage within this region. Defaults to US.
       # See the developer's guide for the authoritative list.
       #
-      # https://cloud.google.com/storage/docs/concepts-techniques
+      # @see https://cloud.google.com/storage/docs/concepts-techniques
       def location
         @gapi["location"]
       end
 
       ##
-      # The destination bucket name for the bucket's logs. For more information,
-      # see {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
+      # The destination bucket name for the bucket's logs.
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
       def logging_bucket
         @gapi["logging"]["logBucket"] if @gapi["logging"]
       end
 
       ##
-      # Updates the destination bucket for the bucket's logs. For more
-      # information, see {Access
-      # Logs}[https://cloud.google.com/storage/docs/access-logs]. (+String+)
+      # Updates the destination bucket for the bucket's logs.
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
+      # @param [String] logging_bucket The bucket to hold the logging output
+      #
       def logging_bucket= logging_bucket
         patch_gapi! logging_bucket: logging_bucket
       end
 
       ##
       # The logging object prefix for the bucket's logs. For more information,
-      # see {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
       def logging_prefix
         @gapi["logging"]["logObjectPrefix"] if @gapi["logging"]
       end
@@ -183,9 +193,10 @@ module Gcloud
       # must be a {valid object
       # name}[https://cloud.google.com/storage/docs/bucket-naming#objectnames].
       # By default, the object prefix is the name
-      # of the bucket for which the logs are enabled. For more information, see
-      # {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
-      # (+String+)
+      # of the bucket for which the logs are enabled.
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
       def logging_prefix= logging_prefix
         patch_gapi! logging_prefix: logging_prefix
       end
@@ -209,58 +220,67 @@ module Gcloud
       ##
       # Updates whether {Object
       # Versioning}[https://cloud.google.com/storage/docs/object-versioning] is
-      # enabled for the bucket. (+Boolean+)
+      # enabled for the bucket.
+      #
+      # @return [Boolean]
+      #
       def versioning= new_versioning
         patch_gapi! versioning: new_versioning
       end
 
       ##
       # The index page returned from a static website served from the bucket
-      # when a site visitor requests the top level directory. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
+      # when a site visitor requests the top level directory.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_main
         @gapi["website"]["mainPageSuffix"] if @gapi["website"]
       end
 
       ##
       # Updates the index page returned from a static website served from the
-      # bucket when a site visitor requests the top level directory. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
-      # (+String+)
+      # bucket when a site visitor requests the top level directory.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_main= website_main
         patch_gapi! website_main: website_main
       end
 
       ##
       # The page returned from a static website served from the bucket when a
-      # site visitor requests a resource that does not exist. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
+      # site visitor requests a resource that does not exist.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_404
         @gapi["website"]["notFoundPage"] if @gapi["website"]
       end
 
       ##
       # Updates the page returned from a static website served from the bucket
-      # when a site visitor requests a resource that does not exist. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
-      # (+String+)
+      # when a site visitor requests a resource that does not exist.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_404= website_404
         patch_gapi! website_404: website_404
       end
 
       ##
       # Updates the bucket with changes made in the given block in a single
-      # PATCH request. The following attributes may be set: #cors=,
-      # #logging_bucket=, #logging_prefix=, #versioning=, #website_main=, and
-      # #website_404=. In addition, the #cors configuration accessible in the
-      # block is completely mutable and will be included in the request.
+      # PATCH request. The following attributes may be set: {#cors=},
+      # {#logging_bucket=}, {#logging_prefix=}, {#versioning=},
+      # {#website_main=}, and {#website_404=}. In addition, the #cors
+      # configuration accessible in the block is completely mutable and will be
+      # included in the request. (See {Bucket::Cors})
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -274,9 +294,7 @@ module Gcloud
       #     b.cors[1]["responseHeader"] << "X-Another-Custom-Header"
       #   end
       #
-      # New CORS rules can also be added in a nested block. See Bucket::Cors for
-      # details.
-      #
+      # @example New CORS rules can also be added in a nested block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -302,18 +320,16 @@ module Gcloud
       # Permanently deletes the bucket.
       # The bucket must be empty before it can be deleted.
       #
-      # === Parameters
+      # The API call to delete the bucket may be retried under certain
+      # conditions. See {Gcloud::Backoff} to control this behavior, or
+      # specify the wanted behavior using the +retries+ option.
       #
-      # +retries+::
-      #   The number of times the API call should be retried.
-      #   Default is Gcloud::Backoff.retries. (+Integer+)
+      # @param [Integer] retries The number of times the API call should be
+      #   retried. Default is Gcloud::Backoff.retries.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the bucket was deleted.
       #
-      # +true+ if the bucket was deleted.
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -322,10 +338,7 @@ module Gcloud
       #   bucket = storage.bucket "my-bucket"
       #   bucket.delete
       #
-      # The API call to delete the bucket may be retried under certain
-      # conditions. See Gcloud::Backoff to control this behavior, or
-      # specify the wanted behavior in the call:
-      #
+      # @example Specify the number of retries to attempt:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -348,31 +361,22 @@ module Gcloud
       ##
       # Retrieves a list of files matching the criteria.
       #
-      # === Parameters
-      #
-      # +prefix+::
-      #   Filter results to files whose names begin with this prefix.
-      #   (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of items plus prefixes to return. As duplicate prefixes
-      #   are omitted, fewer total results may be returned than requested.
-      #   The default value of this parameter is 1,000 items. (+Integer+)
-      # +versions+::
-      #   If +true+, lists all versions of an object as distinct results.
-      #   The default is +false+. For more information, see
+      # @param [String] prefix Filter results to files whose names begin with
+      #   this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of items plus prefixes to return. As
+      #   duplicate prefixes are omitted, fewer total results may be returned
+      #   than requested. The default value of this parameter is 1,000 items.
+      # @param [Boolean] versions If +true+, lists all versions of an object as
+      #   distinct results. The default is +false+. For more information, see
       #   {Object Versioning
       #   }[https://cloud.google.com/storage/docs/object-versioning].
-      #   (+Boolean+)
       #
-      # === Returns
+      # @return [Array<Gcloud::Storage::File>] (See
+      #   {Gcloud::Storage::File::List})
       #
-      # Array of Gcloud::Storage::File (See Gcloud::Storage::File::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -384,9 +388,7 @@ module Gcloud
       #     puts file.name
       #   end
       #
-      # If you have a significant number of files, you may need to paginate
-      # through them: (See File::List#token)
-      #
+      # @example With pagination: (See {File::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -421,20 +423,13 @@ module Gcloud
       ##
       # Retrieves a file matching the path.
       #
-      # === Parameters
+      # @param [String] path Name (path) of the file.
+      # @param [Integer] generation When present, selects a specific revision of
+      #   this object. Default is the latest version.
       #
-      # +path+::
-      #   Name (path) of the file. (+String+)
-      # +generation+::
-      #   When present, selects a specific revision of this object.
-      #   Default is the latest version. (+Integer+)
+      # @return [Gcloud::Storage::File, nil] Returns nil if file does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Storage::File or nil if file does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -461,15 +456,16 @@ module Gcloud
       # Create a new File object by providing a path to a local file to upload
       # and the path to store it with in the bucket.
       #
-      # === Parameters
+      # A +chunk_size+ value can be provided in the options to be used
+      # in resumable uploads. This value is the number of bytes per
+      # chunk and must be divisible by 256KB. If it is not divisible
+      # by 256KB then it will be lowered to the nearest acceptable
+      # value.
       #
-      # +file+::
-      #   Path of the file on the filesystem to upload. (+String+)
-      # +path+::
-      #   Path to store the file in Google Cloud Storage. (+String+)
-      # +acl+::
-      #   A predefined set of access controls to apply to this file.
-      #   (+String+)
+      # @param [String] file Path of the file on the filesystem to upload.
+      # @param [String] path Path to store the file in Google Cloud Storage.
+      # @param [String] acl A predefined set of access controls to apply to this
+      #   file.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -484,50 +480,43 @@ module Gcloud
       #     and project team members get access according to their roles.
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
-      # +cache_control+::
-      #   The {Cache-Control}[https://tools.ietf.org/html/rfc7234#section-5.2]
-      #   response header to be returned when the file is downloaded. (+String+)
-      # +content_disposition+::
-      #   The {Content-Disposition}[https://tools.ietf.org/html/rfc6266]
-      #   response header to be returned when the file is downloaded. (+String+)
-      # +content_encoding+::
-      #   The {Content-Encoding
+      # @param [String] cache_control The
+      #   {Cache-Control}[https://tools.ietf.org/html/rfc7234#section-5.2]
+      #   response header to be returned when the file is downloaded.
+      # @param [String] content_disposition The
+      #   {Content-Disposition}[https://tools.ietf.org/html/rfc6266]
+      #   response header to be returned when the file is downloaded.
+      # @param [String] content_encoding The {Content-Encoding
       #   }[https://tools.ietf.org/html/rfc7231#section-3.1.2.2] response header
-      #   to be returned when the file is downloaded. (+String+)
-      # +content_language+::
-      #   The {Content-Language}[http://tools.ietf.org/html/bcp47] response
-      #   header to be returned when the file is downloaded. (+String+)
-      # +content_type+::
-      #   The {Content-Type}[https://tools.ietf.org/html/rfc2616#section-14.17]
-      #   response header to be returned when the file is downloaded. (+String+)
-      # +chunk_size+::
-      #   The number of bytes per chunk in a resumable upload. Must be divisible
-      #   by 256KB. If it is not divisible by 265KB then it will be lowered to
-      #   the nearest acceptable value. (+Integer+)
-      # +crc32c+::
-      #   The CRC32c checksum of the file data, as described in
-      #   {RFC 4960, Appendix B}[http://tools.ietf.org/html/rfc4960#appendix-B].
+      #   to be returned when the file is downloaded.
+      # @param [String] content_language The
+      #   {Content-Language}[http://tools.ietf.org/html/bcp47] response
+      #   header to be returned when the file is downloaded.
+      # @param [String] content_type The
+      #   {Content-Type}[https://tools.ietf.org/html/rfc2616#section-14.17]
+      #   response header to be returned when the file is downloaded.
+      # @param [Integer] chunk_size The number of bytes per chunk in a resumable
+      #   upload. Must be divisible by 256KB. If it is not divisible by 265KB
+      #   then it will be lowered to the nearest acceptable value.
+      # @param [String] crc32c The CRC32c checksum of the file data, as
+      #   described in {RFC 4960, Appendix
+      #   B}[http://tools.ietf.org/html/rfc4960#appendix-B].
       #   If provided, Cloud Storage will only create the file if the value
       #   matches the value calculated by the service. See
       #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags]
-      #   for more information. (+String+)
-      # +md5+::
-      #   The MD5 hash of the file data. If provided, Cloud Storage will only
-      #   create the file if the value matches the value calculated by the
-      #   service. See
-      #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags]
-      #   for more information. (+String+)
-      # +metadata+::
-      #   A hash of custom, user-provided web-safe keys and arbitrary string
-      #   values that will returned with requests for the file as "x-goog-meta-"
-      #   response headers. (+Hash+)
+      #   for more information.
+      # @param [String] md5 The MD5 hash of the file data. If provided, Cloud
+      #   Storage will only create the file if the value matches the value
+      #   calculated by the service. See
+      #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags] for
+      #   more information.
+      # @param [Hash] metadata A hash of custom, user-provided web-safe keys and
+      #   arbitrary string values that will returned with requests for the file
+      #   as "x-goog-meta-" response headers.
       #
-      # === Returns
+      # @return [Gcloud::Storage::File]
       #
-      # Gcloud::Storage::File
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -537,8 +526,7 @@ module Gcloud
       #
       #   bucket.create_file "path/to/local.file.ext"
       #
-      # Additionally, a destination path can be specified.
-      #
+      # @example Additionally, a destination path can be specified.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -549,12 +537,7 @@ module Gcloud
       #   bucket.create_file "path/to/local.file.ext",
       #                      "destination/path/file.ext"
       #
-      # A +chunk_size+ value can be provided in the options to be used
-      # in resumable uploads. This value is the number of bytes per
-      # chunk and must be divisible by 256KB. If it is not divisible
-      # by 265KB then it will be lowered to the nearest acceptable
-      # value.
-      #
+      # @example Specify the chunk size as a number of bytes:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -627,16 +610,12 @@ module Gcloud
       #
       # A bucket has owners, writers, and readers. Permissions can be granted to
       # an individual user's email address, a group's email address, as well as
-      # many predefined lists. See the
-      # {Access Control guide
-      # }[https://cloud.google.com/storage/docs/access-control]
-      # for more.
+      # many predefined lists.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/access-control Access Control
+      #   guide
       #
-      # Access to a bucket can be granted to a user by appending +"user-"+ to
-      # the email address:
-      #
+      # @example Grant access to a user by pre-pending +"user-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -647,9 +626,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   bucket.acl.add_reader "user-#{email}"
       #
-      # Access to a bucket can be granted to a group by appending +"group-"+ to
-      # the email address:
-      #
+      # @example Grant access to a group by pre-pending +"group-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -660,9 +637,7 @@ module Gcloud
       #   email = "authors@example.net"
       #   bucket.acl.add_reader "group-#{email}"
       #
-      # Access to a bucket can also be granted to a predefined list of
-      # permissions:
-      #
+      # @example Or, grant access via a predefined permissions list:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -682,16 +657,12 @@ module Gcloud
       #
       # A bucket's files have owners, writers, and readers. Permissions can be
       # granted to an individual user's email address, a group's email address,
-      # as well as many predefined lists. See the
-      # {Access Control guide
-      # }[https://cloud.google.com/storage/docs/access-control]
-      # for more.
+      # as well as many predefined lists.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/access-control Access Control
+      #   guide
       #
-      # Access to a bucket's files can be granted to a user by appending
-      # +"user-"+ to the email address:
-      #
+      # @example Grant access to a user by pre-pending +"user-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -702,9 +673,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   bucket.default_acl.add_reader "user-#{email}"
       #
-      # Access to a bucket's files can be granted to a group by appending
-      # +"group-"+ to the email address:
-      #
+      # @example Grant access to a group by pre-pending +"group-"+ to an email
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -715,9 +684,7 @@ module Gcloud
       #   email = "authors@example.net"
       #   bucket.default_acl.add_reader "group-#{email}"
       #
-      # Access to a bucket's files can also be granted to a predefined list of
-      # permissions:
-      #
+      # @example Or, grant access via a predefined permissions list:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -726,6 +693,7 @@ module Gcloud
       #   bucket = storage.bucket "my-todo-app"
       #
       #   bucket.default_acl.public!
+      #
       def default_acl
         @default_acl ||= Bucket::DefaultAcl.new self
       end
@@ -744,8 +712,8 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # New Bucket from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Bucket from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -778,8 +746,8 @@ module Gcloud
       end
 
       ##
-      # Determines if a resumable upload should be used.
-      def resumable_upload? file #:nodoc:
+      # @private Determines if a resumable upload should be used.
+      def resumable_upload? file
         ::File.size?(file).to_i > Upload.resumable_threshold
       end
 

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -21,6 +21,7 @@ module Gcloud
       #
       # Represents a Bucket's Access Control List.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -31,6 +32,7 @@ module Gcloud
       #   bucket.acl.readers.each { |reader| puts reader }
       #
       class Acl
+        # @private
         RULES = { "authenticatedRead" => "authenticatedRead",
                   "auth" => "authenticatedRead",
                   "auth_read" => "authenticatedRead",
@@ -44,12 +46,12 @@ module Gcloud
                   "public" => "publicRead",
                   "public_read" => "publicRead",
                   "publicReadWrite" => "publicReadWrite",
-                  "public_write" => "publicReadWrite" } #:nodoc:
+                  "public_write" => "publicReadWrite" }
 
         ##
-        # Initialized a new Acl object.
+        # @private Initialized a new Acl object.
         # Must provide a valid Bucket object.
-        def initialize bucket #:nodoc:
+        def initialize bucket
           @bucket = bucket.name
           @connection = bucket.connection
           @owners  = nil
@@ -60,8 +62,7 @@ module Gcloud
         ##
         # Reloads all Access Control List data for the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -83,12 +84,9 @@ module Gcloud
         ##
         # Lists the owners of the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -106,12 +104,9 @@ module Gcloud
         ##
         # Lists the owners of the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -129,12 +124,9 @@ module Gcloud
         ##
         # Lists the readers of the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -152,11 +144,8 @@ module Gcloud
         ##
         # Grants owner permission to the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -167,11 +156,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -182,9 +167,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_owner "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -208,11 +191,8 @@ module Gcloud
         ##
         # Grants writer permission to the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -223,11 +203,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -238,9 +214,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_writer "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -264,11 +238,8 @@ module Gcloud
         ##
         # Grants reader permission to the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -279,11 +250,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -294,9 +261,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_reader "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -320,11 +285,8 @@ module Gcloud
         ##
         # Permanently deletes the entity from the bucket's access control list.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -335,8 +297,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -358,7 +319,8 @@ module Gcloud
           false
         end
 
-        def self.predefined_rule_for rule_name #:nodoc:
+        # @private
+        def self.predefined_rule_for rule_name
           RULES[rule_name.to_s]
         end
 
@@ -368,8 +330,7 @@ module Gcloud
         # Convenience method to apply the +authenticatedRead+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -391,8 +352,7 @@ module Gcloud
         # Convenience method to apply the +private+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -410,8 +370,7 @@ module Gcloud
         # Convenience method to apply the +projectPrivate+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -430,8 +389,7 @@ module Gcloud
         # Convenience method to apply the +publicRead+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -450,8 +408,7 @@ module Gcloud
         # Convenience method to apply the +publicReadWrite+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -506,6 +463,7 @@ module Gcloud
       #   bucket.default_acl.readers.each { |reader| puts reader }
       #
       class DefaultAcl
+        # @private
         RULES = { "authenticatedRead" => "authenticatedRead",
                   "auth" => "authenticatedRead",
                   "auth_read" => "authenticatedRead",
@@ -520,12 +478,12 @@ module Gcloud
                   "project_private" => "projectPrivate",
                   "publicRead" => "publicRead",
                   "public" => "publicRead",
-                  "public_read" => "publicRead" } #:nodoc:
+                  "public_read" => "publicRead" }
 
         ##
-        # Initialized a new DefaultAcl object.
+        # @private Initialized a new DefaultAcl object.
         # Must provide a valid Bucket object.
-        def initialize bucket #:nodoc:
+        def initialize bucket
           @bucket = bucket.name
           @connection = bucket.connection
           @owners  = nil
@@ -536,8 +494,7 @@ module Gcloud
         ##
         # Reloads all Default Access Control List data for the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -559,12 +516,9 @@ module Gcloud
         ##
         # Lists the default owners for files in the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -582,12 +536,9 @@ module Gcloud
         ##
         # Lists the default writers for files in the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -605,12 +556,9 @@ module Gcloud
         ##
         # Lists the default readers for files in the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -628,11 +576,8 @@ module Gcloud
         ##
         # Grants default owner permission to files in the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -643,11 +588,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -658,9 +599,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_owner "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -684,11 +623,8 @@ module Gcloud
         ##
         # Grants default writer permission to files in the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -699,11 +635,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -714,9 +646,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_writer "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -740,11 +670,8 @@ module Gcloud
         ##
         # Grants default reader permission to files in the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -755,11 +682,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -770,9 +693,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_reader "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -797,11 +718,8 @@ module Gcloud
         # Permanently deletes the entity from the bucket's default access
         # control list for files.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -812,8 +730,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -835,7 +752,8 @@ module Gcloud
           false
         end
 
-        def self.predefined_rule_for rule_name #:nodoc:
+        # @private
+        def self.predefined_rule_for rule_name
           RULES[rule_name.to_s]
         end
 
@@ -845,8 +763,7 @@ module Gcloud
         # Convenience method to apply the default +authenticatedRead+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -868,8 +785,7 @@ module Gcloud
         # Convenience method to apply the default +bucketOwnerFullControl+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -888,8 +804,7 @@ module Gcloud
         # Convenience method to apply the default +bucketOwnerRead+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -908,8 +823,7 @@ module Gcloud
         # Convenience method to apply the default +private+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -927,8 +841,7 @@ module Gcloud
         # Convenience method to apply the default +projectPrivate+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -947,8 +860,7 @@ module Gcloud
         # Convenience method to apply the default +publicRead+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -22,12 +22,13 @@ module Gcloud
       # = Bucket Cors
       #
       # A special-case Array for managing the website CORS rules for a bucket.
-      # Accessed via a block argument to Project#create_bucket, Bucket#cors, or
-      # Bucket#update.
+      # Accessed via a block argument to {Project#create_bucket}, {Bucket#cors},
+      # or {Bucket#update}.
       #
-      # For more information about CORS, see {Cross-Origin Resource
-      # Sharing (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -47,13 +48,15 @@ module Gcloud
       #
       class Cors < DelegateClass(::Array)
         ##
+        # @private
         # Initialize a new CORS rules builder with existing CORS rules, if any.
-        def initialize cors = [] #:nodoc:
+        def initialize cors = []
           super cors.dup
           @original = cors.dup
         end
 
-        def changed? #:nodoc:
+        # @private
+        def changed?
           @original != self
         end
 
@@ -64,30 +67,24 @@ module Gcloud
         # methods}[http://www.w3.org/TR/cors/#simple-method] and {simple
         # headers}[http://www.w3.org/TR/cors/#simple-header].
         #
-        # === Parameters
+        # @param [String, Array<String>] origin The
+        #   {origin}[http://tools.ietf.org/html/rfc6454] or origins permitted
+        #   for cross origin resource sharing with the bucket. Note: "*" is
+        #   permitted in the list of origins, and means "any Origin".
+        # @param [String, Array<String>] methods The list of HTTP methods
+        #   permitted in cross origin resource sharing with the bucket. (GET,
+        #   OPTIONS, POST, etc) Note: "*" is permitted in the list of methods,
+        #   and means "any method".
+        # @param [String, Array<String>] headers The list of header field names
+        #   to send in the Access-Control-Allow-Headers header in the preflight
+        #   response. Indicates the custom request headers that may be used in
+        #   the actual request.
+        # @param [Integer] max_age The value to send in the
+        #   Access-Control-Max-Age header in the preflight response. Indicates
+        #   how many seconds the results of a preflight request can be cached in
+        #   a preflight result cache. The default value is +1800+ (30 minutes.)
         #
-        # +origin+::
-        #   The {origin}[http://tools.ietf.org/html/rfc6454] or origins
-        #   permitted for cross origin resource sharing with the bucket. Note:
-        #   "*" is permitted in the list of origins, and means "any Origin".
-        #   (+String+ or +Array+)
-        # +methods+::
-        #   The list of HTTP methods permitted in cross origin resource sharing
-        #   with the bucket. (GET, OPTIONS, POST, etc) Note: "*" is permitted in
-        #   the list of methods, and means "any method". (+String+ or +Array+)
-        # +headers+::
-        #   The list of header field names to send in the
-        #   Access-Control-Allow-Headers header in the preflight response.
-        #   Indicates the custom request headers that may be used in the actual
-        #   request. (+String+ or +Array+)
-        # +max_age+::
-        #   The value to send in the Access-Control-Max-Age header in the
-        #   preflight response. Indicates how many seconds the results of a
-        #   preflight request can be cached in a preflight result cache. The
-        #   default value is +1800+ (30 minutes.) (+Integer+)
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/bucket/list.rb
+++ b/lib/gcloud/storage/bucket/list.rb
@@ -35,8 +35,8 @@ module Gcloud
         end
 
         ##
-        # New Bucket::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Bucket::List from a response object.
+        def self.from_response resp, conn
           buckets = Array(resp.data["items"]).map do |gapi_object|
             Bucket.from_gapi gapi_object, conn
           end

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -22,13 +22,15 @@ require "mime/types"
 module Gcloud
   module Storage
     ##
-    # Represents the connection to Storage,
+    # @private Represents the connection to Storage,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
+
+      # @private
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
@@ -301,7 +303,8 @@ module Gcloud
         MIME::Types.of(path).first.to_s
       end
 
-      def inspect #:nodoc:
+      # @private
+      def inspect
         "#{self.class}(#{@project})"
       end
 
@@ -352,7 +355,8 @@ module Gcloud
         }.delete_if { |_, v| v.nil? } if website_main || website_404
       end
 
-      def storage_class str #:nodoc:
+      # @private
+      def storage_class str
         { "durable_reduced_availability" => "DURABLE_REDUCED_AVAILABILITY",
           "dra" => "DURABLE_REDUCED_AVAILABILITY",
           "durable" => "DURABLE_REDUCED_AVAILABILITY",

--- a/lib/gcloud/storage/credentials.rb
+++ b/lib/gcloud/storage/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Storage
     ##
-    # Represents the OAuth 2.0 signing logic for Storage.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the OAuth 2.0 signing logic for Storage.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/devstorage.full_control"]
       PATH_ENV_VARS = %w(STORAGE_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(STORAGE_KEYFILE_JSON GCLOUD_KEYFILE_JSON

--- a/lib/gcloud/storage/errors.rb
+++ b/lib/gcloud/storage/errors.rb
@@ -43,7 +43,8 @@ module Gcloud
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         new resp.data["error"]["message"],
             resp.data["error"]["code"],
             resp.data["error"]["errors"]
@@ -68,7 +69,8 @@ module Gcloud
       # The value of the digest on the downloaded file.
       attr_accessor :local_digest
 
-      def self.for_md5 gcloud_digest, local_digest #:nodoc:
+      # @private
+      def self.for_md5 gcloud_digest, local_digest
         new("The downloaded file failed MD5 verification.").tap do |e|
           e.type = :md5
           e.gcloud_digest = gcloud_digest
@@ -76,7 +78,8 @@ module Gcloud
         end
       end
 
-      def self.for_crc32c gcloud_digest, local_digest #:nodoc:
+      # @private
+      def self.for_crc32c gcloud_digest, local_digest
         new("The downloaded file failed CRC32c verification.").tap do |e|
           e.type = :crc32c
           e.gcloud_digest = gcloud_digest

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -24,15 +24,18 @@ module Gcloud
     #
     # Represents a File
     # ({Object}[https://cloud.google.com/storage/docs/json_api/v1/objects]) that
-    # belongs to a Bucket. Files (Objects) are
+    # belongs to a {Bucket}. Files (Objects) are
     # the individual pieces of data that you store in Google Cloud Storage. A
     # file can be up to 5 TB in size. Files have two components:
     # data and metadata. The data component is the data from an external file or
     # other data source that you want to store in Google Cloud Storage. The
     # metadata component is a collection of name-value pairs that describe
-    # various qualities of the data. For more information, see {Concepts and
-    # Techniques}[https://cloud.google.com/storage/docs/concepts-techniques].
+    # various qualities of the data.
     #
+    # @see https://cloud.google.com/storage/docs/concepts-techniques Concepts
+    #   and Techniques
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -45,16 +48,16 @@ module Gcloud
     #
     class File
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty File object.
-      def initialize #:nodoc:
+      # @private Create an empty File object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -79,7 +82,7 @@ module Gcloud
       end
 
       ##
-      # The name of the bucket containing this file.
+      # The name of the {Bucket} containing this file.
       def bucket
         @gapi["bucket"]
       end
@@ -244,13 +247,12 @@ module Gcloud
 
       ##
       # Updates the file with changes made in the given block in a single
-      # PATCH request. The following attributes may be set: #cache_control=,
-      # #content_disposition=, #content_encoding=, #content_language=,
-      # #content_type=, and #metadata=. The #metadata hash accessible in the
-      # block is completely mutable and will be included in the request.
+      # PATCH request. The following attributes may be set: {#cache_control=},
+      # {#content_disposition=}, {#content_encoding=}, {#content_language=},
+      # {#content_type=}, and {#metadata=}. The {#metadata} hash accessible in
+      # the block is completely mutable and will be included in the request.
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -279,14 +281,12 @@ module Gcloud
       ##
       # Download the file's contents to a local file.
       #
-      # === Parameters
+      # By default, the download is verified by calculating the MD5 digest.
       #
-      # +path+::
-      #   The path on the local file system to write the data to.
-      #   The path provided must be writable. (+String+)
-      # +verify+::
-      #   The verification algoruthm used to ensure the downloaded file contents
-      #   are correct. Default is +:md5+. (+Symbol+)
+      # @param [String] path The path on the local file system to write the data
+      #   to. The path provided must be writable.
+      # @param [Symbol] verify The verification algoruthm used to ensure the
+      #   downloaded file contents are correct. Default is +:md5+.
       #
       #   Acceptable values are:
       #   * +md5+ - Verify file content match using the MD5 hash.
@@ -294,12 +294,9 @@ module Gcloud
       #   * +all+ - Perform all available file content verification.
       #   * +none+ - Don't perform file content verification.
       #
-      # === Returns
+      # @return [File] Returns a +::File+ object on the local file system
       #
-      # +::File+ object on the local file system
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -310,9 +307,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext"
       #
-      # The download is verified by calculating the MD5 digest.
-      # The CRC32c digest can be used by passing :crc32c.
-      #
+      # @example Use the CRC32c digest by passing :crc32c.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -323,8 +318,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :crc32c
       #
-      # Both the MD5 and CRC32c digest can be used by passing :all.
-      #
+      # @example Use the MD5 and CRC32c digests by passing :all.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -335,8 +329,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :all
       #
-      # The download verification can be disabled by passing :none
-      #
+      # @example Disable the download verification by passing :none.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -363,17 +356,13 @@ module Gcloud
       ##
       # Copy the file to a new location.
       #
-      # === Parameters
-      #
-      # +dest_bucket_or_path+::
-      #   Either the bucket to copy the file to, or the path to copy the file to
-      #   in the current bucket. (+String+)
-      # +dest_path+::
-      #   If a bucket was provided in the first parameter, this contains the
-      #   path to copy the file to in the given bucket. (+String+)
-      # +acl+::
-      #   A predefined set of access controls to apply to new file.
-      #   (+String+)
+      # @param [String] dest_bucket_or_path Either the bucket to copy the file
+      #   to, or the path to copy the file to in the current bucket.
+      # @param [String] dest_path If a bucket was provided in the first
+      #   parameter, this contains the path to copy the file to in the given
+      #   bucket.
+      # @param [String] acl A predefined set of access controls to apply to new
+      #   file.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -388,18 +377,12 @@ module Gcloud
       #     and project team members get access according to their roles.
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
-      # +generation+::
-      #   Select a specific revision of the file to copy. The default is the
-      #   latest version. (+Integer+)
+      # @param [Integer] generation Select a specific revision of the file to
+      #   copy. The default is the latest version.
       #
-      # === Returns
+      # @return [Gcloud::Storage::File]
       #
-      # +File+ object
-      #
-      # === Examples
-      #
-      # The file can also be copied to a new path in the current bucket:
-      #
+      # @example The file can be copied to a new path in the current bucket:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -410,8 +393,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.copy "path/to/destination/file.ext"
       #
-      # The file can also be copied to a different bucket:
-      #
+      # @example The file can also be copied to a different bucket:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -423,8 +405,7 @@ module Gcloud
       #   file.copy "new-destination-bucket",
       #             "path/to/destination/file.ext"
       #
-      # The file can also be copied by specifying a generation:
-      #
+      # @example The file can also be copied by specifying a generation:
       #   file.copy "copy/of/previous/generation/file.ext",
       #             generation: 123456
       #
@@ -446,12 +427,9 @@ module Gcloud
       ##
       # Permanently deletes the file.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the file was deleted.
       #
-      # +true+ if the file was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -474,19 +452,17 @@ module Gcloud
 
       ##
       # Public URL to access the file. If the file is not public, requests to
-      # the URL will return an error. (See File::Acl#public! and
-      # Bucket::DefaultAcl#public!) For more information, read [Accessing Public
-      # Data]{https://cloud.google.com/storage/docs/access-public-data}.
+      # the URL will return an error. (See {File::Acl#public!} and
+      # {Bucket::DefaultAcl#public!}) To share a file that is not public see
+      # {#signed_url}.
       #
-      # To share a file that is not public see #signed_url.
+      # @see https://cloud.google.com/storage/docs/access-public-data Accessing
+      #   Public Data
       #
-      # === Parameters
+      # @param [String] protocol The protocol to use for the URL. Default is
+      #   +HTTPS+.
       #
-      # +protocol+::
-      #   The protocol to use for the URL. Default is +HTTPS+. (+String+)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -496,9 +472,7 @@ module Gcloud
       #   file = bucket.file "avatars/heidi/400x400.png"
       #   public_url = file.public_url
       #
-      # To generate the URL with a protocol other than HTTPS, use the +protocol+
-      # option:
-      #
+      # @example Generate the URL with a protocol other than HTTPS:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -516,46 +490,41 @@ module Gcloud
       ##
       # Access without authentication can be granted to a File for a specified
       # period of time. This URL uses a cryptographic signature
-      # of your credentials to access the file. See the
-      # {Access Control Signed URLs guide
-      # }[https://cloud.google.com/storage/docs/access-control#Signed-URLs]
-      # for more.
+      # of your credentials to access the file.
       #
       # Generating a URL requires service account credentials, either by
-      # connecting with a service account when calling Gcloud.storage, or by
-      # passing in the service account +issuer+ and +signing_key+ values. A
-      # SignedUrlUnavailable is raised if the service account credentials are
+      # connecting with a service account when calling {Gcloud.storage}, or by
+      # passing in the service account +issuer+ and +signing_key+ values.
+      # Although the private key can be passed as a string for convenience,
+      # creating and storing an instance of +OpenSSL::PKey::RSA+ is more
+      # efficient when making multiple calls to +signed_url+.
+      #
+      # A SignedUrlUnavailable is raised if the service account credentials are
       # missing. Service account credentials are acquired by following the steps
       # in {Service Account Authentication}[
       # https://cloud.google.com/storage/docs/authentication#service_accounts].
       #
-      # === Parameters
+      # @see https://cloud.google.com/storage/docs/access-control#Signed-URLs
+      #   Access Control Signed URLs guide
       #
-      # +method+::
-      #   The HTTP verb to be used with the signed URL. Signed URLs can be used
+      # @param [String] method The HTTP verb to be used with the signed URL.
+      #   Signed URLs can be used
       #   with +GET+, +HEAD+, +PUT+, and +DELETE+ requests. Default is +GET+.
-      #   (+String+)
-      # +expires+::
-      #   The number of seconds until the URL expires. Default is 300/5 minutes.
-      #   (+Integer+)
-      # +content_type+::
-      #   When provided, the client (browser) must send this value in the
-      #   HTTP header. e.g. +text/plain+ (+String+)
-      # +content_md5+::
-      #   The MD5 digest value in base64. If you provide this in the string, the
-      #   client (usually a browser) must provide this HTTP header with this
-      #   same value in its request. (+String+)
-      # +issuer+::
-      #   Service Account's Client Email. (+String+)
-      # +client_email+::
-      #   Service Account's Client Email. (+String+)
-      # +signing_key+::
-      #   Service Account's Private Key. (+OpenSSL::PKey::RSA+ or +String+)
-      # +private_key+::
-      #   Service Account's Private Key. (+OpenSSL::PKey::RSA+ or +String+)
+      # @param [Integer] expires The number of seconds until the URL expires.
+      #   Default is 300/5 minutes.
+      # @param [String] content_type When provided, the client (browser) must
+      #   send this value in the HTTP header. e.g. +text/plain+
+      # @param [String] content_md5 The MD5 digest value in base64. If you
+      #   provide this in the string, the client (usually a browser) must
+      #   provide this HTTP header with this same value in its request.
+      # @param [String] issuer Service Account's Client Email.
+      # @param [String] client_email Service Account's Client Email.
+      # @param [OpenSSL::PKey::RSA, String] signing_key Service Account's
+      #   Private Key.
+      # @param [OpenSSL::PKey::RSA, String] private_key Service Account's
+      #   Private Key.
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -565,8 +534,7 @@ module Gcloud
       #   file = bucket.file "avatars/heidi/400x400.png"
       #   shared_url = file.signed_url
       #
-      # Any of the option parameters may be specified:
-      #
+      # @example Any of the option parameters may be specified:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -577,13 +545,7 @@ module Gcloud
       #   shared_url = file.signed_url method: "GET",
       #                                expires: 300 # 5 minutes from now
       #
-      # Signed URLs require service account credentials. If you are not
-      # authenticated with a service account, those credentials can be passed in
-      # using the +issuer+ and +signing_key+ options. Although the private key
-      # can be passed as a string for convenience, creating and storing an
-      # instance of +OpenSSL::PKey::RSA+ is more efficient when making multiple
-      # calls to +signed_url+.
-      #
+      # @example Using the +issuer+ and +signing_key+ options:
       #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
@@ -607,20 +569,16 @@ module Gcloud
       end
 
       ##
-      # The File::Acl instance used to control access to the file.
+      # The {File::Acl} instance used to control access to the file.
       #
       # A file has owners, writers, and readers. Permissions can be granted to
       # an individual user's email address, a group's email address,  as well as
-      # many predefined lists. See the
-      # {Access Control guide
-      # }[https://cloud.google.com/storage/docs/access-control]
-      # for more.
+      # many predefined lists.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/access-control Access Control
+      #   guide
       #
-      # Access to a file can be granted to a user by appending +"user-"+ to the
-      # email address:
-      #
+      # @example Grant access to a user by pre-pending +"user-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -632,9 +590,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   file.acl.add_reader "user-#{email}"
       #
-      # Access to a file can be granted to a group by appending +"group-"+ to
-      # the email address:
-      #
+      # @example Grant access to a group by pre-pending +"group-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -646,9 +602,7 @@ module Gcloud
       #   email = "authors@example.net"
       #   file.acl.add_reader "group-#{email}"
       #
-      # Access to a file can also be granted to a predefined list of
-      # permissions:
-      #
+      # @example Or, grant access via a predefined permissions list:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -677,15 +631,15 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # URI of the location and file name in the format of
+      # @private URI of the location and file name in the format of
       # <code>gs://my-bucket/file-name.json</code>.
-      def to_gs_url #:nodoc:
+      def to_gs_url
         "gs://#{bucket}/#{name}"
       end
 
       ##
-      # New File from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New File from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -733,8 +687,8 @@ module Gcloud
       end
 
       ##
-      # Create a signed_url for a file.
-      class Signer #:nodoc:
+      # @private Create a signed_url for a file.
+      class Signer
         def initialize file
           @file = file
         end

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -21,6 +21,7 @@ module Gcloud
       #
       # Represents a File's Access Control List.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -32,6 +33,7 @@ module Gcloud
       #   file.acl.readers.each { |reader| puts reader }
       #
       class Acl
+        # @private
         RULES = { "authenticatedRead" => "authenticatedRead",
                   "auth" => "authenticatedRead",
                   "auth_read" => "authenticatedRead",
@@ -46,12 +48,12 @@ module Gcloud
                   "project_private" => "projectPrivate",
                   "publicRead" => "publicRead",
                   "public" => "publicRead",
-                  "public_read" => "publicRead" } #:nodoc:
+                  "public_read" => "publicRead" }
 
         ##
-        # Initialized a new Acl object.
+        # @private Initialized a new Acl object.
         # Must provide a valid Bucket object.
-        def initialize file #:nodoc:
+        def initialize file
           @bucket = file.bucket
           @file = file.name
           @connection = file.connection
@@ -63,8 +65,7 @@ module Gcloud
         ##
         # Reloads all Access Control List data for the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -87,12 +88,9 @@ module Gcloud
         ##
         # Lists the owners of the file.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -111,12 +109,9 @@ module Gcloud
         ##
         # Lists the owners of the file.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -135,12 +130,9 @@ module Gcloud
         ##
         # Lists the readers of the file.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -159,11 +151,8 @@ module Gcloud
         ##
         # Grants owner permission to the file.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -174,15 +163,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Examples
-        #
-        # Access to a file can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -194,9 +178,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_owner "user-#{email}"
         #
-        # Access to a file can be granted to a group by appending +"group-"+ to
-        # the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -223,11 +205,8 @@ module Gcloud
         ##
         # Grants writer permission to the file.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -238,15 +217,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Examples
-        #
-        # Access to a file can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -258,9 +232,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_writer "user-#{email}"
         #
-        # Access to a file can be granted to a group by appending +"group-"+ to
-        # the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -287,11 +259,8 @@ module Gcloud
         ##
         # Grants reader permission to the file.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -302,15 +271,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Examples
-        #
-        # Access to a file can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -322,9 +286,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_reader "user-#{email}"
         #
-        # Access to a file can be granted to a group by appending +"group-"+ to
-        # the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -351,11 +313,8 @@ module Gcloud
         ##
         # Permanently deletes the entity from the file's access control list.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -366,12 +325,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -395,7 +352,8 @@ module Gcloud
           false
         end
 
-        def self.predefined_rule_for rule_name #:nodoc:
+        # @private
+        def self.predefined_rule_for rule_name
           RULES[rule_name.to_s]
         end
 
@@ -405,8 +363,7 @@ module Gcloud
         # Convenience method to apply the +authenticatedRead+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -429,8 +386,7 @@ module Gcloud
         # Convenience method to apply the +bucketOwnerFullControl+ predefined
         # ACL rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -450,8 +406,7 @@ module Gcloud
         # Convenience method to apply the +bucketOwnerRead+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -471,8 +426,7 @@ module Gcloud
         # Convenience method to apply the +private+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -491,8 +445,7 @@ module Gcloud
         # Convenience method to apply the +projectPrivate+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -512,8 +465,7 @@ module Gcloud
         # Convenience method to apply the +publicRead+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/file/list.rb
+++ b/lib/gcloud/storage/file/list.rb
@@ -40,8 +40,8 @@ module Gcloud
         end
 
         ##
-        # New File::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New File::List from a response object.
+        def self.from_response resp, conn
           buckets = Array(resp.data["items"]).map do |gapi_object|
             File.from_gapi gapi_object, conn
           end

--- a/lib/gcloud/storage/file/verifier.rb
+++ b/lib/gcloud/storage/file/verifier.rb
@@ -22,9 +22,10 @@ module Gcloud
   module Storage
     class File
       ##
+      # @private
       # Verifies downloaded files by creating an MD5 or CRC32c hash digest
       # and comparing the value to the one from the Storage API.
-      module Verifier #:nodoc:
+      module Verifier
         def self.verify_md5! gcloud_file, local_file
           gcloud_digest = gcloud_file.md5
           local_digest = md5_for local_file

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -32,9 +32,12 @@ module Gcloud
     # authentication, and monitoring settings for those APIs.
     #
     # Gcloud::Storage::Project is the main object for interacting with
-    # Google Storage. Gcloud::Storage::Bucket objects are created,
+    # Google Storage. {Gcloud::Storage::Bucket} objects are created,
     # read, updated, and deleted by Gcloud::Storage::Project.
     #
+    # See {Gcloud#storage}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -43,17 +46,16 @@ module Gcloud
     #   bucket = storage.bucket "my-bucket"
     #   file = bucket.file "path/to/my-file.ext"
     #
-    # See Gcloud#storage
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Project instance.
+      # @private Creates a new Project instance.
       #
-      # See Gcloud#storage
-      def initialize project, credentials #:nodoc:
+      # See {Gcloud#storage}
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -62,8 +64,7 @@ module Gcloud
       ##
       # The Storage project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -77,8 +78,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["STORAGE_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -88,23 +89,16 @@ module Gcloud
       ##
       # Retrieves a list of buckets for the given project.
       #
-      # === Parameters
+      # @param [String] prefix Filter results to buckets whose names begin with
+      #   this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of buckets to return.
       #
-      # +prefix+::
-      #   Filter results to buckets whose names begin with this prefix.
-      #   (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of buckets to return. (+Integer+)
+      # @return [Array<Gcloud::Storage::Bucket>] (See
+      #   {Gcloud::Storage::Bucket::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Storage::Bucket (See Gcloud::Storage::Bucket::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -115,9 +109,7 @@ module Gcloud
       #     puts bucket.name
       #   end
       #
-      # You can also retrieve all buckets whose names begin with a prefix using
-      # the +:prefix+ option:
-      #
+      # @example Retrieve all buckets with names that begin with a given prefix:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -125,9 +117,7 @@ module Gcloud
       #
       #   user_buckets = storage.buckets prefix: "user-"
       #
-      # If you have a significant number of buckets, you may need to paginate
-      # through them: (See Bucket::List#token)
-      #
+      # @example With pagination: (See {Bucket::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -159,17 +149,12 @@ module Gcloud
       ##
       # Retrieves bucket by name.
       #
-      # === Parameters
+      # @param [String] bucket_name Name of a bucket.
       #
-      # +bucket_name+::
-      #   Name of a bucket. (+String+)
+      # @return [Gcloud::Storage::Bucket, nil] Returns nil if bucket does not
+      #   exist
       #
-      # === Returns
-      #
-      # Gcloud::Storage::Bucket or nil if bucket does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -192,18 +177,25 @@ module Gcloud
       ##
       # Creates a new bucket with optional attributes. Also accepts a block for
       # defining the CORS configuration for a static website served from the
-      # bucket. See Bucket::Cors for details. For more information about
-      # configuring buckets as static websites, see {How to Host a Static
-      # Website }[https://cloud.google.com/storage/docs/website-configuration].
-      # For more information about CORS, see {Cross-Origin Resource Sharing
-      # (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # bucket. See {Bucket::Cors} for details.
       #
-      # === Parameters
+      # The API call to create the bucket may be retried under certain
+      # conditions. See {Gcloud::Backoff} to control this behavior, or
+      # specify the wanted behavior in the call with the +:retries:+ option.
       #
-      # +bucket_name+::
-      #   Name of a bucket. (+String+)
-      # +acl+::
-      #   Apply a predefined set of access controls to this bucket. (+String+)
+      # You can pass {website
+      # settings}[https://cloud.google.com/storage/docs/website-configuration]
+      # for the bucket, including a block that defines CORS rule. See
+      # {Bucket::Cors} for details.
+      #
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
+      # @see https://cloud.google.com/storage/docs/website-configuration How to
+      #   Host a Static Website
+      #
+      # @param [String] bucket_name Name of a bucket.
+      # @param [String] acl Apply a predefined set of access controls to this
+      #   bucket.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -216,9 +208,8 @@ module Gcloud
       #     OWNER access, and allUsers get READER access.
       #   * +public_write+, +publicReadWrite+ - Project team owners get OWNER
       #     access, and allUsers get WRITER access.
-      # +default_acl+::
-      #   Apply a predefined set of default object access controls to this
-      #   bucket. (+String+)
+      # @param [String] default_acl Apply a predefined set of default object
+      #   access controls to this bucket.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -233,60 +224,51 @@ module Gcloud
       #     and project team members get access according to their roles.
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
-      # +cors+::
-      #   The CORS rules for the bucket. Accepts an array of hashes containing
-      #   the attributes specified for the {resource description of
+      # @param [String] cors The CORS rules for the bucket. Accepts an array of
+      #   hashes containing the attributes specified for the {resource
+      #   description of
       #   cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
-      # +location+::
-      #   The location of the bucket. Object data for objects in the bucket
-      #   resides in physical storage within this region. Possible values
-      #   include +ASIA+, +EU+, and +US+.(See the {developer's
+      # @param [String] location The location of the bucket. Object data for
+      #   objects in the bucket resides in physical storage within this region.
+      #   Possible values include +ASIA+, +EU+, and +US+.(See the {developer's
       #   guide}[https://cloud.google.com/storage/docs/bucket-locations] for the
-      #   authoritative list. The default value is +US+. (+String+)
-      # +logging_bucket+::
-      #   The destination bucket for the bucket's logs. For more information,
-      #   see {Access
-      #   Logs}[https://cloud.google.com/storage/docs/access-logs]. (+String+)
-      # +logging_prefix+::
-      #   The prefix used to create log object names for the bucket. It can be
-      #   at most 900 characters and must be a {valid object
+      #   authoritative list. The default value is +US+.
+      # @param [String] logging_bucket The destination bucket for the bucket's
+      #   logs. For more information, see {Access
+      #   Logs}[https://cloud.google.com/storage/docs/access-logs].
+      # @param [String] logging_prefix The prefix used to create log object
+      #   names for the bucket. It can be at most 900 characters and must be a
+      #   {valid object
       #   name}[https://cloud.google.com/storage/docs/bucket-naming#objectnames]
-      #   . By default, the object prefix is the name
-      #   of the bucket for which the logs are enabled. For more information,
-      #   see {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
-      #   (+String+)
-      # +retries+::
-      #   The number of times the API call should be retried.
-      #   Default is Gcloud::Backoff.retries. (+Integer+)
-      # +storage_class+::
-      #   Defines how objects in the bucket are stored and determines the SLA
-      #   and the cost of storage. Values include +:standard+, +:nearline+, and
-      #   +:dra+ (Durable Reduced Availability), as well as the strings returned
-      #   by Bucket#storage_class. For more information, see {Storage
-      #   Classes}[https://cloud.google.com/storage/docs/storage-classes].
-      #   The default value is +:standard+. (+Symbol+ or +String+)
-      # +versioning+::
-      #   Whether {Object
+      #   . By default, the object prefix is the name of the bucket for which
+      #   the logs are enabled. For more information, see {Access
+      #   Logs}[https://cloud.google.com/storage/docs/access-logs].
+      # @param [Integer] retries The number of times the API call should be
+      #   retried. Default is {Gcloud::Backoff.retries}.
+      # @param [Symbol, String] storage_class Defines how objects in the bucket
+      #   are stored and determines the SLA and the cost of storage. Values
+      #   include +:standard+, +:nearline+, and +:dra+ (Durable Reduced
+      #   Availability), as well as the strings returned by
+      #   Bucket#storage_class. For more information, see {Storage
+      #   Classes}[https://cloud.google.com/storage/docs/storage-classes]. The
+      #   default value is +:standard+.
+      # @param [Boolean] versioning Whether {Object
       #   Versioning}[https://cloud.google.com/storage/docs/object-versioning]
       #   is to be enabled for the bucket. The default value is +false+.
-      #   (+Boolean+)
-      # +website_main+::
-      #   The index page returned from a static website served from the bucket
-      #   when a site visitor requests the top level directory. For more
-      #   information, see {How to Host a Static Website
+      # @param [String] website_main The index page returned from a static
+      #   website served from the bucket when a site visitor requests the top
+      #   level directory. For more information, see {How to Host a Static
+      #   Website
       #   }[https://cloud.google.com/storage/docs/website-configuration#step4].
-      # +website_404+::
-      #   The page returned from a static website served from the bucket when a
-      #   site visitor requests a resource that does not exist. For more
-      #   information, see {How to Host a Static Website
+      # @param [String] website_404 The page returned from a static website
+      #   served from the bucket when a site visitor requests a resource that
+      #   does not exist. For more information, see {How to Host a Static
+      #   Website
       #   }[https://cloud.google.com/storage/docs/website-configuration#step4].
       #
-      # === Returns
+      # @return [Gcloud::Storage::Bucket]
       #
-      # Gcloud::Storage::Bucket
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -294,10 +276,7 @@ module Gcloud
       #
       #   bucket = storage.create_bucket "my-bucket"
       #
-      # The API call to create the bucket may be retried under certain
-      # conditions. See Gcloud::Backoff to control this behavior, or
-      # specify the wanted behavior in the call with the +:retries:+ option:
-      #
+      # @example Specify the number of retries to attempt:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -305,11 +284,7 @@ module Gcloud
       #
       #   bucket = storage.create_bucket "my-bucket", retries: 5
       #
-      # You can pass {website
-      # settings}[https://cloud.google.com/storage/docs/website-configuration]
-      # for the bucket, including a block that defines CORS rule. See
-      # Bucket::Cors for details.
-      #
+      # @example Add CORS rules in a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new


### PR DESCRIPTION
This PR converts Storage code comments to YARD tags for the purpose of:

1. Building HTML-based API documentation.
2. Building gcloud-common JSON-based documentation.

[closes #460]