### PR TITLE
Yard jsondoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ keyfile.json
 coverage/*
 doc/*
 pkg/*
+html/*
+jsondoc/*
 
 # Ignore vagrant directory
 .vagrant
@@ -12,4 +14,3 @@ pkg/*
 
 # directories left by gh-pages
 _site/*
-html/*

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,6 @@ gem "gcloud-rdoc",
 gem "yard-gcloud",
     git: "https://github.com/GoogleCloudPlatform/gcloud-ruby.git",
     branch: "yard-gcloud"
+gem "gcloud-jsondoc",
+    git: "https://github.com/GoogleCloudPlatform/gcloud-ruby.git",
+    branch: "gcloud-jsondoc"

--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -43,14 +43,18 @@ namespace :pages do
     tmp   = Pathname.new(Dir.home) + "tmp"
     docs  = tmp + "master-docs"
     pages = tmp + "master-pages"
+    jsondoc = tmp + "master-jsondoc"
     FileUtils.remove_dir docs if Dir.exists? docs
     FileUtils.remove_dir pages if Dir.exists? pages
+    FileUtils.remove_dir jsondoc if Dir.exists? jsondoc
     FileUtils.mkdir_p docs
     FileUtils.mkdir_p pages
+    FileUtils.mkdir_p jsondoc
 
-    Rake::Task["pages:yard"].invoke
+    Rake::Task["pages:jsondoc"].invoke
 
     puts `cp -R html/* #{docs}`
+    puts `cp jsondoc/gcloud.json #{jsondoc}/gcloud.json`
     # checkout the gh-pages branch
     git_repo = "git@github.com:GoogleCloudPlatform/gcloud-ruby.git"
     if ENV["GH_OAUTH_TOKEN"]
@@ -61,6 +65,8 @@ namespace :pages do
     Dir.chdir pages do
       # sync the docs
       puts `rsync -r --delete #{docs}/ docs/master/`
+      FileUtils.mkdir_p "versions"
+      puts `cp #{jsondoc}/gcloud.json versions/master.json`
       # commit changes
       puts `git add -A .`
       if ENV["GH_OAUTH_TOKEN"]

--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -247,4 +247,14 @@ namespace :pages do
       t.options << "--output-dir" << "html"
     end
   end
+
+  desc "Generates JSON output from gcloud-ruby .yardoc"
+  task :jsondoc => :yard do
+    require "gcloud/jsondoc"
+    registry = YARD::Registry.load! ".yardoc"
+    builder = Gcloud::Jsondoc.new registry
+    json = builder.docs.target!
+    FileUtils.mkdir_p "jsondoc"
+    File.write "jsondoc/gcloud.json", json
+  end
 end

--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -121,7 +121,7 @@ namespace :pages do
         if use_rdoc
           puts `bundle exec rake pages:rdoc`
         else
-          puts `bundle exec rake pages:yard`
+          puts `bundle exec rake pages:jsondoc`
         end
       end
     end
@@ -132,8 +132,10 @@ namespace :pages do
     Dir.chdir pages do
       # make the release dir if needed
       FileUtils.mkdir_p "docs/#{tag}/"
+      FileUtils.mkdir_p "versions"
       # sync the docs
       puts `rsync -r --delete #{repo}/html/ docs/#{tag}/`
+      puts `cp #{repo}/jsondoc/gcloud.json versions/#{tag}.json` unless use_rdoc
       # Update releases yaml
       releases = YAML.load_file "_data/releases.yaml"
       unless releases.select { |r| r["version"] == tag }.any?


### PR DESCRIPTION
Add generation of common-format json to gh-pages branch to rake tasks for documentation.

Common-format json is detailed in GoogleCloudPlatform/gcloud-common#33.

The location for the json file(s) in the gh-pages branch is discussed in GoogleCloudPlatform/gcloud-common#42.