### PR TITLE
Add docs for Bucket#files delimiter param

### DIFF
--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -363,6 +363,12 @@ module Gcloud
       #
       # @param [String] prefix Filter results to files whose names begin with
       #   this prefix.
+      # @param [String] delimiter Returns results in a directory-like mode.
+      #   `items` will contain only objects whose names, aside from the
+      #   `prefix`, do not contain `delimiter`. Objects whose names, aside from
+      #   the `prefix`, contain `delimiter` will have their name, truncated
+      #   after the `delimiter`, returned in `prefixes`. Duplicate `prefixes`
+      #   are omitted.
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
       # @param [Integer] max Maximum number of items plus prefixes to return. As


### PR DESCRIPTION
Adds missing documentation for the `delimiter` parameter.

[refs #484]