### PR TITLE
Convert top-level modules to YARD

### DIFF
--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -34,21 +34,14 @@ module Gcloud
   ##
   # Creates a new object for connecting to Google Cloud.
   #
-  # ### Parameters
+  # @param [String] project Project identifier for the Pub/Sub service you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
   #
-  # `project`::
-  #   Project identifier for the Pub/Sub service you are connecting to.
-  #   (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
+  # @return [Gcloud]
   #
-  # ### Returns
-  #
-  # Gcloud
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -70,25 +63,19 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/datastore`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Datastore::Dataset]
   #
-  # Gcloud::Datastore::Dataset
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -101,9 +88,7 @@ module Gcloud
   #
   #   dataset.save entity
   #
-  # You shouldn't need to override the default scope, but it is possible to do
-  # so with the `scope` option:
-  #
+  # @example You shouldn't need to override the default scope, but you can:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -119,24 +104,21 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
-  # ### Parameters
+  # @see https://cloud.google.com/storage/docs/authentication#oauth Storage
+  #   OAuth 2.0 Authentication
   #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
   #
-  # ### Returns
+  # @return [Gcloud::Storage::Project]
   #
-  # Gcloud::Storage::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -144,10 +126,7 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  # The default scope can be overridden with the `scope` option. For more
-  # information see [Storage OAuth 2.0
-  # Authentication](https://cloud.google.com/storage/docs/authentication#oauth).
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -163,24 +142,18 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/pubsub`
   #
-  # ### Returns
+  # @return [Gcloud::Pubsub::Project]
   #
-  # Gcloud::Pubsub::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -188,8 +161,7 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -205,24 +177,18 @@ module Gcloud
   # Creates a new object for connecting to the BigQuery service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/bigquery`
   #
-  # ### Returns
+  # @return [Gcloud::Bigquery::Project]
   #
-  # Gcloud::Bigquery::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -233,8 +199,7 @@ module Gcloud
   #     puts row
   #   end
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -250,24 +215,18 @@ module Gcloud
   # Creates a new object for connecting to the DNS service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   #
-  # ### Returns
+  # @return [Gcloud::Dns::Project]
   #
-  # Gcloud::Dns::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -277,8 +236,7 @@ module Gcloud
   #     puts record.name
   #   end
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -298,24 +256,18 @@ module Gcloud
   # Creates a new object for connecting to the Resource Manager service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
   #
-  # ### Returns
+  # @return [Gcloud::ResourceManager::Manager]
   #
-  # Gcloud::ResourceManager::Manager
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -324,8 +276,7 @@ module Gcloud
   #     puts projects.project_id
   #   end
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -343,25 +294,19 @@ module Gcloud
   # Creates a new object for connecting to the Search service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/cloudsearch`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Search::Project]
   #
-  # Gcloud::Search::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   def search scope: nil

--- a/lib/gcloud/backoff.rb
+++ b/lib/gcloud/backoff.rb
@@ -62,6 +62,7 @@ module Gcloud
     self.backoff = ->(retries) { sleep retries.to_i }
 
     ##
+    # @private
     # Creates a new Backoff object to catch common errors when calling
     # the Google API and handle the error by retrying the call.
     #
@@ -70,14 +71,15 @@ module Gcloud
     #                    parameters: { thing: @thing },
     #                    body_object: { name: thing_name }
     #   end
-    def initialize options = {} #:nodoc:
+    def initialize options = {}
       @max_retries  = (options[:retries]    || Backoff.retries).to_i
       @http_codes   = (options[:http_codes] || Backoff.http_codes).to_a
       @reasons      = (options[:reasons]    || Backoff.reasons).to_a
       @backoff      =  options[:backoff]    || Backoff.backoff
     end
 
-    def execute #:nodoc:
+    # @private
+    def execute
       current_retries = 0
       loop do
         result = yield # Expecting Google::APIClient::Result
@@ -90,6 +92,7 @@ module Gcloud
 
     protected
 
+    # @private
     def retry? result, current_retries #:nodoc:
       if current_retries < @max_retries
         return true if retry_http_code? result
@@ -98,11 +101,13 @@ module Gcloud
       false
     end
 
+    # @private
     def retry_http_code? result #:nodoc:
       @http_codes.include? result.response.status
     end
 
-    def retry_error_reason? result #:nodoc:
+    # @private
+    def retry_error_reason? result
       if result.data &&
          result.data["error"] &&
          result.data["error"]["errors"]

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new `Project` instance connected to the BigQuery service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Identifier for a BigQuery project. If not present, the default project for
-  #   the credentials is used. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Identifier for a BigQuery project. If not present,
+  #   the default project for the credentials is used.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/bigquery`
   #
-  # ### Returns
+  # @return [Gcloud::Bigquery::Project]
   #
-  # Gcloud::Bigquery::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/bigquery"
   #
   #   bigquery = Gcloud.bigquery

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -121,7 +121,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def add_reader_view view
           add_access_role_scope_value :reader, :view, view
         end
@@ -157,7 +157,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def add_writer_view view
           add_access_role_scope_value :writer, :view, view
         end
@@ -193,7 +193,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def add_owner_view view
           add_access_role_scope_value :owner, :view, view
         end
@@ -229,7 +229,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def remove_reader_view view
           remove_access_role_scope_value :reader, :view, view
         end
@@ -265,7 +265,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def remove_writer_view view
           remove_access_role_scope_value :writer, :view, view
         end
@@ -301,7 +301,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def remove_owner_view view
           remove_access_role_scope_value :owner, :view, view
         end
@@ -337,7 +337,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def reader_view? view
           lookup_access_role_scope_value :reader, :view, view
         end
@@ -373,7 +373,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def writer_view? view
           lookup_access_role_scope_value :writer, :view, view
         end
@@ -409,7 +409,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def owner_view? view
           lookup_access_role_scope_value :owner, :view, view
         end

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -166,12 +166,12 @@ module Gcloud
       #   syntax](https://cloud.google.com/bigquery/query-reference), of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
-      # @param [Integer] timeout How long to wait for the query to complete, in
-      #   milliseconds, before the request times out and returns. Note that this
-      #   is only a timeout for the request, not the query. If the query takes
-      #   longer to run than the timeout value, the call returns without any
-      #   results and with QueryData#complete? set to false. The default value
-      #   is 10000 milliseconds (10 seconds).
+      # @param [Integer] max The maximum number of rows of data to return per
+      #   page of results. Setting this flag to a small value such as 1000 and
+      #   then paging through results might improve reliability when the query
+      #   result set is large. In addition to this limit, responses are also
+      #   limited to 10 MB. By default, there is no maximum row count, and only
+      #   the byte limit applies.
       # @param [Integer] timeout How long to wait for the query to complete, in
       #   milliseconds, before the request times out and returns. Note that this
       #   is only a timeout for the request, not the query. If the query takes

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -44,17 +44,17 @@ module Gcloud
       #
       class Schema
         # @private
-        MODES = %w( NULLABLE REQUIRED REPEATED ) #:nodoc:
+        MODES = %w( NULLABLE REQUIRED REPEATED )
 
         # @private
-        TYPES = %w( STRING INTEGER FLOAT BOOLEAN TIMESTAMP RECORD ) #:nodoc:
+        TYPES = %w( STRING INTEGER FLOAT BOOLEAN TIMESTAMP RECORD )
 
         # @private
-        attr_reader :fields #:nodoc:
+        attr_reader :fields
 
         ##
         # @private  Initializes a new schema object with an existing schema.
-        def initialize schema = nil, nested = false #:nodoc:
+        def initialize schema = nil, nested = false
           fields = (schema && schema["fields"]) || []
           @original_fields = fields.dup
           @fields = fields.dup

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -20,10 +20,11 @@ require "googleauth"
 
 module Gcloud
   ##
+  # @private
   # Represents the OAuth 2.0 signing logic.
   # This class is intended to be inherited by API-specific classes
   # which overrides the SCOPE constant.
-  class Credentials #:nodoc:
+  class Credentials
     TOKEN_CREDENTIAL_URI = "https://accounts.google.com/o/oauth2/token"
     AUDIENCE = "https://accounts.google.com/o/oauth2/token"
     SCOPE = []

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -24,30 +24,23 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Dataset identifier for the Datastore you are connecting to. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Dataset identifier for the Datastore you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/datastore`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Datastore::Dataset]
   #
-  # Gcloud::Datastore::Dataset
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore "my-todo-project",

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new `Project` instance connected to the DNS service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Identifier for a DNS project. If not present, the default project for
-  #   the credentials is used. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Identifier for a DNS project. If not present, the
+  #   default project for the credentials is used.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   #
-  # ### Returns
+  # @return [Gcloud::Dns::Project]
   #
-  # Gcloud::Dns::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud"
   #
   #   dns = Gcloud.dns "my-dns-project",

--- a/lib/gcloud/gce.rb
+++ b/lib/gcloud/gce.rb
@@ -17,8 +17,9 @@ require "faraday"
 
 module Gcloud
   ##
+  # @private
   # Represents the Google Compute Engine environment.
-  module GCE #:nodoc:
+  module GCE
     CHECK_URI = "http://169.254.169.254"
     PROJECT_URI = "#{CHECK_URI}/computeMetadata/v1/project/project-id"
 

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Project identifier for the Pub/Sub service you are connecting to.
-  #   (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Project identifier for the Pub/Sub service you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/pubsub`
   #
-  # ### Returns
+  # @return [Gcloud::Pubsub::Project]
   #
-  # Gcloud::Pubsub::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -21,27 +21,20 @@ module Gcloud
   # Creates a new `Project` instance connected to the Resource Manager service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
   #
-  # ### Returns
+  # @return [Gcloud::ResourceManager::Manager]
   #
-  # Gcloud::ResourceManager::Manager
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/resource_manager"
   #
   #   resource_manager = Gcloud.resource_manager

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -452,7 +452,7 @@ module Gcloud
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies
       #
-      # @param [String, Array<String>] permissions The set of permissions to
+      # @param [String, Array<String>] *permissions The set of permissions to
       #   check access for. Permissions with wildcards (such as `*` or
       #   `storage.*`) are not allowed.
       #

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -21,28 +21,22 @@ module Gcloud
   # Creates a new `Project` instance connected to the Search service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Identifier for a Search project. If not present, the default project for
-  #   the credentials is used. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Identifier for a Search project. If not present, the
+  #   default project for the credentials is used.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/cloudsearch`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Search::Project]
   #
-  # Gcloud::Search::Project
   def self.search project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Search::Project.default_project
     if keyfile.nil?

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Project identifier for the Storage service you are connecting to.
-  #   (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Project identifier for the Storage service you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
   #
-  # ### Returns
+  # @return [Gcloud::Storage::Project]
   #
-  # Gcloud::Storage::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/storage"
   #
   #   storage = Gcloud.storage "my-todo-project",


### PR DESCRIPTION
This PR also includes:

* Remove remaining nodoc comments
* Fix YARD tag in ResourceManager
* Fix YARD tag errors in BigQuery

I believe it completes the conversion of all `/lib` files to YARD.