### PR TITLE
Add delimiter parameter to returns results in a directory-like mode

### DIFF
--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -406,9 +406,15 @@ module Gcloud
       #     tmp_files = bucket.files token: tmp_files.token
       #   end
       #
-      def files prefix: nil, token: nil, max: nil, versions: nil
+      def files prefix: nil, delimiter: nil, token: nil, max: nil, versions: nil
         ensure_connection!
-        options = { prefix: prefix, token: token, max: max, versions: versions }
+        options = {
+          prefix: prefix,
+          delimiter: delimiter,
+          token: token,
+          max: max,
+          versions: versions
+        }
         resp = connection.list_files name, options
         if resp.success?
           File::List.from_response resp, connection

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -165,12 +165,14 @@ module Gcloud
       ##
       # Retrieves a list of files matching the criteria.
       def list_files bucket_name, options = {}
-        params = { bucket:     bucket_name,
-                   prefix:     options[:prefix],
-                   pageToken:  options[:token],
-                   maxResults: options[:max],
-                   versions:   options[:versions]
-                 }.delete_if { |_, v| v.nil? }
+        params = {
+          bucket:        bucket_name,
+          prefix:          options[:prefix],
+          delimiter:     options[:delimiter],
+          pageToken:  options[:token],
+          maxResults: options[:max],
+          versions:      options[:versions]
+        }.delete_if { |_, v| v.nil? }
 
         @client.execute(
           api_method: @storage.objects.list,

--- a/test/gcloud/storage/bucket_test.rb
+++ b/test/gcloud/storage/bucket_test.rb
@@ -364,6 +364,22 @@ describe Gcloud::Storage::Bucket, :mock_storage do
     files.prefixes.must_include "/prefix/path2/"
   end
 
+  it "paginates files with delimiter set" do
+    mock_connection.get "/storage/v1/b/#{bucket.name}/o" do |env|
+      env.params.must_include "delimiter"
+      env.params["delimiter"].must_equal "/"
+      [200, { "Content-Type" => "application/json" },
+       list_files_json(3, nil, ["/prefix/path1/","/prefix/path2/"])]
+    end
+
+    files = bucket.files delimiter: "/"
+
+    files.count.must_equal 3
+    files.prefixes.count.must_equal 2
+    files.prefixes.wont_be :empty?
+    files.prefixes.must_include "/prefix/path1/"
+  end
+
   it "paginates files with max set" do
     mock_connection.get "/storage/v1/b/#{bucket.name}/o" do |env|
       env.params.must_include "maxResults"


### PR DESCRIPTION
Add new optional query parameter: `delimiter` this query parameter permit returns results in a directory-like mode.
This PR is based on Cloud Storage Docs - https://cloud.google.com/storage/docs/json_api/v1/objects/list