### PR TITLE
Convert code documentation to YARD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ coverage
 doc
 pkg
 
+# Ignore YARD cache
+.yardoc
+
 # Ignore vagrant directory
 .vagrant
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ keyfile.json
 coverage/*
 doc/*
 pkg/*
+html/*
+jsondoc/*
 
 # Ignore vagrant directory
 .vagrant
@@ -12,4 +14,3 @@ pkg/*
 
 # directories left by gh-pages
 _site/*
-html/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,15 @@
 Gemfile.lock
 keyfile.json
-coverage
-doc
-pkg
-
-# Ignore YARD cache
-.yardoc
+coverage/*
+doc/*
+pkg/*
 
 # Ignore vagrant directory
 .vagrant
 
+# Ignore YARD stuffs
+.yardoc
+
 # directories left by gh-pages
-_site
-html
+_site/*
+html/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
     - "test/**/*"
     - "Vagrantfile"
 
+Documentation:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/MethodDefParentheses:
@@ -17,6 +20,8 @@ Style/NumericLiterals:
 Style/SpaceAroundOperators:
   Enabled: false
 Metrics/ClassLength:
+  Enabled: false
+Style/EmptyLines:
   Enabled: false
 Style/EmptyElse:
   Enabled: false

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+-
+OVERVIEW.md
+README.md
+AUTHENTICATION.md
+CONTRIBUTING.md
+CHANGELOG.md

--- a/.yardopts
+++ b/.yardopts
@@ -1,7 +1,9 @@
 --no-private
+--title=Gcloud
+--exclude lib/gcloud/proto/
+
+./lib/**/*.rb
 -
-OVERVIEW.md
 README.md
+OVERVIEW.md
 AUTHENTICATION.md
-CONTRIBUTING.md
-CHANGELOG.md

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,6 @@ gem "gcloud-rdoc",
 gem "yard-gcloud",
     git: "https://github.com/GoogleCloudPlatform/gcloud-ruby.git",
     branch: "yard-gcloud"
+gem "gcloud-jsondoc",
+    git: "https://github.com/GoogleCloudPlatform/gcloud-ruby.git",
+    branch: "gcloud-jsondoc"

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gem "rake"
 gem "gcloud-rdoc",
     git: "https://github.com/GoogleCloudPlatform/gcloud-ruby.git",
     branch: "gcloud-rdoc"
+gem "yard-gcloud",
+    git: "https://github.com/GoogleCloudPlatform/gcloud-ruby.git",
+    branch: "yard-gcloud"

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -6,7 +6,7 @@ The `gcloud` library is installable through rubygems:
 $ gem install gcloud
 ```
 
-Gcloud aims to make authentication as simple as possible. Google Cloud requires a **Project ID** and **Service Account Credentials** to connect to the APIs. You can learn more about various options for connection on the [Authentication Guide](AUTHENTICATION.md).
+Gcloud aims to make authentication as simple as possible. Google Cloud requires a **Project ID** and **Service Account Credentials** to connect to the APIs. You can learn more about various options for connection on the [Authentication Guide](AUTHENTICATION).
 
 # BigQuery
 

--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      "httpclient", "~> 2.5"
   gem.add_development_dependency      "simplecov", "~> 0.9"
   gem.add_development_dependency      "coveralls", "~> 0.7"
+  gem.add_development_dependency      "yard", "~> 0.8"
 end

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -34,21 +34,14 @@ module Gcloud
   ##
   # Creates a new object for connecting to Google Cloud.
   #
-  # ### Parameters
+  # @param [String] project Project identifier for the Pub/Sub service you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
   #
-  # `project`::
-  #   Project identifier for the Pub/Sub service you are connecting to.
-  #   (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
+  # @return [Gcloud]
   #
-  # ### Returns
-  #
-  # Gcloud
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -70,25 +63,19 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/datastore`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Datastore::Dataset]
   #
-  # Gcloud::Datastore::Dataset
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -101,9 +88,7 @@ module Gcloud
   #
   #   dataset.save entity
   #
-  # You shouldn't need to override the default scope, but it is possible to do
-  # so with the `scope` option:
-  #
+  # @example You shouldn't need to override the default scope, but you can:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -119,24 +104,21 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
-  # ### Parameters
+  # @see https://cloud.google.com/storage/docs/authentication#oauth Storage
+  #   OAuth 2.0 Authentication
   #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
   #
-  # ### Returns
+  # @return [Gcloud::Storage::Project]
   #
-  # Gcloud::Storage::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -144,10 +126,7 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  # The default scope can be overridden with the `scope` option. For more
-  # information see [Storage OAuth 2.0
-  # Authentication](https://cloud.google.com/storage/docs/authentication#oauth).
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -163,24 +142,18 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/pubsub`
   #
-  # ### Returns
+  # @return [Gcloud::Pubsub::Project]
   #
-  # Gcloud::Pubsub::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -188,8 +161,7 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -205,24 +177,18 @@ module Gcloud
   # Creates a new object for connecting to the BigQuery service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/bigquery`
   #
-  # ### Returns
+  # @return [Gcloud::Bigquery::Project]
   #
-  # Gcloud::Bigquery::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -233,8 +199,7 @@ module Gcloud
   #     puts row
   #   end
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -250,24 +215,18 @@ module Gcloud
   # Creates a new object for connecting to the DNS service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   #
-  # ### Returns
+  # @return [Gcloud::Dns::Project]
   #
-  # Gcloud::Dns::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -277,8 +236,7 @@ module Gcloud
   #     puts record.name
   #   end
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -298,24 +256,18 @@ module Gcloud
   # Creates a new object for connecting to the Resource Manager service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
   #
-  # ### Returns
+  # @return [Gcloud::ResourceManager::Manager]
   #
-  # Gcloud::ResourceManager::Manager
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
@@ -324,8 +276,7 @@ module Gcloud
   #     puts projects.project_id
   #   end
   #
-  # The default scope can be overridden with the `scope` option:
-  #
+  # @example The default scope can be overridden with the `scope` option:
   #   require "gcloud"
   #
   #   gcloud  = Gcloud.new
@@ -343,25 +294,19 @@ module Gcloud
   # Creates a new object for connecting to the Search service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/cloudsearch`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Search::Project]
   #
-  # Gcloud::Search::Project
-  #
-  # ### Examples
-  #
+  # @example
   #   require "gcloud"
   #
   def search scope: nil

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -28,7 +28,7 @@ require "gcloud/version"
 # is taken care of for you.
 #
 # You can learn more about various options for connection on the
-# [Authentication Guide](AUTHENTICATION.md).
+# [Authentication Guide](AUTHENTICATION).
 #
 module Gcloud
   ##

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -36,12 +36,12 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +project+::
+  # `project`::
   #   Project identifier for the Pub/Sub service you are connecting to.
-  #   (+String+)
-  # +keyfile+::
+  #   (`String`)
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
+  #   readable. (`String` or `Hash`)
   #
   # ### Returns
   #
@@ -72,16 +72,16 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +scope+::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scopes are:
   #
-  #   * +https://www.googleapis.com/auth/datastore+
-  #   * +https://www.googleapis.com/auth/userinfo.email+
+  #   * `https://www.googleapis.com/auth/datastore`
+  #   * `https://www.googleapis.com/auth/userinfo.email`
   #
   # ### Returns
   #
@@ -102,7 +102,7 @@ module Gcloud
   #   dataset.save entity
   #
   # You shouldn't need to override the default scope, but it is possible to do
-  # so with the +scope+ option:
+  # so with the `scope` option:
   #
   #   require "gcloud"
   #
@@ -121,15 +121,15 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +scope+::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/devstorage.full_control+
+  #   * `https://www.googleapis.com/auth/devstorage.full_control`
   #
   # ### Returns
   #
@@ -144,7 +144,7 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  # The default scope can be overridden with the +scope+ option. For more
+  # The default scope can be overridden with the `scope` option. For more
   # information see [Storage OAuth 2.0
   # Authentication](https://cloud.google.com/storage/docs/authentication#oauth).
   #
@@ -165,15 +165,15 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +scope+::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/pubsub+
+  #   * `https://www.googleapis.com/auth/pubsub`
   #
   # ### Returns
   #
@@ -188,7 +188,7 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  # The default scope can be overridden with the +scope+ option:
+  # The default scope can be overridden with the `scope` option:
   #
   #   require "gcloud"
   #
@@ -207,15 +207,15 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +scope+::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/bigquery+
+  #   * `https://www.googleapis.com/auth/bigquery`
   #
   # ### Returns
   #
@@ -233,7 +233,7 @@ module Gcloud
   #     puts row
   #   end
   #
-  # The default scope can be overridden with the +scope+ option:
+  # The default scope can be overridden with the `scope` option:
   #
   #   require "gcloud"
   #
@@ -252,15 +252,15 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +scope+::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/ndev.clouddns.readwrite+
+  #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   #
   # ### Returns
   #
@@ -277,7 +277,7 @@ module Gcloud
   #     puts record.name
   #   end
   #
-  # The default scope can be overridden with the +scope+ option:
+  # The default scope can be overridden with the `scope` option:
   #
   #   require "gcloud"
   #
@@ -300,15 +300,15 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +scope+::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/cloud-platform+
+  #   * `https://www.googleapis.com/auth/cloud-platform`
   #
   # ### Returns
   #
@@ -324,7 +324,7 @@ module Gcloud
   #     puts projects.project_id
   #   end
   #
-  # The default scope can be overridden with the +scope+ option:
+  # The default scope can be overridden with the `scope` option:
   #
   #   require "gcloud"
   #
@@ -345,16 +345,16 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +scope+::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scopes are:
   #
-  #   * +https://www.googleapis.com/auth/cloudsearch+
-  #   * +https://www.googleapis.com/auth/userinfo.email+
+  #   * `https://www.googleapis.com/auth/cloudsearch`
+  #   * `https://www.googleapis.com/auth/userinfo.email`
   #
   # ### Returns
   #

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -28,7 +28,7 @@ require "gcloud/version"
 # is taken care of for you.
 #
 # You can learn more about various options for connection on the
-# {Authentication Guide}[AUTHENTICATION.md].
+# [Authentication Guide](AUTHENTICATION.md).
 #
 module Gcloud
   ##
@@ -74,8 +74,8 @@ module Gcloud
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scopes are:
@@ -123,8 +123,8 @@ module Gcloud
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -145,8 +145,8 @@ module Gcloud
   #   file = bucket.file "path/to/my-file.ext"
   #
   # The default scope can be overridden with the +scope+ option. For more
-  # information see {Storage OAuth 2.0
-  # Authentication}[https://cloud.google.com/storage/docs/authentication#oauth].
+  # information see [Storage OAuth 2.0
+  # Authentication](https://cloud.google.com/storage/docs/authentication#oauth).
   #
   #   require "gcloud"
   #
@@ -167,8 +167,8 @@ module Gcloud
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -209,8 +209,8 @@ module Gcloud
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -254,8 +254,8 @@ module Gcloud
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -302,8 +302,8 @@ module Gcloud
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -347,8 +347,8 @@ module Gcloud
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scopes are:

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/version"
 

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -16,7 +16,7 @@
 require "gcloud/version"
 
 ##
-# = Google Cloud
+# # Google Cloud
 #
 # Gcloud is the official library for interacting with the Google Cloud Platform.
 # Google Cloud Platform is a set of modular cloud-based services that allow
@@ -34,7 +34,7 @@ module Gcloud
   ##
   # Creates a new object for connecting to Google Cloud.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +project+::
   #   Project identifier for the Pub/Sub service you are connecting to.
@@ -43,11 +43,11 @@ module Gcloud
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (+String+ or +Hash+)
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud
   #
-  # === Example
+  # ### Example
   #
   #   require "gcloud"
   #
@@ -70,7 +70,7 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
@@ -83,11 +83,11 @@ module Gcloud
   #   * +https://www.googleapis.com/auth/datastore+
   #   * +https://www.googleapis.com/auth/userinfo.email+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Datastore::Dataset
   #
-  # === Examples
+  # ### Examples
   #
   #   require "gcloud"
   #
@@ -119,7 +119,7 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
@@ -131,11 +131,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/devstorage.full_control+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Storage::Project
   #
-  # === Examples
+  # ### Examples
   #
   #   require "gcloud"
   #
@@ -163,7 +163,7 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
@@ -175,11 +175,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/pubsub+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Pubsub::Project
   #
-  # === Examples
+  # ### Examples
   #
   #   require "gcloud"
   #
@@ -205,7 +205,7 @@ module Gcloud
   # Creates a new object for connecting to the BigQuery service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
@@ -217,11 +217,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/bigquery+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Bigquery::Project
   #
-  # === Examples
+  # ### Examples
   #
   #   require "gcloud"
   #
@@ -250,7 +250,7 @@ module Gcloud
   # Creates a new object for connecting to the DNS service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
@@ -262,11 +262,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/ndev.clouddns.readwrite+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Dns::Project
   #
-  # === Examples
+  # ### Examples
   #
   #   require "gcloud"
   #
@@ -298,7 +298,7 @@ module Gcloud
   # Creates a new object for connecting to the Resource Manager service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
@@ -310,11 +310,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/cloud-platform+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::ResourceManager::Manager
   #
-  # === Examples
+  # ### Examples
   #
   #   require "gcloud"
   #
@@ -343,7 +343,7 @@ module Gcloud
   # Creates a new object for connecting to the Search service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
@@ -356,11 +356,11 @@ module Gcloud
   #   * +https://www.googleapis.com/auth/cloudsearch+
   #   * +https://www.googleapis.com/auth/userinfo.email+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Search::Project
   #
-  # === Examples
+  # ### Examples
   #
   #   require "gcloud"
   #

--- a/lib/gcloud/backoff.rb
+++ b/lib/gcloud/backoff.rb
@@ -62,6 +62,7 @@ module Gcloud
     self.backoff = ->(retries) { sleep retries.to_i }
 
     ##
+    # @private
     # Creates a new Backoff object to catch common errors when calling
     # the Google API and handle the error by retrying the call.
     #
@@ -70,14 +71,15 @@ module Gcloud
     #                    parameters: { thing: @thing },
     #                    body_object: { name: thing_name }
     #   end
-    def initialize options = {} #:nodoc:
+    def initialize options = {}
       @max_retries  = (options[:retries]    || Backoff.retries).to_i
       @http_codes   = (options[:http_codes] || Backoff.http_codes).to_a
       @reasons      = (options[:reasons]    || Backoff.reasons).to_a
       @backoff      =  options[:backoff]    || Backoff.backoff
     end
 
-    def execute #:nodoc:
+    # @private
+    def execute
       current_retries = 0
       loop do
         result = yield # Expecting Google::APIClient::Result
@@ -90,6 +92,7 @@ module Gcloud
 
     protected
 
+    # @private
     def retry? result, current_retries #:nodoc:
       if current_retries < @max_retries
         return true if retry_http_code? result
@@ -98,11 +101,13 @@ module Gcloud
       false
     end
 
+    # @private
     def retry_http_code? result #:nodoc:
       @http_codes.include? result.response.status
     end
 
-    def retry_error_reason? result #:nodoc:
+    # @private
+    def retry_error_reason? result
       if result.data &&
          result.data["error"] &&
          result.data["error"]["errors"]

--- a/lib/gcloud/backoff.rb
+++ b/lib/gcloud/backoff.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#--
-# Google Cloud Backoff
+
 module Gcloud
   ##
   # Backoff allows users to control how Google API calls are retried.

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new `Project` instance connected to the BigQuery service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Identifier for a BigQuery project. If not present, the default project for
-  #   the credentials is used. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Identifier for a BigQuery project. If not present,
+  #   the default project for the credentials is used.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/bigquery`
   #
-  # ### Returns
+  # @return [Gcloud::Bigquery::Project]
   #
-  # Gcloud::Bigquery::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/bigquery"
   #
   #   bigquery = Gcloud.bigquery

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -19,26 +19,26 @@ require "gcloud/bigquery/project"
 # Google Cloud BigQuery
 module Gcloud
   ##
-  # Creates a new +Project+ instance connected to the BigQuery service.
+  # Creates a new `Project` instance connected to the BigQuery service.
   # Each call creates a new connection.
   #
   # ### Parameters
   #
-  # +project+::
+  # `project`::
   #   Identifier for a BigQuery project. If not present, the default project for
-  #   the credentials is used. (+String+)
-  # +keyfile+::
+  #   the credentials is used. (`String`)
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
-  # +scope+::
+  #   readable. (`String` or `Hash`)
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/bigquery+
+  #   * `https://www.googleapis.com/auth/bigquery`
   #
   # ### Returns
   #
@@ -88,7 +88,7 @@ module Gcloud
   #
   # A BigQuery project holds datasets, which in turn hold tables. Assuming that
   # you have not yet created datasets or tables in your own project, let's
-  # connect to Google's +publicdata+ project, and see what you find.
+  # connect to Google's `publicdata` project, and see what you find.
   #
   #   require "gcloud"
   #
@@ -106,7 +106,7 @@ module Gcloud
   #
   # In addition listing all datasets and tables in the project, you can also
   # retrieve individual datasets and tables by ID. Let's look at the structure
-  # of the +shakespeare+ table, which contains an entry for every word in every
+  # of the `shakespeare` table, which contains an entry for every word in every
   # play written by Shakespeare.
   #
   #   require "gcloud"
@@ -147,7 +147,7 @@ module Gcloud
   #   data.next? #=> false
   #   data.first #=> {"word"=>"you", "count"=>42}
   #
-  # The +TOP+ function shown above is just one of a variety of functions
+  # The `TOP` function shown above is just one of a variety of functions
   # offered by BigQuery. See the [Query
   # Reference](https://cloud.google.com/bigquery/query-reference) for a full
   # listing.
@@ -197,7 +197,7 @@ module Gcloud
   # Now that you have a dataset, you can use it to create a table. Every table
   # is defined by a schema that may contain nested and repeated fields. The
   # example below shows a schema with a repeated record field named
-  # +cities_lived+. (For more information about nested and repeated fields, see
+  # `cities_lived`. (For more information about nested and repeated fields, see
   # [Preparing Data for
   # BigQuery](https://cloud.google.com/bigquery/preparing-data-for-bigquery).)
   #
@@ -294,10 +294,10 @@ module Gcloud
   #   load_job = table.load file, format: "csv"
   #
   # Because the names data, although formatted as CSV, is distributed in files
-  # with a +.txt+ extension, this example explicitly passes the +format+ option
+  # with a `.txt` extension, this example explicitly passes the `format` option
   # in order to demonstrate how to handle such situations. Because CSV is the
   # default format for load operations, the option is not actually necessary.
-  # For JSON saved with a +.txt+ extension, however, it would be.
+  # For JSON saved with a `.txt` extension, however, it would be.
   #
   # ### A note about large uploads
   #
@@ -326,7 +326,7 @@ module Gcloud
   #
   # ## Exporting query results to Google Cloud Storage
   #
-  # The example below shows how to pass the +table+ option with a query in order
+  # The example below shows how to pass the `table` option with a query in order
   # to store results in a permanent table. It also shows how to export the
   # result data to a Google Cloud Storage file. In order to follow along, you
   # will need to enable the Google Cloud Storage API in addition to setting up

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -22,7 +22,7 @@ module Gcloud
   # Creates a new +Project+ instance connected to the BigQuery service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +project+::
   #   Identifier for a BigQuery project. If not present, the default project for
@@ -40,11 +40,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/bigquery+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Bigquery::Project
   #
-  # === Example
+  # ### Example
   #
   #   require "gcloud/bigquery"
   #
@@ -63,7 +63,7 @@ module Gcloud
   end
 
   ##
-  # = Google Cloud BigQuery
+  # # Google Cloud BigQuery
   #
   # Google Cloud BigQuery enables super-fast, SQL-like queries against massive
   # datasets, using the processing power of Google's infrastructure. To learn
@@ -84,7 +84,7 @@ module Gcloud
   # first examples without the need to set up billing or to load data (although
   # we'll show you how to do that too.)
   #
-  # == Listing Datasets and Tables
+  # ## Listing Datasets and Tables
   #
   # A BigQuery project holds datasets, which in turn hold tables. Assuming that
   # you have not yet created datasets or tables in your own project, let's
@@ -123,12 +123,12 @@ module Gcloud
   # Now that you know the column names for the Shakespeare table, you can write
   # and run a query.
   #
-  # == Running queries
+  # ## Running queries
   #
   # BigQuery offers both synchronous and asynchronous methods, as explained in
   # {Querying Data}[https://cloud.google.com/bigquery/querying-data].
   #
-  # === Synchronous queries
+  # ### Synchronous queries
   #
   # Let's start with the simpler synchronous approach. Notice that this time you
   # are connecting using your own default project. This is necessary for running
@@ -152,7 +152,7 @@ module Gcloud
   # Reference}[https://cloud.google.com/bigquery/query-reference] for a full
   # listing.
   #
-  # === Asynchronous queries
+  # ### Asynchronous queries
   #
   # Because you probably should not block for most BigQuery operations,
   # including querying as well as importing, exporting, and copying data, the
@@ -183,7 +183,7 @@ module Gcloud
   # 24 hours. See the final example below for a demonstration of how to store
   # query results in a permanent table.
   #
-  # == Creating Datasets and Tables
+  # ## Creating Datasets and Tables
   #
   # The first thing you need to do in a new BigQuery project is to create a
   # Gcloud::Bigquery::Dataset. Datasets hold tables and control access to them.
@@ -218,7 +218,7 @@ module Gcloud
   # Because of the repeated field in this schema, we cannot use the CSV format
   # to load data into the table.
   #
-  # == Loading records
+  # ## Loading records
   #
   # In addition to CSV, data can be imported from files that are formatted as
   # {Newline-delimited JSON}[http://jsonlines.org/] or
@@ -228,7 +228,7 @@ module Gcloud
   # To follow along with these examples, you will need to set up billing on the
   # {Google Developers Console}[https://console.developers.google.com].
   #
-  # === Streaming records
+  # ### Streaming records
   #
   # For situations in which you want new data to be available for querying as
   # soon as possible, inserting individual records directly from your Ruby
@@ -271,7 +271,7 @@ module Gcloud
   # discussion of data consistency in {Streaming Data Into
   # BigQuery}[https://cloud.google.com/bigquery/streaming-data-into-bigquery].
   #
-  # === Uploading a file
+  # ### Uploading a file
   #
   # To follow along with this example, please download the
   # {names.zip}[http://www.ssa.gov/OACT/babynames/names.zip] archive from the
@@ -299,7 +299,7 @@ module Gcloud
   # default format for load operations, the option is not actually necessary.
   # For JSON saved with a +.txt+ extension, however, it would be.
   #
-  # === A note about large uploads
+  # ### A note about large uploads
   #
   # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to
   # upload large files. To avoid this problem, add the
@@ -324,7 +324,7 @@ module Gcloud
   #   gcloud = Gcloud.new
   #   bigquery = gcloud.bigquery
   #
-  # == Exporting query results to Google Cloud Storage
+  # ## Exporting query results to Google Cloud Storage
   #
   # The example below shows how to pass the +table+ option with a query in order
   # to store results in a permanent table. It also shows how to export the

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -90,35 +90,39 @@ module Gcloud
   # you have not yet created datasets or tables in your own project, let's
   # connect to Google's `publicdata` project, and see what you find.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new "publicdata"
-  #   bigquery = gcloud.bigquery
+  # gcloud = Gcloud.new "publicdata"
+  # bigquery = gcloud.bigquery
   #
-  #   bigquery.datasets.count #=> 1
-  #   bigquery.datasets.first.dataset_id #=> "samples"
+  # bigquery.datasets.count #=> 1
+  # bigquery.datasets.first.dataset_id #=> "samples"
   #
-  #   dataset = bigquery.datasets.first
-  #   tables = dataset.tables
+  # dataset = bigquery.datasets.first
+  # tables = dataset.tables
   #
-  #   tables.count #=> 7
-  #   tables.map &:table_id #=> [..., "shakespeare", "trigrams", "wikipedia"]
+  # tables.count #=> 7
+  # tables.map &:table_id #=> [..., "shakespeare", "trigrams", "wikipedia"]
+  # ```
   #
   # In addition listing all datasets and tables in the project, you can also
   # retrieve individual datasets and tables by ID. Let's look at the structure
   # of the `shakespeare` table, which contains an entry for every word in every
   # play written by Shakespeare.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new "publicdata"
-  #   bigquery = gcloud.bigquery
+  # gcloud = Gcloud.new "publicdata"
+  # bigquery = gcloud.bigquery
   #
-  #   dataset = bigquery.dataset "samples"
-  #   table = dataset.table "shakespeare"
+  # dataset = bigquery.dataset "samples"
+  # table = dataset.table "shakespeare"
   #
-  #   table.headers #=> ["word", "word_count", "corpus", "corpus_date"]
-  #   table.rows_count #=> 164656
+  # table.headers #=> ["word", "word_count", "corpus", "corpus_date"]
+  # table.rows_count #=> 164656
+  # ```
   #
   # Now that you know the column names for the Shakespeare table, you can write
   # and run a query.
@@ -134,18 +138,20 @@ module Gcloud
   # are connecting using your own default project. This is necessary for running
   # a query, since queries need to be able to create tables to hold results.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
   #
-  #   sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " +
-  #         "FROM publicdata:samples.shakespeare"
-  #   data = bigquery.query sql
+  # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " +
+  #       "FROM publicdata:samples.shakespeare"
+  # data = bigquery.query sql
   #
-  #   data.count #=> 50
-  #   data.next? #=> false
-  #   data.first #=> {"word"=>"you", "count"=>42}
+  # data.count #=> 50
+  # data.next? #=> false
+  # data.first #=> {"word"=>"you", "count"=>42}
+  # ```
   #
   # The `TOP` function shown above is just one of a variety of functions
   # offered by BigQuery. See the [Query
@@ -160,21 +166,23 @@ module Gcloud
   # approach to running a query, an instance of Gcloud::Bigquery::QueryJob is
   # returned, rather than an instance of Gcloud::Bigquery::QueryData.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
   #
-  #   sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " +
-  #         "FROM publicdata:samples.shakespeare"
-  #   job = bigquery.query_job sql
+  # sql = "SELECT TOP(word, 50) as word, COUNT(*) as count " +
+  #       "FROM publicdata:samples.shakespeare"
+  # job = bigquery.query_job sql
   #
-  #   job.wait_until_done!
-  #   if !job.failed?
-  #     job.query_results.each do |row|
-  #       puts row["word"]
-  #     end
+  # job.wait_until_done!
+  # if !job.failed?
+  #   job.query_results.each do |row|
+  #     puts row["word"]
   #   end
+  # end
+  # ```
   #
   # Once you have determined that the job is done and has not failed, you can
   # obtain an instance of Gcloud::Bigquery::QueryData by calling
@@ -188,11 +196,13 @@ module Gcloud
   # The first thing you need to do in a new BigQuery project is to create a
   # Gcloud::Bigquery::Dataset. Datasets hold tables and control access to them.
   #
-  #   require "gcloud/bigquery"
+  # ```ruby
+  # require "gcloud/bigquery"
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
-  #   dataset = bigquery.create_dataset "my_dataset"
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
+  # dataset = bigquery.create_dataset "my_dataset"
+  # ```
   #
   # Now that you have a dataset, you can use it to create a table. Every table
   # is defined by a schema that may contain nested and repeated fields. The
@@ -201,19 +211,21 @@ module Gcloud
   # [Preparing Data for
   # BigQuery](https://cloud.google.com/bigquery/preparing-data-for-bigquery).)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
-  #   dataset = bigquery.dataset "my_dataset"
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
+  # dataset = bigquery.dataset "my_dataset"
   #
-  #   table = dataset.create_table "people" do |schema|
-  #     schema.string "first_name", mode: :required
-  #     schema.record "cities_lived", mode: :repeated do |nested_schema|
-  #       nested_schema.string "place", mode: :required
-  #       nested_schema.integer "number_of_years", mode: :required
-  #     end
+  # table = dataset.create_table "people" do |schema|
+  #   schema.string "first_name", mode: :required
+  #   schema.record "cities_lived", mode: :repeated do |nested_schema|
+  #     nested_schema.string "place", mode: :required
+  #     nested_schema.integer "number_of_years", mode: :required
   #   end
+  # end
+  # ```
   #
   # Because of the repeated field in this schema, we cannot use the CSV format
   # to load data into the table.
@@ -234,38 +246,40 @@ module Gcloud
   # soon as possible, inserting individual records directly from your Ruby
   # application is a great approach.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
-  #   dataset = bigquery.dataset "my_dataset"
-  #   table = dataset.table "people"
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
+  # dataset = bigquery.dataset "my_dataset"
+  # table = dataset.table "people"
   #
-  #   rows = [
-  #       {
-  #           "first_name" => "Anna",
-  #           "cities_lived" => [
-  #               {
-  #                   "place" => "Stockholm",
-  #                   "number_of_years" => 2
-  #               }
-  #           ]
-  #       },
-  #       {
-  #           "first_name" => "Bob",
-  #           "cities_lived" => [
-  #               {
-  #                   "place" => "Seattle",
-  #                   "number_of_years" => 5
-  #               },
-  #               {
-  #                   "place" => "Austin",
-  #                   "number_of_years" => 6
-  #               }
-  #           ]
-  #       }
-  #   ]
-  #   table.insert rows
+  # rows = [
+  #     {
+  #         "first_name" => "Anna",
+  #         "cities_lived" => [
+  #             {
+  #                 "place" => "Stockholm",
+  #                 "number_of_years" => 2
+  #             }
+  #         ]
+  #     },
+  #     {
+  #         "first_name" => "Bob",
+  #         "cities_lived" => [
+  #             {
+  #                 "place" => "Seattle",
+  #                 "number_of_years" => 5
+  #             },
+  #             {
+  #                 "place" => "Austin",
+  #                 "number_of_years" => 6
+  #             }
+  #         ]
+  #     }
+  # ]
+  # table.insert rows
+  # ```
   #
   # There are some trade-offs involved with streaming, so be sure to read the
   # discussion of data consistency in [Streaming Data Into
@@ -279,19 +293,21 @@ module Gcloud
   # 100 files containing baby name records since the year 1880. A PDF file also
   # contained in the archive specifies the schema used below.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
-  #   dataset = bigquery.dataset "my_dataset"
-  #   table = dataset.create_table "baby_names" do |schema|
-  #     schema.string "name", mode: :required
-  #     schema.string "sex", mode: :required
-  #     schema.integer "number", mode: :required
-  #   end
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
+  # dataset = bigquery.dataset "my_dataset"
+  # table = dataset.create_table "baby_names" do |schema|
+  #   schema.string "name", mode: :required
+  #   schema.string "sex", mode: :required
+  #   schema.integer "number", mode: :required
+  # end
   #
-  #   file = File.open "names/yob2014.txt"
-  #   load_job = table.load file, format: "csv"
+  # file = File.open "names/yob2014.txt"
+  # load_job = table.load file, format: "csv"
+  # ```
   #
   # Because the names data, although formatted as CSV, is distributed in files
   # with a `.txt` extension, this example explicitly passes the `format` option
@@ -311,18 +327,20 @@ module Gcloud
   # are using a version of Faraday at or above 0.9.2, is a workaround for [this
   # gzip issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   # Use httpclient to avoid broken pipe errors with large uploads
-  #   Faraday.default_adapter = :httpclient
+  # # Use httpclient to avoid broken pipe errors with large uploads
+  # Faraday.default_adapter = :httpclient
   #
-  #   # Only add the following statement if using Faraday >= 0.9.2
-  #   # Override gzip middleware with no-op for httpclient
-  #   Faraday::Response.register_middleware :gzip =>
-  #                                           Faraday::Response::Middleware
+  # # Only add the following statement if using Faraday >= 0.9.2
+  # # Override gzip middleware with no-op for httpclient
+  # Faraday::Response.register_middleware :gzip =>
+  #                                         Faraday::Response::Middleware
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
+  # ```
   #
   # ## Exporting query results to Google Cloud Storage
   #
@@ -332,37 +350,39 @@ module Gcloud
   # will need to enable the Google Cloud Storage API in addition to setting up
   # billing.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   bigquery = gcloud.bigquery
-  #   dataset = bigquery.dataset "my_dataset"
-  #   source_table = dataset.table "baby_names"
-  #   result_table = dataset.create_table "baby_names_results"
+  # gcloud = Gcloud.new
+  # bigquery = gcloud.bigquery
+  # dataset = bigquery.dataset "my_dataset"
+  # source_table = dataset.table "baby_names"
+  # result_table = dataset.create_table "baby_names_results"
   #
-  #   sql = "SELECT name, number as count " +
-  #         "FROM baby_names " +
-  #         "WHERE name CONTAINS 'Sam' " +
-  #         "ORDER BY count DESC"
-  #   query_job = dataset.query_job sql, table: result_table
+  # sql = "SELECT name, number as count " +
+  #       "FROM baby_names " +
+  #       "WHERE name CONTAINS 'Sam' " +
+  #       "ORDER BY count DESC"
+  # query_job = dataset.query_job sql, table: result_table
   #
-  #   query_job.wait_until_done!
+  # query_job.wait_until_done!
   #
-  #   if !query_job.failed?
+  # if !query_job.failed?
   #
-  #     storage = gcloud.storage
-  #     bucket_id = "bigquery-exports-#{SecureRandom.uuid}"
-  #     bucket = storage.create_bucket bucket_id
-  #     extract_url = "gs://#{bucket.id}/baby-names-sam.csv"
+  #   storage = gcloud.storage
+  #   bucket_id = "bigquery-exports-#{SecureRandom.uuid}"
+  #   bucket = storage.create_bucket bucket_id
+  #   extract_url = "gs://#{bucket.id}/baby-names-sam.csv"
   #
-  #     extract_job = result_table.extract extract_url
+  #   extract_job = result_table.extract extract_url
   #
-  #     extract_job.wait_until_done!
+  #   extract_job.wait_until_done!
   #
-  #     # Download to local filesystem
-  #     bucket.files.first.download "baby-names-sam.csv"
+  #   # Download to local filesystem
+  #   bucket.files.first.download "baby-names-sam.csv"
   #
-  #   end
+  # end
+  # ```
   #
   # If a table you wish to export contains a large amount of data, you can pass
   # a wildcard URI to export to multiple files (for sharding), or an array of

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -75,7 +75,7 @@ module Gcloud
   # the project and credential information to connect to the BigQuery service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you. You can read more about the options for connecting in the
-  # [Authentication Guide](link:AUTHENTICATION.md).
+  # [Authentication Guide](../AUTHENTICATION).
   #
   # To help you get started quickly, the first few examples below use a public
   # dataset provided by Google. As soon as you have [signed

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -32,8 +32,8 @@ module Gcloud
   #   readable. (+String+ or +Hash+)
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -67,19 +67,19 @@ module Gcloud
   #
   # Google Cloud BigQuery enables super-fast, SQL-like queries against massive
   # datasets, using the processing power of Google's infrastructure. To learn
-  # more, read {What is
-  # BigQuery?}[https://cloud.google.com/bigquery/what-is-bigquery].
+  # more, read [What is
+  # BigQuery?](https://cloud.google.com/bigquery/what-is-bigquery).
   #
   # Gcloud's goal is to provide an API that is familiar and comfortable to
   # Rubyists. Authentication is handled by Gcloud#bigquery. You can provide
   # the project and credential information to connect to the BigQuery service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you. You can read more about the options for connecting in the
-  # {Authentication Guide}[link:AUTHENTICATION.md].
+  # [Authentication Guide](link:AUTHENTICATION.md).
   #
   # To help you get started quickly, the first few examples below use a public
-  # dataset provided by Google. As soon as you have {signed
-  # up}[https://cloud.google.com/bigquery/sign-up] to use BigQuery, and provided
+  # dataset provided by Google. As soon as you have [signed
+  # up](https://cloud.google.com/bigquery/sign-up) to use BigQuery, and provided
   # that you stay in the free tier for queries, you should be able to run these
   # first examples without the need to set up billing or to load data (although
   # we'll show you how to do that too.)
@@ -126,7 +126,7 @@ module Gcloud
   # ## Running queries
   #
   # BigQuery offers both synchronous and asynchronous methods, as explained in
-  # {Querying Data}[https://cloud.google.com/bigquery/querying-data].
+  # [Querying Data](https://cloud.google.com/bigquery/querying-data).
   #
   # ### Synchronous queries
   #
@@ -148,8 +148,8 @@ module Gcloud
   #   data.first #=> {"word"=>"you", "count"=>42}
   #
   # The +TOP+ function shown above is just one of a variety of functions
-  # offered by BigQuery. See the {Query
-  # Reference}[https://cloud.google.com/bigquery/query-reference] for a full
+  # offered by BigQuery. See the [Query
+  # Reference](https://cloud.google.com/bigquery/query-reference) for a full
   # listing.
   #
   # ### Asynchronous queries
@@ -198,8 +198,8 @@ module Gcloud
   # is defined by a schema that may contain nested and repeated fields. The
   # example below shows a schema with a repeated record field named
   # +cities_lived+. (For more information about nested and repeated fields, see
-  # {Preparing Data for
-  # BigQuery}[https://cloud.google.com/bigquery/preparing-data-for-bigquery].)
+  # [Preparing Data for
+  # BigQuery](https://cloud.google.com/bigquery/preparing-data-for-bigquery).)
   #
   #   require "gcloud"
   #
@@ -221,12 +221,12 @@ module Gcloud
   # ## Loading records
   #
   # In addition to CSV, data can be imported from files that are formatted as
-  # {Newline-delimited JSON}[http://jsonlines.org/] or
-  # {Avro}[http://avro.apache.org/], or from a Google Cloud Datastore backup. It
+  # [Newline-delimited JSON](http://jsonlines.org/) or
+  # [Avro](http://avro.apache.org/), or from a Google Cloud Datastore backup. It
   # can also be "streamed" into BigQuery.
   #
   # To follow along with these examples, you will need to set up billing on the
-  # {Google Developers Console}[https://console.developers.google.com].
+  # [Google Developers Console](https://console.developers.google.com).
   #
   # ### Streaming records
   #
@@ -268,13 +268,13 @@ module Gcloud
   #   table.insert rows
   #
   # There are some trade-offs involved with streaming, so be sure to read the
-  # discussion of data consistency in {Streaming Data Into
-  # BigQuery}[https://cloud.google.com/bigquery/streaming-data-into-bigquery].
+  # discussion of data consistency in [Streaming Data Into
+  # BigQuery](https://cloud.google.com/bigquery/streaming-data-into-bigquery).
   #
   # ### Uploading a file
   #
   # To follow along with this example, please download the
-  # {names.zip}[http://www.ssa.gov/OACT/babynames/names.zip] archive from the
+  # [names.zip](http://www.ssa.gov/OACT/babynames/names.zip) archive from the
   # U.S. Social Security Administration. Inside the archive you will find over
   # 100 files containing baby name records since the year 1880. A PDF file also
   # contained in the archive specifies the schema used below.
@@ -303,13 +303,13 @@ module Gcloud
   #
   # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to
   # upload large files. To avoid this problem, add the
-  # {httpclient}[https://rubygems.org/gems/httpclient] gem to your project, and
+  # [httpclient](https://rubygems.org/gems/httpclient) gem to your project, and
   # the line (or lines) of configuration shown below. These lines must execute
   # after you require gcloud but before you make your first gcloud connection.
-  # The first statement configures {Faraday}[https://rubygems.org/gems/faraday]
+  # The first statement configures [Faraday](https://rubygems.org/gems/faraday)
   # to use httpclient. The second statement, which should only be added if you
-  # are using a version of Faraday at or above 0.9.2, is a workaround for {this
-  # gzip issue}[https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367].
+  # are using a version of Faraday at or above 0.9.2, is a workaround for [this
+  # gzip issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
   #
   #   require "gcloud"
   #
@@ -366,8 +366,8 @@ module Gcloud
   #
   # If a table you wish to export contains a large amount of data, you can pass
   # a wildcard URI to export to multiple files (for sharding), or an array of
-  # URIs (for partitioning), or both. See {Exporting Data From
-  # BigQuery}[https://cloud.google.com/bigquery/exporting-data-from-bigquery]
+  # URIs (for partitioning), or both. See [Exporting Data From
+  # BigQuery](https://cloud.google.com/bigquery/exporting-data-from-bigquery)
   # for details.
   #
   module Bigquery

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 require "gcloud/bigquery/project"
 
-#--
-# Google Cloud BigQuery
 module Gcloud
   ##
   # Creates a new `Project` instance connected to the BigQuery service.

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -21,17 +21,17 @@ require "digest/md5"
 module Gcloud
   module Bigquery
     ##
-    # Represents the connection to Bigquery,
+    # @private Represents the connection to Bigquery,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v2"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
-      def initialize project, credentials #:nodoc:
+      def initialize project, credentials
         @project = project
         @credentials = credentials
         @client = Google::APIClient.new application_name:    "gcloud-ruby",
@@ -338,7 +338,7 @@ module Gcloud
         default_table_ref.merge str_table_ref
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
 
@@ -554,7 +554,7 @@ module Gcloud
         }
       end
 
-      def create_disposition str #:nodoc:
+      def create_disposition str
         { "create_if_needed" => "CREATE_IF_NEEDED",
           "createifneeded" => "CREATE_IF_NEEDED",
           "if_needed" => "CREATE_IF_NEEDED",
@@ -564,7 +564,7 @@ module Gcloud
           "never" => "CREATE_NEVER" }[str.to_s.downcase]
       end
 
-      def write_disposition str #:nodoc:
+      def write_disposition str
         { "write_truncate" => "WRITE_TRUNCATE",
           "writetruncate" => "WRITE_TRUNCATE",
           "truncate" => "WRITE_TRUNCATE",

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "pathname"
 require "gcloud/version"

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -322,7 +322,7 @@ module Gcloud
       end
 
       ##
-      # Extracts at least +tbl+ group, and possibly +dts+ and +prj+ groups,
+      # Extracts at least `tbl` group, and possibly `dts` and `prj` groups,
       # from strings in the formats: "my_table", "my_dataset.my_table", or
       # "my-project:my_dataset.my_table". Then merges project_id and
       # dataset_id from the default table if they are missing.

--- a/lib/gcloud/bigquery/copy_job.rb
+++ b/lib/gcloud/bigquery/copy_job.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Bigquery

--- a/lib/gcloud/bigquery/copy_job.rb
+++ b/lib/gcloud/bigquery/copy_job.rb
@@ -16,7 +16,7 @@
 module Gcloud
   module Bigquery
     ##
-    # = CopyJob
+    # # CopyJob
     #
     # A {Job} subclass representing a copy operation that may be performed on a
     # {Table}. A CopyJob instance is created when you call {Table#copy}.

--- a/lib/gcloud/bigquery/copy_job.rb
+++ b/lib/gcloud/bigquery/copy_job.rb
@@ -49,7 +49,7 @@ module Gcloud
       end
 
       ##
-      # Checks if the create disposition for the job is +CREATE_IF_NEEDED+,
+      # Checks if the create disposition for the job is `CREATE_IF_NEEDED`,
       # which provides the following behavior: If the table does not exist,
       # the copy operation creates the table. This is the default.
       def create_if_needed?
@@ -58,7 +58,7 @@ module Gcloud
       end
 
       ##
-      # Checks if the create disposition for the job is +CREATE_NEVER+, which
+      # Checks if the create disposition for the job is `CREATE_NEVER`, which
       # provides the following behavior: The table must already exist; if it
       # does not, an error is returned in the job result.
       def create_never?
@@ -67,7 +67,7 @@ module Gcloud
       end
 
       ##
-      # Checks if the write disposition for the job is +WRITE_TRUNCATE+, which
+      # Checks if the write disposition for the job is `WRITE_TRUNCATE`, which
       # provides the following behavior: If the table already exists, the copy
       # operation overwrites the table data.
       def write_truncate?
@@ -76,7 +76,7 @@ module Gcloud
       end
 
       ##
-      # Checks if the write disposition for the job is +WRITE_APPEND+, which
+      # Checks if the write disposition for the job is `WRITE_APPEND`, which
       # provides the following behavior: If the table already exists, the copy
       # operation appends the data to the table.
       def write_append?
@@ -85,7 +85,7 @@ module Gcloud
       end
 
       ##
-      # Checks if the write disposition for the job is +WRITE_EMPTY+, which
+      # Checks if the write disposition for the job is `WRITE_EMPTY`, which
       # provides the following behavior: If the table already exists and
       # contains data, the job will have an error. This is the default.
       def write_empty?

--- a/lib/gcloud/bigquery/copy_job.rb
+++ b/lib/gcloud/bigquery/copy_job.rb
@@ -18,19 +18,18 @@ module Gcloud
     ##
     # = CopyJob
     #
-    # A Job subclass representing a copy operation that may be performed on a
-    # Table. A CopyJob instance is created when you call Table#copy.
+    # A {Job} subclass representing a copy operation that may be performed on a
+    # {Table}. A CopyJob instance is created when you call {Table#copy}.
     #
-    # See {Copying an Existing
-    # Table}[https://cloud.google.com/bigquery/docs/tables#copyingtable]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/docs/tables#copyingtable Copying an
+    #   Existing Table
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class CopyJob < Job
       ##
       # The table from which data is copied. This is the table on
-      # which Table#copy was called. Returns a Table instance.
+      # which {Table#copy} was called. Returns a {Table} instance.
       def source
         table = config["copy"]["sourceTable"]
         return nil unless table
@@ -40,7 +39,7 @@ module Gcloud
       end
 
       ##
-      # The table to which data is copied. Returns a Table instance.
+      # The table to which data is copied. Returns a {Table} instance.
       def destination
         table = config["copy"]["destinationTable"]
         return nil unless table

--- a/lib/gcloud/bigquery/credentials.rb
+++ b/lib/gcloud/bigquery/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Bigquery
     ##
-    # Represents the Oauth2 signing logic for Bigquery.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the Oauth2 signing logic for Bigquery.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/bigquery"]
       PATH_ENV_VARS = %w(BIGQUERY_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(BIGQUERY_KEYFILE_JSON GCLOUD_KEYFILE_JSON

--- a/lib/gcloud/bigquery/credentials.rb
+++ b/lib/gcloud/bigquery/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/credentials"
 

--- a/lib/gcloud/bigquery/data.rb
+++ b/lib/gcloud/bigquery/data.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/bigquery/data.rb
+++ b/lib/gcloud/bigquery/data.rb
@@ -18,7 +18,7 @@ require "delegate"
 module Gcloud
   module Bigquery
     ##
-    # = Data
+    # # Data
     #
     # Represents {Table} Data as a list of name/value pairs.
     # Also contains metadata such as +etag+ and +total+.

--- a/lib/gcloud/bigquery/data.rb
+++ b/lib/gcloud/bigquery/data.rb
@@ -21,7 +21,7 @@ module Gcloud
     # # Data
     #
     # Represents {Table} Data as a list of name/value pairs.
-    # Also contains metadata such as +etag+ and +total+.
+    # Also contains metadata such as `etag` and `total`.
     class Data < DelegateClass(::Array)
       ##
       # @private The {Table} object the data belongs to.

--- a/lib/gcloud/bigquery/data.rb
+++ b/lib/gcloud/bigquery/data.rb
@@ -20,18 +20,19 @@ module Gcloud
     ##
     # = Data
     #
-    # Represents Table Data as a list of name/value pairs.
+    # Represents {Table} Data as a list of name/value pairs.
     # Also contains metadata such as +etag+ and +total+.
     class Data < DelegateClass(::Array)
       ##
-      # The Table object the data belongs to.
-      attr_accessor :table #:nodoc:
+      # @private The {Table} object the data belongs to.
+      attr_accessor :table
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
-      def initialize arr = [] #:nodoc:
+      # @private
+      def initialize arr = []
         @table = nil
         @gapi = {}
         super arr
@@ -79,8 +80,8 @@ module Gcloud
       end
 
       ##
-      # New Data from a response object.
-      def self.from_response resp, table #:nodoc:
+      # @private New Data from a response object.
+      def self.from_response resp, table
         formatted_rows = format_rows resp.data["rows"], table.fields
 
         data = new formatted_rows

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -23,7 +23,7 @@ require "gcloud/bigquery/dataset/access"
 module Gcloud
   module Bigquery
     ##
-    # = Dataset
+    # # Dataset
     #
     # Represents a Dataset. A dataset is a grouping mechanism that holds zero or
     # more tables. Datasets are the lowest level unit of access control; you

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -247,8 +247,8 @@ module Gcloud
 
       ##
       # Sets the access rules for a Dataset using the Google Cloud Datastore API
-      # data structure of an array of hashes. See {BigQuery Access
-      # Control}[https://cloud.google.com/bigquery/access-control] for more
+      # data structure of an array of hashes. See [BigQuery Access
+      # Control](https://cloud.google.com/bigquery/access-control) for more
       # information.
       #
       # This method is provided for advanced usage of managing the access rules.
@@ -308,8 +308,8 @@ module Gcloud
 
       ##
       # Creates a new table. If you are adapting existing code that was written
-      # for the {Rest API
-      # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource],
+      # for the [Rest API
+      # ](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource),
       # you can pass the table's schema as a hash (see example.)
       #
       # @param [String] table_id The ID of the table. The ID must contain only
@@ -319,8 +319,8 @@ module Gcloud
       # @param [String] description A user-friendly description of the table.
       # @param [Hash] schema A hash specifying fields and data types for the
       #   table. A block may be passed instead (see examples.) For the format of
-      #   this hash, see the {Tables resource
-      #   }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
+      #   this hash, see the [Tables resource
+      #   ](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource)
       #   .
       #
       # @return [Gcloud::Bigquery::Table]
@@ -530,14 +530,14 @@ module Gcloud
       end
 
       ##
-      # Queries data using the {asynchronous
-      # method}[https://cloud.google.com/bigquery/querying-data].
+      # Queries data using the [asynchronous
+      # method](https://cloud.google.com/bigquery/querying-data).
       #
       # Sets the current dataset as the default dataset in the query. Useful for
       # using unqualified table names.
       #
-      # @param [String] query A query string, following the BigQuery {query
-      #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
+      # @param [String] query A query string, following the BigQuery [query
+      #   syntax](https://cloud.google.com/bigquery/query-reference), of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
       # @param [String] priority Specifies a priority for the query. Possible
@@ -546,8 +546,8 @@ module Gcloud
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
-      #   For more information, see {query
-      #   caching}[https://developers.google.com/bigquery/querying-data].
+      #   For more information, see [query
+      #   caching](https://developers.google.com/bigquery/querying-data).
       # @param [Table] table The destination table where the query results
       #   should be stored. If not present, a new table will be created to store
       #   the results.
@@ -608,14 +608,14 @@ module Gcloud
       end
 
       ##
-      # Queries data using the {synchronous
-      # method}[https://cloud.google.com/bigquery/querying-data].
+      # Queries data using the [synchronous
+      # method](https://cloud.google.com/bigquery/querying-data).
       #
       # Sets the current dataset as the default dataset in the query. Useful for
       # using unqualified table names.
       #
-      # @param [String] query A query string, following the BigQuery {query
-      #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
+      # @param [String] query A query string, following the BigQuery [query
+      #   syntax](https://cloud.google.com/bigquery/query-reference), of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
       # @param [Integer] max The maximum number of rows of data to return per
@@ -637,8 +637,8 @@ module Gcloud
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
-      #   For more information, see {query
-      #   caching}[https://developers.google.com/bigquery/querying-data].
+      #   For more information, see [query
+      #   caching](https://developers.google.com/bigquery/querying-data).
       #
       # @return [Gcloud::Bigquery::QueryData]
       #

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -277,13 +277,13 @@ module Gcloud
 
       ##
       # Permanently deletes the dataset. The dataset must be empty before it can
-      # be deleted unless the +force+ option is set to +true+.
+      # be deleted unless the `force` option is set to `true`.
       #
-      # @param [Boolean] force If +true+, delete all the tables in the dataset.
-      #   If +false+ and the dataset contains tables, the request will fail.
-      #   Default is +false+.
+      # @param [Boolean] force If `true`, delete all the tables in the dataset.
+      #   If `false` and the dataset contains tables, the request will fail.
+      #   Default is `false`.
       #
-      # @return [Boolean] Returns +true+ if the dataset was deleted.
+      # @return [Boolean] Returns `true` if the dataset was deleted.
       #
       # @example
       #   require "gcloud"
@@ -453,7 +453,7 @@ module Gcloud
       # @param [String] table_id The ID of a table.
       #
       # @return [Gcloud::Bigquery::Table, Gcloud::Bigquery::View, nil] Returns
-      #   +nil+ if the table does not exist
+      #   `nil` if the table does not exist
       #
       # @example
       #   require "gcloud"
@@ -541,8 +541,8 @@ module Gcloud
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
       # @param [String] priority Specifies a priority for the query. Possible
-      #   values include +INTERACTIVE+ and +BATCH+. The default value is
-      #   +INTERACTIVE+.
+      #   values include `INTERACTIVE` and `BATCH`. The default value is
+      #   `INTERACTIVE`.
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
@@ -555,23 +555,23 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
-      #   * +needed+ - Create the table if it does not exist.
-      #   * +never+ - The table must already exist. A 'notFound' error is
+      #   * `needed` - Create the table if it does not exist.
+      #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
       # @param [String] write Specifies the action that occurs if the
       #   destination table already exists.
       #
       #   The following values are supported:
-      #   * +truncate+ - BigQuery overwrites the table data.
-      #   * +append+ - BigQuery appends the data to the table.
-      #   * +empty+ - A 'duplicate' error is returned in the job result if the
+      #   * `truncate` - BigQuery overwrites the table data.
+      #   * `append` - BigQuery appends the data to the table.
+      #   * `empty` - A 'duplicate' error is returned in the job result if the
       #     table exists and contains data.
-      # @param [Boolean] large_results If +true+, allows the query to produce
+      # @param [Boolean] large_results If `true`, allows the query to produce
       #   arbitrarily large result tables at a slight cost in performance.
-      #   Requires +table+ parameter to be set.
+      #   Requires `table` parameter to be set.
       # @param [Boolean] flatten Flattens all nested and repeated fields in the
-      #   query results. The default value is +true+. +large_results+ parameter
-      #   must be +true+ if this is set to +false+.
+      #   query results. The default value is `true`. `large_results` parameter
+      #   must be `true` if this is set to `false`.
       #
       # @return [Gcloud::Bigquery::QueryJob]
       #
@@ -630,10 +630,10 @@ module Gcloud
       #   longer to run than the timeout value, the call returns without any
       #   results and with QueryData#complete? set to false. The default value
       #   is 10000 milliseconds (10 seconds).
-      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      # @param [Boolean] dryrun If set to `true`, BigQuery doesn't run the job.
       #   Instead, if the query is valid, BigQuery returns statistics about the
       #   job such as how many bytes would be processed. If the query is
-      #   invalid, an error returns. The default value is +false+.
+      #   invalid, an error returns. The default value is `false`.
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "json"
 require "gcloud/bigquery/errors"

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -30,6 +30,7 @@ module Gcloud
     # cannot control access at the table level. A dataset is contained within a
     # specific project.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -41,16 +42,16 @@ module Gcloud
     #
     class Dataset
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Dataset object.
-      def initialize #:nodoc:
+      # @private Create an empty Dataset object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -60,7 +61,7 @@ module Gcloud
       # The ID must contain only letters (a-z, A-Z), numbers (0-9),
       # or underscores (_). The maximum length is 1,024 characters.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def dataset_id
         @gapi["datasetReference"]["datasetId"]
@@ -69,16 +70,17 @@ module Gcloud
       ##
       # The ID of the project containing this dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def project_id
         @gapi["datasetReference"]["projectId"]
       end
 
       ##
+      # @private
       # The gapi fragment containing the Project ID and Dataset ID as a
       # camel-cased hash.
-      def dataset_ref #:nodoc:
+      def dataset_ref
         dataset_ref = @gapi["datasetReference"]
         dataset_ref = dataset_ref.to_hash if dataset_ref.respond_to? :to_hash
         dataset_ref
@@ -87,7 +89,7 @@ module Gcloud
       ##
       # A descriptive name for the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name
         @gapi["friendlyName"]
@@ -96,7 +98,7 @@ module Gcloud
       ##
       # Updates the descriptive name for the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name= new_name
         patch_gapi! name: new_name
@@ -105,7 +107,7 @@ module Gcloud
       ##
       # A string hash of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def etag
         ensure_full_data!
@@ -115,7 +117,7 @@ module Gcloud
       ##
       # A URL that can be used to access the dataset using the REST API.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def api_url
         ensure_full_data!
@@ -125,7 +127,7 @@ module Gcloud
       ##
       # A user-friendly description of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description
         ensure_full_data!
@@ -135,7 +137,7 @@ module Gcloud
       ##
       # Updates the user-friendly description of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description= new_description
         patch_gapi! description: new_description
@@ -144,7 +146,7 @@ module Gcloud
       ##
       # The default lifetime of all tables in the dataset, in milliseconds.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def default_expiration
         ensure_full_data!
@@ -155,7 +157,7 @@ module Gcloud
       # Updates the default lifetime of all tables in the dataset, in
       # milliseconds.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def default_expiration= new_default_expiration
         patch_gapi! default_expiration: new_default_expiration
@@ -164,7 +166,7 @@ module Gcloud
       ##
       # The time when this dataset was created.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def created_at
         ensure_full_data!
@@ -174,7 +176,7 @@ module Gcloud
       ##
       # The date when this dataset or any of its tables was last modified.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def modified_at
         ensure_full_data!
@@ -185,7 +187,7 @@ module Gcloud
       # The geographic location where the dataset should reside. Possible
       # values include EU and US. The default value is US.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def location
         ensure_full_data!
@@ -195,13 +197,13 @@ module Gcloud
       ##
       # Retrieves the access rules for a Dataset using the Google Cloud
       # Datastore API data structure of an array of hashes. The rules can be
-      # updated when passing a block, see Dataset::Access for all the methods
-      # available. See {BigQuery Access
-      # Control}[https://cloud.google.com/bigquery/access-control] for more
-      # information.
+      # updated when passing a block, see {Dataset::Access} for all the methods
+      # available.
       #
-      # === Examples
+      # @see https://cloud.google.com/bigquery/access-control BigQuery Access
+      #   Control
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -217,8 +219,7 @@ module Gcloud
       #                  #    {"role"=>"OWNER",
       #                  #     "userByEmail"=>"123456789-...com"}]
       #
-      # Manage the access rules by passing a block.
-      #
+      # @example Manage the access rules by passing a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -251,11 +252,10 @@ module Gcloud
       # information.
       #
       # This method is provided for advanced usage of managing the access rules.
-      # Calling #access with a block is the preferred way to manage access
+      # Calling {#access} with a block is the preferred way to manage access
       # rules.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -279,19 +279,13 @@ module Gcloud
       # Permanently deletes the dataset. The dataset must be empty before it can
       # be deleted unless the +force+ option is set to +true+.
       #
-      # === Parameters
+      # @param [Boolean] force If +true+, delete all the tables in the dataset.
+      #   If +false+ and the dataset contains tables, the request will fail.
+      #   Default is +false+.
       #
-      # +force+::
-      #   If +true+, delete all the tables in the dataset. If +false+ and the
-      #   dataset contains tables, the request will fail. Default is +false+.
-      #   (+Boolean+)
+      # @return [Boolean] Returns +true+ if the dataset was deleted.
       #
-      # === Returns
-      #
-      # +true+ if the dataset was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -300,7 +294,7 @@ module Gcloud
       #   dataset = bigquery.dataset "my_dataset"
       #   dataset.delete
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def delete force: nil
         ensure_connection!
@@ -313,31 +307,25 @@ module Gcloud
       end
 
       ##
-      # Creates a new table.
+      # Creates a new table. If you are adapting existing code that was written
+      # for the {Rest API
+      # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource],
+      # you can pass the table's schema as a hash (see example.)
       #
-      # === Parameters
-      #
-      # +table_id+::
-      #   The ID of the table. The ID must contain only letters (a-z, A-Z),
-      #   numbers (0-9), or underscores (_). The maximum length is 1,024
-      #   characters. (+String+)
-      # +name+::
-      #   A descriptive name for the table. (+String+)
-      # +description+::
-      #   A user-friendly description of the table. (+String+)
-      # +schema+::
-      #   A hash specifying fields and data types for the table. A block may be
-      #   passed instead (see examples.) For the format of this hash, see the
-      #   {Tables resource
+      # @param [String] table_id The ID of the table. The ID must contain only
+      #   letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum
+      #   length is 1,024 characters.
+      # @param [String] name A descriptive name for the table.
+      # @param [String] description A user-friendly description of the table.
+      # @param [Hash] schema A hash specifying fields and data types for the
+      #   table. A block may be passed instead (see examples.) For the format of
+      #   this hash, see the {Tables resource
       #   }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
-      #   . (+Hash+)
+      #   .
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Table]
       #
-      # Gcloud::Bigquery::Table
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -345,8 +333,7 @@ module Gcloud
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.create_table "my_table"
       #
-      # You can also pass name and description options.
-      #
+      # @example You can also pass name and description options.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -356,8 +343,7 @@ module Gcloud
       #                                name: "My Table",
       #                                description: "A description of my table."
       #
-      # You can define the table's schema using a block.
-      #
+      # @example You can define the table's schema using a block.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -371,10 +357,7 @@ module Gcloud
       #     end
       #   end
       #
-      # Or, if you are adapting existing code that was written for the {Rest API
-      # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource],
-      # you can pass the table's schema as a hash.
-      #
+      # @example You can pass the table's schema as a hash.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -409,7 +392,7 @@ module Gcloud
       #   }
       #   table = dataset.create_table "my_table", schema: schema
       #
-      # :category: Table
+      # @!group Table
       #
       def create_table table_id, name: nil, description: nil, schema: nil
         ensure_connection!
@@ -428,26 +411,17 @@ module Gcloud
       ##
       # Creates a new view table from the given query.
       #
-      # === Parameters
+      # @param [String] table_id The ID of the view table. The ID must contain
+      #   only letters (a-z, A-Z), numbers (0-9), or underscores (_). The
+      #   maximum length is 1,024 characters.
+      # @param [String] query The query that BigQuery executes when the view is
+      #   referenced.
+      # @param [String] name A descriptive name for the table.
+      # @param [String] description A user-friendly description of the table.
       #
-      # +table_id+::
-      #   The ID of the view table. The ID must contain only letters (a-z, A-Z),
-      #   numbers (0-9), or underscores (_). The maximum length is 1,024
-      #   characters. (+String+)
-      # +query+::
-      #   The query that BigQuery executes when the view is referenced.
-      #   (+String+)
-      # +name+::
-      #   A descriptive name for the table. (+String+)
-      # +description+::
-      #   A user-friendly description of the table. (+String+)
+      # @return [Gcloud::Bigquery::View]
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::View
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -456,8 +430,7 @@ module Gcloud
       #   view = dataset.create_view "my_view",
       #             "SELECT name, age FROM [proj:dataset.users]"
       #
-      # A name and description can be provided:
-      #
+      # @example A name and description can be provided:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -467,7 +440,7 @@ module Gcloud
       #             "SELECT name, age FROM [proj:dataset.users]",
       #             name: "My View", description: "This is my view"
       #
-      # :category: Table
+      # @!group Table
       #
       def create_view table_id, query, name: nil, description: nil
         options = { query: query, name: name, description: description }
@@ -477,18 +450,12 @@ module Gcloud
       ##
       # Retrieves an existing table by ID.
       #
-      # === Parameters
+      # @param [String] table_id The ID of a table.
       #
-      # +table_id+::
-      #   The ID of a table. (+String+)
+      # @return [Gcloud::Bigquery::Table, Gcloud::Bigquery::View, nil] Returns
+      #   +nil+ if the table does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::Table or Gcloud::Bigquery::View or nil if the table
-      # does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -497,7 +464,7 @@ module Gcloud
       #   table = dataset.table "my_table"
       #   puts table.name
       #
-      # :category: Table
+      # @!group Table
       #
       def table table_id
         ensure_connection!
@@ -512,21 +479,14 @@ module Gcloud
       ##
       # Retrieves the list of tables belonging to the dataset.
       #
-      # === Parameters
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of tables to return.
       #
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of tables to return. (+Integer+)
+      # @return [Array<Gcloud::Bigquery::Table>, Array<Gcloud::Bigquery::View>]
+      #   (See {Gcloud::Bigquery::Table::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Bigquery::Table or Gcloud::Bigquery::View
-      # (See Gcloud::Bigquery::Table::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -537,9 +497,7 @@ module Gcloud
       #     puts table.name
       #   end
       #
-      # If you have a significant number of tables, you may need to paginate
-      # through them: (See Dataset::List#token)
-      #
+      # @example With pagination: (See {Dataset::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -558,7 +516,7 @@ module Gcloud
       #     tmp_tables = dataset.tables token: tmp_tables.token
       #   end
       #
-      # :category: Table
+      # @!group Table
       #
       def tables token: nil, max: nil
         ensure_connection!
@@ -578,55 +536,46 @@ module Gcloud
       # Sets the current dataset as the default dataset in the query. Useful for
       # using unqualified table names.
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +priority+::
-      #   Specifies a priority for the query. Possible values include
-      #   +INTERACTIVE+ and +BATCH+. The default value is +INTERACTIVE+.
-      #   (+String+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is +true+. (+Boolean+)
-      # +table+::
-      #   The destination table where the query results should be stored. If not
-      #   present, a new table will be created to store the results. (+Table+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [String] priority Specifies a priority for the query. Possible
+      #   values include +INTERACTIVE+ and +BATCH+. The default value is
+      #   +INTERACTIVE+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [Table] table The destination table where the query results
+      #   should be stored. If not present, a new table will be created to store
+      #   the results.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies the action that occurs if the destination table already
-      #   exists. (+String+)
+      # @param [String] write Specifies the action that occurs if the
+      #   destination table already exists.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - A 'duplicate' error is returned in the job result if the
       #     table exists and contains data.
-      # +large_results+::
-      #   If +true+, allows the query to produce arbitrarily large result tables
-      #   at a slight cost in performance. Requires +table+ parameter to be set.
-      #   (+Boolean+)
-      # +flatten+::
-      #   Flattens all nested and repeated fields in the query results. The
-      #   default value is +true+. +large_results+ parameter must be +true+ if
-      #   this is set to +false+. (+Boolean+)
+      # @param [Boolean] large_results If +true+, allows the query to produce
+      #   arbitrarily large result tables at a slight cost in performance.
+      #   Requires +table+ parameter to be set.
+      # @param [Boolean] flatten Flattens all nested and repeated fields in the
+      #   query results. The default value is +true+. +large_results+ parameter
+      #   must be +true+ if this is set to +false+.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryJob]
       #
-      # Gcloud::Bigquery::QueryJob
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -641,7 +590,7 @@ module Gcloud
       #     end
       #   end
       #
-      # :category: Data
+      # @!group Data
       #
       def query_job query, priority: "INTERACTIVE", cache: true, table: nil,
                     create: nil, write: nil, large_results: nil, flatten: nil
@@ -665,45 +614,35 @@ module Gcloud
       # Sets the current dataset as the default dataset in the query. Useful for
       # using unqualified table names.
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +max+::
-      #   The maximum number of rows of data to return per page of results.
-      #   Setting this flag to a small value such as 1000 and then paging
-      #   through results might improve reliability when the query result set is
-      #   large. In addition to this limit, responses are also limited to 10 MB.
-      #   By default, there is no maximum row count, and only the byte limit
-      #   applies. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   the request times out and returns. Note that this is only a timeout
-      #   for the request, not the query. If the query takes longer to run than
-      #   the timeout value, the call returns without any results and with
-      #   QueryData#complete? set to false. The default value is 10000
-      #   milliseconds (10 seconds). (+Integer+)
-      # +dryrun+::
-      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
-      #   is valid, BigQuery returns statistics about the job such as how many
-      #   bytes would be processed. If the query is invalid, an error returns.
-      #   The default value is +false+. (+Boolean+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is true. For more information, see
-      #   {query caching}[https://developers.google.com/bigquery/querying-data].
-      #   (+Boolean+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [Integer] max The maximum number of rows of data to return per
+      #   page of results. Setting this flag to a small value such as 1000 and
+      #   then paging through results might improve reliability when the query
+      #   result set is large. In addition to this limit, responses are also
+      #   limited to 10 MB. By default, there is no maximum row count, and only
+      #   the byte limit applies.
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      #   Instead, if the query is valid, BigQuery returns statistics about the
+      #   job such as how many bytes would be processed. If the query is
+      #   invalid, an error returns. The default value is +false+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -714,7 +653,7 @@ module Gcloud
       #     puts row["name"]
       #   end
       #
-      # :category: Data
+      # @!group Data
       #
       def query query, max: nil, timeout: 10000, dryrun: nil, cache: true
         options = { max: max, timeout: timeout, dryrun: dryrun, cache: cache }
@@ -730,8 +669,8 @@ module Gcloud
       end
 
       ##
-      # New Dataset from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Dataset from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Bigquery

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -110,7 +110,7 @@ module Gcloud
 
         ##
         # Add reader access to a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def add_reader_special group
           add_access_role_scope_value :reader, :special, group
         end
@@ -146,7 +146,7 @@ module Gcloud
 
         ##
         # Add writer access to a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def add_writer_special group
           add_access_role_scope_value :writer, :special, group
         end
@@ -182,7 +182,7 @@ module Gcloud
 
         ##
         # Add owner access to a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def add_owner_special group
           add_access_role_scope_value :owner, :special, group
         end
@@ -218,7 +218,7 @@ module Gcloud
 
         ##
         # Remove reader access from a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def remove_reader_special group
           remove_access_role_scope_value :reader, :special, group
         end
@@ -254,7 +254,7 @@ module Gcloud
 
         ##
         # Remove writer access from a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def remove_writer_special group
           remove_access_role_scope_value :writer, :special, group
         end
@@ -290,7 +290,7 @@ module Gcloud
 
         ##
         # Remove owner access from a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def remove_owner_special group
           remove_access_role_scope_value :owner, :special, group
         end
@@ -326,7 +326,7 @@ module Gcloud
 
         ##
         # Checks reader access for a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def reader_special? group
           lookup_access_role_scope_value :reader, :special, group
         end
@@ -362,7 +362,7 @@ module Gcloud
 
         ##
         # Checks writer access for a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def writer_special? group
           lookup_access_role_scope_value :writer, :special, group
         end
@@ -398,7 +398,7 @@ module Gcloud
 
         ##
         # Checks owner access for a special group.
-        # Accepted values are +owners+, +writers+, +readers+, and +all+.
+        # Accepted values are `owners`, `writers`, `readers`, and `all`.
         def owner_special? group
           lookup_access_role_scope_value :owner, :special, group
         end

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -19,9 +19,12 @@ module Gcloud
       ##
       # = Dataset Access Control
       #
-      # Represents the Access rules for a Dataset. See {BigQuery Access
-      # Control}[https://cloud.google.com/bigquery/access-control].
+      # Represents the Access rules for a {Dataset}.
       #
+      # @see https://cloud.google.com/bigquery/access-control BigQuery Access
+      #   Control
+      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -37,10 +40,12 @@ module Gcloud
       #   end
       #
       class Access
+        # @private
         ROLES = { "reader" => "READER",
                   "writer" => "WRITER",
-                  "owner"  => "OWNER" } #:nodoc:
+                  "owner"  => "OWNER" }
 
+        # @private
         SCOPES = { "user"           => "userByEmail",
                    "user_by_email"  => "userByEmail",
                    "userByEmail"    => "userByEmail",
@@ -51,8 +56,9 @@ module Gcloud
                    "special"        => "specialGroup",
                    "special_group"  => "specialGroup",
                    "specialGroup"   => "specialGroup",
-                   "view"           => "view" } #:nodoc:
+                   "view"           => "view" }
 
+        # @private
         GROUPS = { "owners"                  => "projectOwners",
                    "project_owners"          => "projectOwners",
                    "projectOwners"           => "projectOwners",
@@ -66,18 +72,21 @@ module Gcloud
                    "all_authenticated_users" => "allAuthenticatedUsers",
                    "allAuthenticatedUsers"   => "allAuthenticatedUsers" }
 
-        attr_reader :access #:nodoc:
+        # @private
+        attr_reader :access
 
         ##
+        # @private
         # Initialized a new Access object.
         # Must provide a valid Dataset object.
-        def initialize access, context #:nodoc:
+        def initialize access, context
           @original   = access.dup
           @access     = access.dup
           @context    = context
         end
 
-        def changed? #:nodoc:
+        # @private
+        def changed?
           @original != @access
         end
 
@@ -112,7 +121,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def add_reader_view view
           add_access_role_scope_value :reader, :view, view
         end
@@ -148,7 +157,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def add_writer_view view
           add_access_role_scope_value :writer, :view, view
         end
@@ -184,7 +193,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def add_owner_view view
           add_access_role_scope_value :owner, :view, view
         end
@@ -220,7 +229,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def remove_reader_view view
           remove_access_role_scope_value :reader, :view, view
         end
@@ -256,7 +265,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def remove_writer_view view
           remove_access_role_scope_value :writer, :view, view
         end
@@ -292,7 +301,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def remove_owner_view view
           remove_access_role_scope_value :owner, :view, view
         end
@@ -328,7 +337,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def reader_view? view
           lookup_access_role_scope_value :reader, :view, view
         end
@@ -364,7 +373,7 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def writer_view? view
           lookup_access_role_scope_value :writer, :view, view
         end
@@ -400,14 +409,15 @@ module Gcloud
         # or a string identifier as specified by the
         # {Query
         # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-        # +project_name:datasetId.tableId+.
+        # @param [String] project_name:datasetId.tableId+.
         def owner_view? view
           lookup_access_role_scope_value :owner, :view, view
         end
 
         protected
 
-        def validate_role role #:nodoc:
+        # @private
+        def validate_role role
           good_role = ROLES[role.to_s]
           if good_role.nil?
             fail ArgumentError "Unable to determine role for #{role}"
@@ -415,7 +425,8 @@ module Gcloud
           good_role
         end
 
-        def validate_scope scope #:nodoc:
+        # @private
+        def validate_scope scope
           good_scope = SCOPES[scope.to_s]
           if good_scope.nil?
             fail ArgumentError "Unable to determine scope for #{scope}"
@@ -423,13 +434,15 @@ module Gcloud
           good_scope
         end
 
-        def validate_special_group value #:nodoc:
+        # @private
+        def validate_special_group value
           good_value = GROUPS[value.to_s]
           return good_value unless good_value.nil?
           scope
         end
 
-        def validate_view view #:nodoc:
+        # @private
+        def validate_view view
           if view.respond_to? :table_ref
             view.table_ref
           else
@@ -437,7 +450,8 @@ module Gcloud
           end
         end
 
-        def add_access_role_scope_value role, scope, value #:nodoc:
+        # @private
+        def add_access_role_scope_value role, scope, value
           role = validate_role role
           scope = validate_scope scope
           # If scope is special group, make sure value is in the list
@@ -450,7 +464,8 @@ module Gcloud
           access << { "role" => role, scope => value }
         end
 
-        def remove_access_role_scope_value role, scope, value #:nodoc:
+        # @private
+        def remove_access_role_scope_value role, scope, value
           role = validate_role role
           scope = validate_scope scope
           # If scope is special group, make sure value is in the list
@@ -461,7 +476,8 @@ module Gcloud
           access.reject! { |h| h["role"] == role && h[scope] == value }
         end
 
-        def lookup_access_role_scope_value role, scope, value #:nodoc:
+        # @private
+        def lookup_access_role_scope_value role, scope, value
           role = validate_role role
           scope = validate_scope scope
           # If scope is special group, make sure value is in the list

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -119,8 +119,8 @@ module Gcloud
         # Add reader access to a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def add_reader_view view
           add_access_role_scope_value :reader, :view, view
@@ -155,8 +155,8 @@ module Gcloud
         # Add writer access to a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def add_writer_view view
           add_access_role_scope_value :writer, :view, view
@@ -191,8 +191,8 @@ module Gcloud
         # Add owner access to a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def add_owner_view view
           add_access_role_scope_value :owner, :view, view
@@ -227,8 +227,8 @@ module Gcloud
         # Remove reader access from a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def remove_reader_view view
           remove_access_role_scope_value :reader, :view, view
@@ -263,8 +263,8 @@ module Gcloud
         # Remove writer access from a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def remove_writer_view view
           remove_access_role_scope_value :writer, :view, view
@@ -299,8 +299,8 @@ module Gcloud
         # Remove owner access from a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def remove_owner_view view
           remove_access_role_scope_value :owner, :view, view
@@ -335,8 +335,8 @@ module Gcloud
         # Checks reader access for a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def reader_view? view
           lookup_access_role_scope_value :reader, :view, view
@@ -371,8 +371,8 @@ module Gcloud
         # Checks writer access for a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def writer_view? view
           lookup_access_role_scope_value :writer, :view, view
@@ -407,8 +407,8 @@ module Gcloud
         # Checks owner access for a view.
         # The view can be a Gcloud::Bigquery::View object,
         # or a string identifier as specified by the
-        # {Query
-        # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+        # [Query
+        # Reference](https://cloud.google.com/bigquery/query-reference#from):
         # @param [String] project_name:datasetId.tableId+.
         def owner_view? view
           lookup_access_role_scope_value :owner, :view, view

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -121,7 +121,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def add_reader_view view
           add_access_role_scope_value :reader, :view, view
         end
@@ -157,7 +157,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def add_writer_view view
           add_access_role_scope_value :writer, :view, view
         end
@@ -193,7 +193,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def add_owner_view view
           add_access_role_scope_value :owner, :view, view
         end
@@ -229,7 +229,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def remove_reader_view view
           remove_access_role_scope_value :reader, :view, view
         end
@@ -265,7 +265,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def remove_writer_view view
           remove_access_role_scope_value :writer, :view, view
         end
@@ -301,7 +301,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def remove_owner_view view
           remove_access_role_scope_value :owner, :view, view
         end
@@ -337,7 +337,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def reader_view? view
           lookup_access_role_scope_value :reader, :view, view
         end
@@ -373,7 +373,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def writer_view? view
           lookup_access_role_scope_value :writer, :view, view
         end
@@ -409,7 +409,7 @@ module Gcloud
         # or a string identifier as specified by the
         # [Query
         # Reference](https://cloud.google.com/bigquery/query-reference#from):
-        # @param [String] project_name:datasetId.tableId+.
+        # +project_name:datasetId.tableId+.
         def owner_view? view
           lookup_access_role_scope_value :owner, :view, view
         end

--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -17,7 +17,7 @@ module Gcloud
   module Bigquery
     class Dataset
       ##
-      # = Dataset Access Control
+      # # Dataset Access Control
       #
       # Represents the Access rules for a {Dataset}.
       #

--- a/lib/gcloud/bigquery/dataset/list.rb
+++ b/lib/gcloud/bigquery/dataset/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/bigquery/dataset/list.rb
+++ b/lib/gcloud/bigquery/dataset/list.rb
@@ -36,8 +36,8 @@ module Gcloud
         end
 
         ##
-        # New Dataset::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Dataset::List from a response object.
+        def self.from_response resp, conn
           datasets = List.new(Array(resp.data["datasets"]).map do |gapi_object|
             Dataset.from_gapi gapi_object, conn
           end)

--- a/lib/gcloud/bigquery/errors.rb
+++ b/lib/gcloud/bigquery/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/errors"
 

--- a/lib/gcloud/bigquery/errors.rb
+++ b/lib/gcloud/bigquery/errors.rb
@@ -33,13 +33,15 @@ module Gcloud
       # The errors encountered.
       attr_reader :errors
 
-      def initialize message, code, errors = [] #:nodoc:
+      # @private
+      def initialize message, code, errors = []
         super message
         @code   = code
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         if resp.data? && resp.data["error"]
           from_response_data resp.data["error"]
         else
@@ -47,11 +49,13 @@ module Gcloud
         end
       end
 
-      def self.from_response_data error #:nodoc:
+      # @private
+      def self.from_response_data error
         new error["message"], error["code"], error["errors"]
       end
 
-      def self.from_response_status resp #:nodoc:
+      # @private
+      def self.from_response_status resp
         if resp.status == 404
           new "#{resp.error_message}: #{resp.request.uri.request_uri}",
               resp.status

--- a/lib/gcloud/bigquery/extract_job.rb
+++ b/lib/gcloud/bigquery/extract_job.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Bigquery

--- a/lib/gcloud/bigquery/extract_job.rb
+++ b/lib/gcloud/bigquery/extract_job.rb
@@ -48,7 +48,7 @@ module Gcloud
 
       ##
       # Checks if the export operation compresses the data using gzip. The
-      # default is +false+.
+      # default is `false`.
       def compression?
         val = config["extract"]["compression"]
         val == "GZIP"
@@ -56,7 +56,7 @@ module Gcloud
 
       ##
       # Checks if the destination format for the data is [newline-delimited
-      # JSON](http://jsonlines.org/). The default is +false+.
+      # JSON](http://jsonlines.org/). The default is `false`.
       def json?
         val = config["extract"]["destinationFormat"]
         val == "NEWLINE_DELIMITED_JSON"
@@ -64,7 +64,7 @@ module Gcloud
 
       ##
       # Checks if the destination format for the data is CSV. Tables with nested
-      # or repeated fields cannot be exported as CSV. The default is +true+.
+      # or repeated fields cannot be exported as CSV. The default is `true`.
       def csv?
         val = config["extract"]["destinationFormat"]
         return true if val.nil?
@@ -73,7 +73,7 @@ module Gcloud
 
       ##
       # Checks if the destination format for the data is
-      # [Avro](http://avro.apache.org/). The default is +false+.
+      # [Avro](http://avro.apache.org/). The default is `false`.
       def avro?
         val = config["extract"]["destinationFormat"]
         val == "AVRO"
@@ -90,7 +90,7 @@ module Gcloud
 
       ##
       # Checks if the exported data contains a header row. The default is
-      # +true+.
+      # `true`.
       def print_header?
         val = config["extract"]["printHeader"]
         val = true if val.nil?

--- a/lib/gcloud/bigquery/extract_job.rb
+++ b/lib/gcloud/bigquery/extract_job.rb
@@ -16,7 +16,7 @@
 module Gcloud
   module Bigquery
     ##
-    # = ExtractJob
+    # # ExtractJob
     #
     # A {Job} subclass representing an export operation that may be performed
     # on a {Table}. A ExtractJob instance is created when you call

--- a/lib/gcloud/bigquery/extract_job.rb
+++ b/lib/gcloud/bigquery/extract_job.rb
@@ -55,8 +55,8 @@ module Gcloud
       end
 
       ##
-      # Checks if the destination format for the data is {newline-delimited
-      # JSON}[http://jsonlines.org/]. The default is +false+.
+      # Checks if the destination format for the data is [newline-delimited
+      # JSON](http://jsonlines.org/). The default is +false+.
       def json?
         val = config["extract"]["destinationFormat"]
         val == "NEWLINE_DELIMITED_JSON"
@@ -73,7 +73,7 @@ module Gcloud
 
       ##
       # Checks if the destination format for the data is
-      # {Avro}[http://avro.apache.org/]. The default is +false+.
+      # [Avro](http://avro.apache.org/). The default is +false+.
       def avro?
         val = config["extract"]["destinationFormat"]
         val == "AVRO"

--- a/lib/gcloud/bigquery/extract_job.rb
+++ b/lib/gcloud/bigquery/extract_job.rb
@@ -18,14 +18,14 @@ module Gcloud
     ##
     # = ExtractJob
     #
-    # A Job subclass representing an export operation that may be performed
-    # on a Table. A ExtractJob instance is created when you call Table#extract.
+    # A {Job} subclass representing an export operation that may be performed
+    # on a {Table}. A ExtractJob instance is created when you call
+    # {Table#extract}.
     #
-    # See {Exporting Data From
-    # BigQuery}[https://cloud.google.com/bigquery/exporting-data-from-bigquery]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/exporting-data-from-bigquery
+    #   Exporting Data From BigQuery
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class ExtractJob < Job
       ##
@@ -37,7 +37,7 @@ module Gcloud
 
       ##
       # The table from which the data is exported. This is the table upon
-      # which Table#extract was called. Returns a Table instance.
+      # which {Table#extract} was called. Returns a {Table} instance.
       def source
         table = config["extract"]["sourceTable"]
         return nil unless table
@@ -99,7 +99,7 @@ module Gcloud
 
       ##
       # The count of files per destination URI or URI pattern specified in
-      # #destinations. Returns an Array of values in the same order as the URI
+      # {#destinations}. Returns an Array of values in the same order as the URI
       # patterns.
       def destinations_file_counts
         Array stats["extract"]["destinationUriFileCounts"]
@@ -107,7 +107,7 @@ module Gcloud
 
       ##
       # The count of files per destination URI or URI pattern specified in
-      # #destinations. Returns a Hash with the URI patterns as keys and the
+      # {#destinations}. Returns a Hash with the URI patterns as keys and the
       # counts as values.
       def destinations_counts
         Hash[destinations.zip destinations_file_counts]

--- a/lib/gcloud/bigquery/insert_response.rb
+++ b/lib/gcloud/bigquery/insert_response.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Bigquery

--- a/lib/gcloud/bigquery/insert_response.rb
+++ b/lib/gcloud/bigquery/insert_response.rb
@@ -18,7 +18,8 @@ module Gcloud
     ##
     # InsertResponse
     class InsertResponse
-      def initialize rows, gapi #:nodoc:
+      # @private
+      def initialize rows, gapi
         @rows = rows
         @gapi = gapi
       end
@@ -59,7 +60,8 @@ module Gcloud
         []
       end
 
-      def self.from_gapi rows, gapi #:nodoc:
+      # @private
+      def self.from_gapi rows, gapi
         gapi = gapi.to_hash if gapi.respond_to? :to_hash
         new rows, gapi
       end
@@ -70,7 +72,8 @@ module Gcloud
         attr_reader :row
         attr_reader :errors
 
-        def initialize row, errors #:nodoc:
+        # @private
+        def initialize row, errors
           @row = row
           @errors = errors
         end

--- a/lib/gcloud/bigquery/job.rb
+++ b/lib/gcloud/bigquery/job.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/bigquery/query_data"
 require "gcloud/bigquery/job/list"

--- a/lib/gcloud/bigquery/job.rb
+++ b/lib/gcloud/bigquery/job.rb
@@ -22,20 +22,21 @@ module Gcloud
     ##
     # = Job
     #
-    # Represents a generic Job that may be performed on a Table.
+    # Represents a generic Job that may be performed on a {Table}.
     #
-    # See {Managing Jobs, Datasets, and Projects
-    # }[https://cloud.google.com/bigquery/docs/managing_jobs_datasets_projects]
-    # for an overview of BigQuery jobs, and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # The subclasses of Job represent the specific BigQuery job types:
+    # {CopyJob}, {ExtractJob}, {LoadJob}, and {QueryJob}.
     #
-    # The subclasses of Job represent the specific BigQuery job types: CopyJob,
-    # ExtractJob, LoadJob, and QueryJob.
+    # A job instance is created when you call {Project#query_job},
+    # {Dataset#query_job}, {Table#copy}, {Table#extract}, {Table#load}, or
+    # {View#data}.
     #
-    # A job instance is created when you call Project#query_job,
-    # Dataset#query_job, Table#copy, Table#extract, Table#load, or View#data.
+    # @see https://cloud.google.com/bigquery/docs/managing_jobs_datasets_projects
+    #   Managing Jobs, Datasets, and Projects
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -54,16 +55,16 @@ module Gcloud
     #
     class Job
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Job object.
-      def initialize #:nodoc:
+      # @private Create an empty Job object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -83,7 +84,7 @@ module Gcloud
       ##
       # The current state of the job. The possible values are +PENDING+,
       # +RUNNING+, and +DONE+. A +DONE+ state does not mean that the job
-      # completed successfully. Use #failed? to discover if an error occurred
+      # completed successfully. Use {#failed?} to discover if an error occurred
       # or if the job was successful.
       def state
         return nil if @gapi["status"].nil?
@@ -107,7 +108,7 @@ module Gcloud
       ##
       # Checks if the job's state is +DONE+. When +true+, the job has stopped
       # running. However, a +DONE+ state does not mean that the job completed
-      # successfully.  Use #failed? to detect if an error occurred or if the
+      # successfully.  Use {#failed?} to detect if an error occurred or if the
       # job was successful.
       def done?
         return false if state.nil?
@@ -148,8 +149,10 @@ module Gcloud
       end
 
       ##
-      # The configuration for the job. Returns a hash. See the {Jobs API
-      # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs].
+      # The configuration for the job. Returns a hash.
+      #
+      # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+      #   reference
       def configuration
         hash = @gapi["configuration"] || {}
         hash = hash.to_hash if hash.respond_to? :to_hash
@@ -158,8 +161,10 @@ module Gcloud
       alias_method :config, :configuration
 
       ##
-      # The statistics for the job. Returns a hash. See the {Jobs API
-      # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs].
+      # The statistics for the job. Returns a hash.
+      #
+      # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+      #   reference
       def statistics
         hash = @gapi["statistics"] || {}
         hash = hash.to_hash if hash.respond_to? :to_hash
@@ -169,7 +174,7 @@ module Gcloud
 
       ##
       # The job's status. Returns a hash. The values contained in the hash are
-      # also exposed by #state, #error, and #errors.
+      # also exposed by {#state}, {#error}, and {#errors}.
       def status
         hash = @gapi["status"] || {}
         hash = hash.to_hash if hash.respond_to? :to_hash
@@ -178,12 +183,12 @@ module Gcloud
 
       ##
       # The last error for the job, if any errors have occurred. Returns a
-      # hash. See the {Jobs API
-      # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs].
+      # hash.
       #
-      # === Returns
+      # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+      #   reference
       #
-      # +Hash+
+      # @return [Hash] Returns a hash containing +reason+ and +message+ keys:
       #
       #   {
       #     "reason"=>"notFound",
@@ -196,7 +201,7 @@ module Gcloud
 
       ##
       # The errors for the job, if any errors have occurred. Returns an array
-      # of hash objects. See #error.
+      # of hash objects. See {#error}.
       def errors
         Array status["errors"]
       end
@@ -230,8 +235,7 @@ module Gcloud
       # Refreshes the job until the job is +DONE+.
       # The delay between refreshes will incrementally increase.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -254,8 +258,8 @@ module Gcloud
       end
 
       ##
-      # New Job from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Job from a Google API Client object.
+      def self.from_gapi gapi, conn
         klass = klass_for gapi
         klass.new.tap do |f|
           f.gapi = gapi

--- a/lib/gcloud/bigquery/job.rb
+++ b/lib/gcloud/bigquery/job.rb
@@ -20,7 +20,7 @@ require "gcloud/bigquery/errors"
 module Gcloud
   module Bigquery
     ##
-    # = Job
+    # # Job
     #
     # Represents a generic Job that may be performed on a {Table}.
     #

--- a/lib/gcloud/bigquery/job.rb
+++ b/lib/gcloud/bigquery/job.rb
@@ -82,8 +82,8 @@ module Gcloud
       end
 
       ##
-      # The current state of the job. The possible values are +PENDING+,
-      # +RUNNING+, and +DONE+. A +DONE+ state does not mean that the job
+      # The current state of the job. The possible values are `PENDING`,
+      # `RUNNING`, and `DONE`. A `DONE` state does not mean that the job
       # completed successfully. Use {#failed?} to discover if an error occurred
       # or if the job was successful.
       def state
@@ -92,22 +92,22 @@ module Gcloud
       end
 
       ##
-      # Checks if the job's state is +RUNNING+.
+      # Checks if the job's state is `RUNNING`.
       def running?
         return false if state.nil?
         "running".casecmp(state).zero?
       end
 
       ##
-      # Checks if the job's state is +PENDING+.
+      # Checks if the job's state is `PENDING`.
       def pending?
         return false if state.nil?
         "pending".casecmp(state).zero?
       end
 
       ##
-      # Checks if the job's state is +DONE+. When +true+, the job has stopped
-      # running. However, a +DONE+ state does not mean that the job completed
+      # Checks if the job's state is `DONE`. When `true`, the job has stopped
+      # running. However, a `DONE` state does not mean that the job completed
       # successfully.  Use {#failed?} to detect if an error occurred or if the
       # job was successful.
       def done?
@@ -131,8 +131,8 @@ module Gcloud
 
       ##
       # The time when the job was started.
-      # This field is present after the job's state changes from +PENDING+
-      # to either +RUNNING+ or +DONE+.
+      # This field is present after the job's state changes from `PENDING`
+      # to either `RUNNING` or `DONE`.
       def started_at
         return nil if @gapi["statistics"].nil?
         return nil if @gapi["statistics"]["startTime"].nil?
@@ -141,7 +141,7 @@ module Gcloud
 
       ##
       # The time when the job ended.
-      # This field is present when the job's state is +DONE+.
+      # This field is present when the job's state is `DONE`.
       def ended_at
         return nil if @gapi["statistics"].nil?
         return nil if @gapi["statistics"]["endTime"].nil?
@@ -188,7 +188,7 @@ module Gcloud
       # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
       #   reference
       #
-      # @return [Hash] Returns a hash containing +reason+ and +message+ keys:
+      # @return [Hash] Returns a hash containing `reason` and `message` keys:
       #
       #   {
       #     "reason"=>"notFound",
@@ -232,7 +232,7 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # Refreshes the job until the job is +DONE+.
+      # Refreshes the job until the job is `DONE`.
       # The delay between refreshes will incrementally increase.
       #
       # @example

--- a/lib/gcloud/bigquery/job/list.rb
+++ b/lib/gcloud/bigquery/job/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/bigquery/job/list.rb
+++ b/lib/gcloud/bigquery/job/list.rb
@@ -39,8 +39,8 @@ module Gcloud
         end
 
         ##
-        # New Job::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Job::List from a response object.
+        def self.from_response resp, conn
           jobs = List.new(Array(resp.data["jobs"]).map do |gapi_object|
             Job.from_gapi gapi_object, conn
           end)

--- a/lib/gcloud/bigquery/load_job.rb
+++ b/lib/gcloud/bigquery/load_job.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Bigquery

--- a/lib/gcloud/bigquery/load_job.rb
+++ b/lib/gcloud/bigquery/load_job.rb
@@ -56,7 +56,7 @@ module Gcloud
 
       ##
       # The number of header rows at the top of a CSV file to skip. The default
-      # value is \`0\`.
+      # value is `0`.
       def skip_leading_rows
         val = config["load"]["skipLeadingRows"]
         val = 0 if val.nil?

--- a/lib/gcloud/bigquery/load_job.rb
+++ b/lib/gcloud/bigquery/load_job.rb
@@ -18,14 +18,13 @@ module Gcloud
     ##
     # = LoadJob
     #
-    # A Job subclass representing a load operation that may be performed
-    # on a Table. A LoadJob instance is created when you call Table#load.
+    # A {Job} subclass representing a load operation that may be performed
+    # on a {Table}. A LoadJob instance is created when you call {Table#load}.
     #
-    # See {Loading Data Into
-    # BigQuery}[https://cloud.google.com/bigquery/loading-data-into-bigquery]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/loading-data-into-bigquery Loading
+    #   Data Into BigQuery
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class LoadJob < Job
       ##
@@ -37,7 +36,7 @@ module Gcloud
 
       ##
       # The table into which the operation loads data. This is the table on
-      # which Table#load was invoked. Returns a Table instance.
+      # which {Table#load} was invoked. Returns a {Table} instance.
       def destination
         table = config["load"]["destinationTable"]
         return nil unless table
@@ -84,7 +83,7 @@ module Gcloud
       # The value that is used to quote data sections in a CSV file.
       # The default value is a double-quote (+"+). If your data does not contain
       # quoted sections, the value should be an empty string. If your data
-      # contains quoted newline characters, #quoted_newlines? should return
+      # contains quoted newline characters, {#quoted_newlines?} should return
       # +true+.
       def quote
         val = config["load"]["quote"]
@@ -161,8 +160,8 @@ module Gcloud
 
       ##
       # The schema for the data. Returns a hash. Can be empty if the table
-      # has already has the correct schema (see Table#schema= and Table#schema),
-      # or if the schema can be inferred from the loaded data.
+      # has already has the correct schema (see {Table#schema=} and
+      # {Table#schema}), or if the schema can be inferred from the loaded data.
       def schema
         val = config["load"]["schema"]
         val = {} if val.nil?

--- a/lib/gcloud/bigquery/load_job.rb
+++ b/lib/gcloud/bigquery/load_job.rb
@@ -113,7 +113,7 @@ module Gcloud
 
       ##
       # Checks if the format of the source data is
-      # {newline-delimited JSON}[http://jsonlines.org/]. The default is +false+.
+      # [newline-delimited JSON](http://jsonlines.org/). The default is +false+.
       def json?
         val = config["load"]["sourceFormat"]
         val == "NEWLINE_DELIMITED_JSON"

--- a/lib/gcloud/bigquery/load_job.rb
+++ b/lib/gcloud/bigquery/load_job.rb
@@ -56,7 +56,7 @@ module Gcloud
 
       ##
       # The number of header rows at the top of a CSV file to skip. The default
-      # value is +0+.
+      # value is \`0\`.
       def skip_leading_rows
         val = config["load"]["skipLeadingRows"]
         val = 0 if val.nil?
@@ -81,10 +81,10 @@ module Gcloud
 
       ##
       # The value that is used to quote data sections in a CSV file.
-      # The default value is a double-quote (+"+). If your data does not contain
+      # The default value is a double-quote (`"`). If your data does not contain
       # quoted sections, the value should be an empty string. If your data
       # contains quoted newline characters, {#quoted_newlines?} should return
-      # +true+.
+      # `true`.
       def quote
         val = config["load"]["quote"]
         val = "\"" if val.nil?
@@ -94,7 +94,7 @@ module Gcloud
       ##
       # The maximum number of bad records that the load operation can ignore. If
       # the number of bad records exceeds this value, an error is
-      # returned. The default value is +0+, which requires that all records be
+      # returned. The default value is `0`, which requires that all records be
       # valid.
       def max_bad_records
         val = config["load"]["maxBadRecords"]
@@ -104,7 +104,7 @@ module Gcloud
 
       ##
       # Checks if quoted data sections may contain newline characters in a CSV
-      # file. The default is +false+.
+      # file. The default is `false`.
       def quoted_newlines?
         val = config["load"]["allowQuotedNewlines"]
         val = true if val.nil?
@@ -113,14 +113,14 @@ module Gcloud
 
       ##
       # Checks if the format of the source data is
-      # [newline-delimited JSON](http://jsonlines.org/). The default is +false+.
+      # [newline-delimited JSON](http://jsonlines.org/). The default is `false`.
       def json?
         val = config["load"]["sourceFormat"]
         val == "NEWLINE_DELIMITED_JSON"
       end
 
       ##
-      # Checks if the format of the source data is CSV. The default is +true+.
+      # Checks if the format of the source data is CSV. The default is `true`.
       def csv?
         val = config["load"]["sourceFormat"]
         return true if val.nil?
@@ -136,10 +136,10 @@ module Gcloud
 
       ##
       # Checks if the load operation accepts rows that are missing trailing
-      # optional columns. The missing values are treated as nulls. If +false+,
+      # optional columns. The missing values are treated as nulls. If `false`,
       # records with missing trailing columns are treated as bad records, and
       # if there are too many bad records, an error is returned. The default
-      # value is +false+. Only applicable to CSV, ignored for other formats.
+      # value is `false`. Only applicable to CSV, ignored for other formats.
       def allow_jagged_rows?
         val = config["load"]["allowJaggedRows"]
         val = false if val.nil?
@@ -148,10 +148,10 @@ module Gcloud
 
       ##
       # Checks if the load operation allows extra values that are not
-      # represented in the table schema. If +true+, the extra values are
-      # ignored. If +false+, records with extra columns are treated as bad
+      # represented in the table schema. If `true`, the extra values are
+      # ignored. If `false`, records with extra columns are treated as bad
       # records, and if there are too many bad records, an invalid error is
-      # returned. The default is +false+.
+      # returned. The default is `false`.
       def ignore_unknown_values?
         val = config["load"]["ignoreUnknownValues"]
         val = false if val.nil?

--- a/lib/gcloud/bigquery/load_job.rb
+++ b/lib/gcloud/bigquery/load_job.rb
@@ -16,7 +16,7 @@
 module Gcloud
   module Bigquery
     ##
-    # = LoadJob
+    # # LoadJob
     #
     # A {Job} subclass representing a load operation that may be performed
     # on a {Table}. A LoadJob instance is created when you call {Table#load}.

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -166,12 +166,12 @@ module Gcloud
       #   syntax](https://cloud.google.com/bigquery/query-reference), of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
-      # @param [Integer] timeout How long to wait for the query to complete, in
-      #   milliseconds, before the request times out and returns. Note that this
-      #   is only a timeout for the request, not the query. If the query takes
-      #   longer to run than the timeout value, the call returns without any
-      #   results and with QueryData#complete? set to false. The default value
-      #   is 10000 milliseconds (10 seconds).
+      # @param [Integer] max The maximum number of rows of data to return per
+      #   page of results. Setting this flag to a small value such as 1000 and
+      #   then paging through results might improve reliability when the query
+      #   result set is large. In addition to this limit, responses are also
+      #   limited to 10 MB. By default, there is no maximum row count, and only
+      #   the byte limit applies.
       # @param [Integer] timeout How long to wait for the query to complete, in
       #   milliseconds, before the request times out and returns. Note that this
       #   is only a timeout for the request, not the query. If the query takes

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -31,9 +31,12 @@ module Gcloud
     # data. Each project has a friendly name and a unique ID.
     #
     # Gcloud::Bigquery::Project is the main object for interacting with
-    # Google BigQuery. Gcloud::Bigquery::Dataset objects are created,
+    # Google BigQuery. {Gcloud::Bigquery::Dataset} objects are created,
     # accessed, and deleted by Gcloud::Bigquery::Project.
     #
+    # See {Gcloud#bigquery}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -41,16 +44,15 @@ module Gcloud
     #   dataset = bigquery.dataset "my_dataset"
     #   table = dataset.table "my_table"
     #
-    # See Gcloud#bigquery
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
       # Creates a new Connection instance.
       #
-      # See Gcloud.bigquery
+      # See {Gcloud.bigquery}
       def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
@@ -60,8 +62,7 @@ module Gcloud
       ##
       # The BigQuery project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project", "/path/to/keyfile.json"
@@ -74,8 +75,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["BIGQUERY_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -86,58 +87,48 @@ module Gcloud
       # Queries data using the {asynchronous
       # method}[https://cloud.google.com/bigquery/querying-data].
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +priority+::
-      #   Specifies a priority for the query. Possible values include
-      #   +INTERACTIVE+ and +BATCH+. The default value is +INTERACTIVE+.
-      #   (+String+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is +true+. (+Boolean+)
-      # +table+::
-      #   The destination table where the query results should be stored. If not
-      #   present, a new table will be created to store the results. (+Table+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [String] priority Specifies a priority for the query. Possible
+      #   values include +INTERACTIVE+ and +BATCH+. The default value is
+      #   +INTERACTIVE+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [Table] table The destination table where the query results
+      #   should be stored. If not present, a new table will be created to store
+      #   the results.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies the action that occurs if the destination table already
-      #   exists. (+String+)
+      # @param [String] write Specifies the action that occurs if the
+      #   destination table already exists.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - A 'duplicate' error is returned in the job result if the
       #     table exists and contains data.
-      # +large_results+::
-      #   If +true+, allows the query to produce arbitrarily large result tables
-      #   at a slight cost in performance. Requires +table+ parameter to be set.
-      #   (+Boolean+)
-      # +flatten+::
-      #   Flattens all nested and repeated fields in the query results. The
-      #   default value is +true+. +large_results+ parameter must be +true+ if
-      #   this is set to +false+. (+Boolean+)
-      # +dataset+::
-      #   Specifies the default dataset to use for unqualified table names in
-      #   the query. (+Dataset+ or +String+)
+      # @param [Boolean] large_results If +true+, allows the query to produce
+      #   arbitrarily large result tables at a slight cost in performance.
+      #   Requires +table+ parameter to be set.
+      # @param [Boolean] flatten Flattens all nested and repeated fields in the
+      #   query results. The default value is +true+. +large_results+ parameter
+      #   must be +true+ if this is set to +false+.
+      # @param [Dataset, String] dataset Specifies the default dataset to use
+      #   for unqualified table names in the query.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryJob]
       #
-      # Gcloud::Bigquery::QueryJob
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -171,53 +162,42 @@ module Gcloud
       # Queries data using the {synchronous
       # method}[https://cloud.google.com/bigquery/querying-data].
       #
-      # === Parameters
-      #
-      # +query+::
-      #   A query string, following the BigQuery {query
+      # @param [String] query A query string, following the BigQuery {query
       #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
       #   query to execute. Example: "SELECT count(f1) FROM
-      #   [myProjectId:myDatasetId.myTableId]". (+String+)
-      # +max+::
-      #   The maximum number of rows of data to return per page of results.
-      #   Setting this flag to a small value such as 1000 and then paging
-      #   through results might improve reliability when the query result set is
-      #   large. In addition to this limit, responses are also limited to 10 MB.
-      #   By default, there is no maximum row count, and only the byte limit
-      #   applies. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   the request times out and returns. Note that this is only a timeout
-      #   for the request, not the query. If the query takes longer to run than
-      #   the timeout value, the call returns without any results and with
-      #   QueryData#complete? set to false. The default value is 10000
-      #   milliseconds (10 seconds). (+Integer+)
-      # +dryrun+::
-      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
-      #   is valid, BigQuery returns statistics about the job such as how many
-      #   bytes would be processed. If the query is invalid, an error returns.
-      #   The default value is +false+. (+Boolean+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is true. For more information, see
-      #   {query caching}[https://developers.google.com/bigquery/querying-data].
-      #   (+Boolean+)
-      # +dataset+::
-      #   Specifies the default datasetId and projectId to assume for any
-      #   unqualified table names in the query. If not set, all table names in
-      #   the query string must be qualified in the format 'datasetId.tableId'.
-      #   (+String+)
-      # +project+::
-      #   Specifies the default projectId to assume for any unqualified table
-      #   names in the query. Only used if +dataset+ option is set. (+String+)
+      #   [myProjectId:myDatasetId.myTableId]".
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      #   Instead, if the query is valid, BigQuery returns statistics about the
+      #   job such as how many bytes would be processed. If the query is
+      #   invalid, an error returns. The default value is +false+.
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [String] dataset Specifies the default datasetId and projectId to
+      #   assume for any unqualified table names in the query. If not set, all
+      #   table names in the query string must be qualified in the format
+      #   'datasetId.tableId'.
+      # @param [String] project Specifies the default projectId to assume for
+      #   any unqualified table names in the query. Only used if +dataset+
+      #   option is set.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -244,17 +224,12 @@ module Gcloud
       ##
       # Retrieves an existing dataset by ID.
       #
-      # === Parameters
+      # @param [String] dataset_id The ID of a dataset.
       #
-      # +dataset_id+::
-      #   The ID of a dataset. (+String+)
+      # @return [Gcloud::Bigquery::Dataset, nil] Returns +nil+ if the dataset
+      #   does not exist.
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::Dataset or nil if dataset does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -277,31 +252,23 @@ module Gcloud
       ##
       # Creates a new dataset.
       #
-      # === Parameters
-      #
-      # +dataset_id+::
-      #   A unique ID for this dataset, without the project name.
-      #   The ID must contain only letters (a-z, A-Z), numbers (0-9), or
-      #   underscores (_). The maximum length is 1,024 characters. (+String+)
-      # +name+::
-      #   A descriptive name for the dataset. (+String+)
-      # +description+::
-      #   A user-friendly description of the dataset. (+String+)
-      # +expiration+::
-      #   The default lifetime of all tables in the dataset, in milliseconds.
-      #   The minimum value is 3600000 milliseconds (one hour). (+Integer+)
-      # +access+::
-      #   The access rules for a Dataset using the Google Cloud Datastore API
-      #   data structure of an array of hashes. See {BigQuery Access
+      # @param [String] dataset_id A unique ID for this dataset, without the
+      #   project name. The ID must contain only letters (a-z, A-Z), numbers
+      #   (0-9), or underscores (_). The maximum length is 1,024 characters.
+      # @param [String] name A descriptive name for the dataset.
+      # @param [String] description A user-friendly description of the dataset.
+      # @param [Integer] expiration The default lifetime of all tables in the
+      #   dataset, in milliseconds. The minimum value is 3600000 milliseconds
+      #   (one hour).
+      # @param [Array<Hash>] access The access rules for a Dataset using the
+      #   Google Cloud Datastore API data structure of an array of hashes. See
+      #   {BigQuery Access
       #   Control}[https://cloud.google.com/bigquery/access-control] for more
-      #   information. (+Array of Hashes+)
+      #   information.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Dataset]
       #
-      # Gcloud::Bigquery::Dataset
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -309,8 +276,7 @@ module Gcloud
       #
       #   dataset = bigquery.create_dataset "my_dataset"
       #
-      # A name and description can be provided:
-      #
+      # @example A name and description can be provided:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -320,8 +286,7 @@ module Gcloud
       #                                     name: "My Dataset",
       #                                     description: "This is my Dataset"
       #
-      # Access rules can be provided with the +access+ option:
-      #
+      # @example Access rules can be provided with the +access+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -330,9 +295,7 @@ module Gcloud
       #   dataset = bigquery.create_dataset "my_dataset",
       #     access: [{"role"=>"WRITER", "userByEmail"=>"writers@example.com"}]
       #
-      # Or access rules can be configured by using the block syntax:
-      # (See Dataset::Access)
-      #
+      # @example Or, configure access with a block: (See {Dataset::Access})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -362,23 +325,16 @@ module Gcloud
       ##
       # Retrieves the list of datasets belonging to the project.
       #
-      # === Parameters
+      # @param [Boolean] all Whether to list all datasets, including hidden
+      #   ones. The default is +false+.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of datasets to return.
       #
-      # +all+::
-      #   Whether to list all datasets, including hidden ones. The default is
-      #   +false+. (+Boolean+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of datasets to return. (+Integer+)
+      # @return [Array<Gcloud::Bigquery::Dataset>] (See
+      #   {Gcloud::Bigquery::Dataset::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Bigquery::Dataset (See Gcloud::Bigquery::Dataset::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -389,9 +345,7 @@ module Gcloud
       #     puts dataset.name
       #   end
       #
-      # You can also retrieve all datasets, including hidden ones, by providing
-      # the +:all+ option:
-      #
+      # @example Retrieve all datasets, including hidden ones, with +:all+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -399,9 +353,7 @@ module Gcloud
       #
       #   all_datasets = bigquery.datasets, all: true
       #
-      # If you have a significant number of datasets, you may need to paginate
-      # through them: (See Dataset::List#token)
-      #
+      # @example With pagination: (See {Dataset::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -433,17 +385,12 @@ module Gcloud
       ##
       # Retrieves an existing job by ID.
       #
-      # === Parameters
+      # @param [String] job_id The ID of a job.
       #
-      # +job_id+::
-      #   The ID of a job. (+String+)
+      # @return [Gcloud::Bigquery::Job, nil] Returns +nil+ if the job does not
+      #   exist.
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::Job or nil if job does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -465,30 +412,22 @@ module Gcloud
       ##
       # Retrieves the list of jobs belonging to the project.
       #
-      # === Parameters
-      #
-      # +all+::
-      #   Whether to display jobs owned by all users in the project.
-      #   The default is +false+. (+Boolean+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of jobs to return. (+Integer+)
-      # +filter+::
-      #   A filter for job state. (+String+)
+      # @param [Boolean] all Whether to display jobs owned by all users in the
+      #   project. The default is +false+.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of jobs to return.
+      # @param [String] filter A filter for job state.
       #
       #   Acceptable values are:
       #   * +done+ - Finished jobs
       #   * +pending+ - Pending jobs
       #   * +running+ - Running jobs
       #
-      # === Returns
+      # @return [Array<Gcloud::Bigquery::Job>] (See
+      #   {Gcloud::Bigquery::Job::List})
       #
-      # Array of Gcloud::Bigquery::Job (See Gcloud::Bigquery::Job::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -496,7 +435,7 @@ module Gcloud
       #
       #   jobs = bigquery.jobs
       #
-      # You can also retrieve only running jobs using the +:filter+ option:
+      # @example Retrieve only running jobs using the +:filter+ option:
       #
       #   require "gcloud"
       #
@@ -505,8 +444,7 @@ module Gcloud
       #
       #   running_jobs = bigquery.jobs filter: "running"
       #
-      # If you have a significant number of jobs, you may need to paginate
-      # through them: (See Job::List#token)
+      # @example With pagination: (See {Job::List#token})
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/gce"
 require "gcloud/bigquery/connection"

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -84,11 +84,11 @@ module Gcloud
       end
 
       ##
-      # Queries data using the {asynchronous
-      # method}[https://cloud.google.com/bigquery/querying-data].
+      # Queries data using the [asynchronous
+      # method](https://cloud.google.com/bigquery/querying-data).
       #
-      # @param [String] query A query string, following the BigQuery {query
-      #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
+      # @param [String] query A query string, following the BigQuery [query
+      #   syntax](https://cloud.google.com/bigquery/query-reference), of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
       # @param [String] priority Specifies a priority for the query. Possible
@@ -97,8 +97,8 @@ module Gcloud
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
-      #   For more information, see {query
-      #   caching}[https://developers.google.com/bigquery/querying-data].
+      #   For more information, see [query
+      #   caching](https://developers.google.com/bigquery/querying-data).
       # @param [Table] table The destination table where the query results
       #   should be stored. If not present, a new table will be created to store
       #   the results.
@@ -159,11 +159,11 @@ module Gcloud
       end
 
       ##
-      # Queries data using the {synchronous
-      # method}[https://cloud.google.com/bigquery/querying-data].
+      # Queries data using the [synchronous
+      # method](https://cloud.google.com/bigquery/querying-data).
       #
-      # @param [String] query A query string, following the BigQuery {query
-      #   syntax}[https://cloud.google.com/bigquery/query-reference], of the
+      # @param [String] query A query string, following the BigQuery [query
+      #   syntax](https://cloud.google.com/bigquery/query-reference), of the
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
       # @param [Integer] timeout How long to wait for the query to complete, in
@@ -185,8 +185,8 @@ module Gcloud
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
-      #   For more information, see {query
-      #   caching}[https://developers.google.com/bigquery/querying-data].
+      #   For more information, see [query
+      #   caching](https://developers.google.com/bigquery/querying-data).
       # @param [String] dataset Specifies the default datasetId and projectId to
       #   assume for any unqualified table names in the query. If not set, all
       #   table names in the query string must be qualified in the format
@@ -262,8 +262,8 @@ module Gcloud
       #   (one hour).
       # @param [Array<Hash>] access The access rules for a Dataset using the
       #   Google Cloud Datastore API data structure of an array of hashes. See
-      #   {BigQuery Access
-      #   Control}[https://cloud.google.com/bigquery/access-control] for more
+      #   [BigQuery Access
+      #   Control](https://cloud.google.com/bigquery/access-control) for more
       #   information.
       #
       # @return [Gcloud::Bigquery::Dataset]

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -24,7 +24,7 @@ require "gcloud/bigquery/query_data"
 module Gcloud
   module Bigquery
     ##
-    # = Project
+    # # Project
     #
     # Projects are top-level containers in Google Cloud Platform. They store
     # information about billing and authorized users, and they contain BigQuery

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -92,8 +92,8 @@ module Gcloud
       #   query to execute. Example: "SELECT count(f1) FROM
       #   [myProjectId:myDatasetId.myTableId]".
       # @param [String] priority Specifies a priority for the query. Possible
-      #   values include +INTERACTIVE+ and +BATCH+. The default value is
-      #   +INTERACTIVE+.
+      #   values include `INTERACTIVE` and `BATCH`. The default value is
+      #   `INTERACTIVE`.
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
@@ -106,23 +106,23 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
-      #   * +needed+ - Create the table if it does not exist.
-      #   * +never+ - The table must already exist. A 'notFound' error is
+      #   * `needed` - Create the table if it does not exist.
+      #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
       # @param [String] write Specifies the action that occurs if the
       #   destination table already exists.
       #
       #   The following values are supported:
-      #   * +truncate+ - BigQuery overwrites the table data.
-      #   * +append+ - BigQuery appends the data to the table.
-      #   * +empty+ - A 'duplicate' error is returned in the job result if the
+      #   * `truncate` - BigQuery overwrites the table data.
+      #   * `append` - BigQuery appends the data to the table.
+      #   * `empty` - A 'duplicate' error is returned in the job result if the
       #     table exists and contains data.
-      # @param [Boolean] large_results If +true+, allows the query to produce
+      # @param [Boolean] large_results If `true`, allows the query to produce
       #   arbitrarily large result tables at a slight cost in performance.
-      #   Requires +table+ parameter to be set.
+      #   Requires `table` parameter to be set.
       # @param [Boolean] flatten Flattens all nested and repeated fields in the
-      #   query results. The default value is +true+. +large_results+ parameter
-      #   must be +true+ if this is set to +false+.
+      #   query results. The default value is `true`. `large_results` parameter
+      #   must be `true` if this is set to `false`.
       # @param [Dataset, String] dataset Specifies the default dataset to use
       #   for unqualified table names in the query.
       #
@@ -178,10 +178,10 @@ module Gcloud
       #   longer to run than the timeout value, the call returns without any
       #   results and with QueryData#complete? set to false. The default value
       #   is 10000 milliseconds (10 seconds).
-      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      # @param [Boolean] dryrun If set to `true`, BigQuery doesn't run the job.
       #   Instead, if the query is valid, BigQuery returns statistics about the
       #   job such as how many bytes would be processed. If the query is
-      #   invalid, an error returns. The default value is +false+.
+      #   invalid, an error returns. The default value is `false`.
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
@@ -192,7 +192,7 @@ module Gcloud
       #   table names in the query string must be qualified in the format
       #   'datasetId.tableId'.
       # @param [String] project Specifies the default projectId to assume for
-      #   any unqualified table names in the query. Only used if +dataset+
+      #   any unqualified table names in the query. Only used if `dataset`
       #   option is set.
       #
       # @return [Gcloud::Bigquery::QueryData]
@@ -226,7 +226,7 @@ module Gcloud
       #
       # @param [String] dataset_id The ID of a dataset.
       #
-      # @return [Gcloud::Bigquery::Dataset, nil] Returns +nil+ if the dataset
+      # @return [Gcloud::Bigquery::Dataset, nil] Returns `nil` if the dataset
       #   does not exist.
       #
       # @example
@@ -286,7 +286,7 @@ module Gcloud
       #                                     name: "My Dataset",
       #                                     description: "This is my Dataset"
       #
-      # @example Access rules can be provided with the +access+ option:
+      # @example Access rules can be provided with the `access` option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -326,7 +326,7 @@ module Gcloud
       # Retrieves the list of datasets belonging to the project.
       #
       # @param [Boolean] all Whether to list all datasets, including hidden
-      #   ones. The default is +false+.
+      #   ones. The default is `false`.
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
       # @param [Integer] max Maximum number of datasets to return.
@@ -345,7 +345,7 @@ module Gcloud
       #     puts dataset.name
       #   end
       #
-      # @example Retrieve all datasets, including hidden ones, with +:all+:
+      # @example Retrieve all datasets, including hidden ones, with `:all`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -387,7 +387,7 @@ module Gcloud
       #
       # @param [String] job_id The ID of a job.
       #
-      # @return [Gcloud::Bigquery::Job, nil] Returns +nil+ if the job does not
+      # @return [Gcloud::Bigquery::Job, nil] Returns `nil` if the job does not
       #   exist.
       #
       # @example
@@ -413,16 +413,16 @@ module Gcloud
       # Retrieves the list of jobs belonging to the project.
       #
       # @param [Boolean] all Whether to display jobs owned by all users in the
-      #   project. The default is +false+.
+      #   project. The default is `false`.
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
       # @param [Integer] max Maximum number of jobs to return.
       # @param [String] filter A filter for job state.
       #
       #   Acceptable values are:
-      #   * +done+ - Finished jobs
-      #   * +pending+ - Pending jobs
-      #   * +running+ - Running jobs
+      #   * `done` - Finished jobs
+      #   * `pending` - Pending jobs
+      #   * `running` - Running jobs
       #
       # @return [Array<Gcloud::Bigquery::Job>] (See
       #   {Gcloud::Bigquery::Job::List})
@@ -435,7 +435,7 @@ module Gcloud
       #
       #   jobs = bigquery.jobs
       #
-      # @example Retrieve only running jobs using the +:filter+ option:
+      # @example Retrieve only running jobs using the `:filter` option:
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/bigquery/query_data.rb
+++ b/lib/gcloud/bigquery/query_data.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/bigquery/data"
 

--- a/lib/gcloud/bigquery/query_data.rb
+++ b/lib/gcloud/bigquery/query_data.rb
@@ -18,7 +18,7 @@ require "gcloud/bigquery/data"
 module Gcloud
   module Bigquery
     ##
-    # = QueryData
+    # # QueryData
     #
     # Represents Data returned from a query a a list of name/value pairs.
     class QueryData < Data

--- a/lib/gcloud/bigquery/query_data.rb
+++ b/lib/gcloud/bigquery/query_data.rb
@@ -23,10 +23,11 @@ module Gcloud
     # Represents Data returned from a query a a list of name/value pairs.
     class QueryData < Data
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
-      def initialize arr = [] #:nodoc:
+      # @private
+      def initialize arr = []
         @job = nil
         super
       end
@@ -89,7 +90,7 @@ module Gcloud
       end
 
       ##
-      # The BigQuery Job that was created to run the query.
+      # The BigQuery {Job} that was created to run the query.
       def job
         return @job if @job
         return nil unless job?
@@ -104,8 +105,8 @@ module Gcloud
       end
 
       ##
-      # New Data from a response object.
-      def self.from_gapi gapi, connection #:nodoc:
+      # @private New Data from a response object.
+      def self.from_gapi gapi, connection
         formatted_rows = format_rows gapi["rows"],
                                      gapi["schema"]["fields"]
 

--- a/lib/gcloud/bigquery/query_data.rb
+++ b/lib/gcloud/bigquery/query_data.rb
@@ -38,7 +38,7 @@ module Gcloud
       end
 
       # Whether the query has completed or not. When data is present this will
-      # always be +true+. When +false+, +total+ will not be available.
+      # always be `true`. When `false`, `total` will not be available.
       def complete?
         @gapi["jobComplete"]
       end

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Bigquery

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -28,14 +28,14 @@ module Gcloud
     #
     class QueryJob < Job
       ##
-      # Checks if the priority for the query is +BATCH+.
+      # Checks if the priority for the query is `BATCH`.
       def batch?
         val = config["query"]["priority"]
         val == "BATCH"
       end
 
       ##
-      # Checks if the priority for the query is +INTERACTIVE+.
+      # Checks if the priority for the query is `INTERACTIVE`.
       def interactive?
         val = config["query"]["priority"]
         return true if val.nil?
@@ -63,8 +63,8 @@ module Gcloud
 
       ##
       # Checks if the query job flattens nested and repeated fields in the query
-      # results. The default is +true+. If the value is +false+, #large_results?
-      # should return +true+.
+      # results. The default is `true`. If the value is `false`, #large_results?
+      # should return `true`.
       def flatten?
         val = config["query"]["flattenResults"]
         return true if val.nil?

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -18,14 +18,13 @@ module Gcloud
     ##
     # = QueryJob
     #
-    # A Job subclass representing a query operation that may be performed
-    # on a Table. A QueryJob instance is created when you call
-    # Project#query_job, Dataset#query_job, or View#data.
+    # A {Job} subclass representing a query operation that may be performed
+    # on a {Table}. A QueryJob instance is created when you call
+    # {Project#query_job}, {Dataset#query_job}, or {View#data}.
     #
-    # See {Querying Data}[https://cloud.google.com/bigquery/querying-data]
-    # and the {Jobs API
-    # reference}[https://cloud.google.com/bigquery/docs/reference/v2/jobs]
-    # for details.
+    # @see https://cloud.google.com/bigquery/querying-data Querying Data
+    # @see https://cloud.google.com/bigquery/docs/reference/v2/jobs Jobs API
+    #   reference
     #
     class QueryJob < Job
       ##
@@ -97,25 +96,17 @@ module Gcloud
       ##
       # Retrieves the query results for the job.
       #
-      # === Parameters
+      # @param [String] token Page token, returned by a previous call,
+      #   identifying the result set.
+      # @param [Integer] max Maximum number of results to return.
+      # @param [Integer] start Zero-based index of the starting row to read.
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before returning. Default is 10,000 milliseconds (10
+      #   seconds).
       #
-      # +token+::
-      #   Page token, returned by a previous call, identifying the result set.
-      #   (+String+)
-      # +max+::
-      #   Maximum number of results to return. (+Integer+)
-      # +start+::
-      #   Zero-based index of the starting row to read. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   returning. Default is 10,000 milliseconds (10 seconds). (+Integer+)
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -16,7 +16,7 @@
 module Gcloud
   module Bigquery
     ##
-    # = QueryJob
+    # # QueryJob
     #
     # A {Job} subclass representing a query operation that may be performed
     # on a {Table}. A QueryJob instance is created when you call

--- a/lib/gcloud/bigquery/query_job.rb
+++ b/lib/gcloud/bigquery/query_job.rb
@@ -53,8 +53,8 @@ module Gcloud
 
       ##
       # Checks if the query job looks for an existing result in the query cache.
-      # For more information, see {Query
-      # Caching}[https://cloud.google.com/bigquery/querying-data#querycaching].
+      # For more information, see [Query
+      # Caching](https://cloud.google.com/bigquery/querying-data#querycaching).
       def cache?
         val = config["query"]["useQueryCache"]
         return false if val.nil?

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -24,7 +24,7 @@ require "gcloud/upload"
 module Gcloud
   module Bigquery
     ##
-    # = Table
+    # # Table
     #
     # A named resource representing a BigQuery table that holds zero or more
     # records. Every table is defined by a schema that may contain nested and
@@ -707,7 +707,7 @@ module Gcloud
       #   file = File.open "my_data.csv"
       #   load_job = table.load file
       #
-      # === A note about large direct uploads
+      # ### A note about large direct uploads
       #
       # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to
       # upload large files. To avoid this problem, add the

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/bigquery/view"
 require "gcloud/bigquery/data"

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -120,8 +120,8 @@ module Gcloud
 
       ##
       # The combined Project ID, Dataset ID, and Table ID for this table, in the
-      # format specified by the {Query
-      # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+      # format specified by the [Query
+      # Reference](https://cloud.google.com/bigquery/query-reference#from):
       # +project_name:datasetId.tableId+. To use this value in queries see
       # {#query_id}.
       #
@@ -133,8 +133,8 @@ module Gcloud
 
       ##
       # The value returned by {#id}, wrapped in square brackets if the Project
-      # ID contains dashes, as specified by the {Query
-      # Reference}[https://cloud.google.com/bigquery/query-reference#from].
+      # ID contains dashes, as specified by the [Query
+      # Reference](https://cloud.google.com/bigquery/query-reference#from).
       # Useful in queries.
       #
       # @example
@@ -294,8 +294,8 @@ module Gcloud
 
       ##
       # Returns the table's schema as hash containing the keys and values
-      # returned by the Google Cloud BigQuery {Rest API
-      # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource].
+      # returned by the Google Cloud BigQuery [Rest API
+      # ](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource).
       # This method can also be used to set, replace, or add to the schema by
       # passing a block. See {Table::Schema} for available methods. To set the
       # schema by passing a hash instead, use {#schema=}.
@@ -341,8 +341,8 @@ module Gcloud
       # To update the schema using a block instead, use #schema.
       #
       # @param [Hash] new_schema A hash containing keys and values as specified
-      #   by the Google Cloud BigQuery {Rest API
-      #   }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
+      #   by the Google Cloud BigQuery [Rest API
+      #   ](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource)
       #   .
       #
       # @example
@@ -437,8 +437,8 @@ module Gcloud
       ##
       # Copies the data from the table to another table.
       # The destination table argument can also be a string identifier as
-      # specified by the {Query
-      # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+      # specified by the [Query
+      # Reference](https://cloud.google.com/bigquery/query-reference#from):
       # +project_name:datasetId.tableId+. This is useful for referencing tables
       # in other projects and datasets.
       #
@@ -548,8 +548,8 @@ module Gcloud
       #
       #   The following values are supported:
       #   * +csv+ - CSV
-      #   * +json+ - {Newline-delimited JSON}[http://jsonlines.org/]
-      #   * +avro+ - {Avro}[http://avro.apache.org/]
+      #   * +json+ - [Newline-delimited JSON](http://jsonlines.org/)
+      #   * +avro+ - [Avro](http://avro.apache.org/)
       # @param [String] compression The compression type to use for exported
       #   files. Possible values include +GZIP+ and +NONE+. The default value is
       #   +NONE+.
@@ -590,8 +590,8 @@ module Gcloud
       ##
       # Loads data into the table. You can pass a gcloud storage file path or
       # a gcloud storage file instance. Or, you can upload a file directly.
-      # See {Loading Data with a POST Request}[
-      # https://cloud.google.com/bigquery/loading-data-post-request#multipart].
+      # See [Loading Data with a POST Request](
+      # https://cloud.google.com/bigquery/loading-data-post-request#multipart).
       #
       # @param [File, Gcloud::Storage::File, String] file A file or the URI of a
       #   Google Cloud Storage file containing data to load into the table.
@@ -600,8 +600,8 @@ module Gcloud
       #
       #   The following values are supported:
       #   * +csv+ - CSV
-      #   * +json+ - {Newline-delimited JSON}[http://jsonlines.org/]
-      #   * +avro+ - {Avro}[http://avro.apache.org/]
+      #   * +json+ - [Newline-delimited JSON](http://jsonlines.org/)
+      #   * +avro+ - [Avro](http://avro.apache.org/)
       #   * +datastore_backup+ - Cloud Datastore backup
       # @param [String] create Specifies whether the job is allowed to create
       #   new tables.
@@ -711,14 +711,14 @@ module Gcloud
       #
       # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to
       # upload large files. To avoid this problem, add the
-      # {httpclient}[https://rubygems.org/gems/httpclient] gem to your project,
+      # [httpclient](https://rubygems.org/gems/httpclient) gem to your project,
       # and the line (or lines) of configuration shown below. These lines must
       # execute after you require gcloud but before you make your first gcloud
       # connection. The first statement configures
-      # {Faraday}[https://rubygems.org/gems/faraday] to use httpclient. The
+      # [Faraday](https://rubygems.org/gems/faraday) to use httpclient. The
       # second statement, which should only be added if you are using a version
-      # of Faraday at or above 0.9.2, is a workaround for {this gzip
-      # issue}[https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367].
+      # of Faraday at or above 0.9.2, is a workaround for [this gzip
+      # issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -91,7 +91,7 @@ module Gcloud
       end
 
       ##
-      # The ID of the +Dataset+ containing this table.
+      # The ID of the `Dataset` containing this table.
       #
       # @!group Attributes
       #
@@ -100,7 +100,7 @@ module Gcloud
       end
 
       ##
-      # The ID of the +Project+ containing this table.
+      # The ID of the `Project` containing this table.
       #
       # @!group Attributes
       #
@@ -122,7 +122,7 @@ module Gcloud
       # The combined Project ID, Dataset ID, and Table ID for this table, in the
       # format specified by the [Query
       # Reference](https://cloud.google.com/bigquery/query-reference#from):
-      # +project_name:datasetId.tableId+. To use this value in queries see
+      # `project_name:datasetId.tableId`. To use this value in queries see
       # {#query_id}.
       #
       # @!group Attributes
@@ -301,10 +301,10 @@ module Gcloud
       # schema by passing a hash instead, use {#schema=}.
       #
       # @param [Boolean] replace Whether to replace the existing schema with the
-      #   new schema. If +true+, the fields will replace the existing schema. If
-      #   +false+, the fields will be added to the existing schema. When a table
+      #   new schema. If `true`, the fields will replace the existing schema. If
+      #   `false`, the fields will be added to the existing schema. When a table
       #   already contains data, schema changes must be additive. Thus, the
-      #   default value is +false+.
+      #   default value is `false`.
       #
       # @example
       #   require "gcloud"
@@ -439,7 +439,7 @@ module Gcloud
       # The destination table argument can also be a string identifier as
       # specified by the [Query
       # Reference](https://cloud.google.com/bigquery/query-reference#from):
-      # +project_name:datasetId.tableId+. This is useful for referencing tables
+      # `project_name:datasetId.tableId`. This is useful for referencing tables
       # in other projects and datasets.
       #
       # @param [Table, String] destination_table The destination for the copied
@@ -448,16 +448,16 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
-      #   * +needed+ - Create the table if it does not exist.
-      #   * +never+ - The table must already exist. A 'notFound' error is
+      #   * `needed` - Create the table if it does not exist.
+      #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
       # @param [String] write Specifies how to handle data already present in
-      #   the destination table. The default value is +empty+.
+      #   the destination table. The default value is `empty`.
       #
       #   The following values are supported:
-      #   * +truncate+ - BigQuery overwrites the table data.
-      #   * +append+ - BigQuery appends the data to the table.
-      #   * +empty+ - An error will be returned if the destination table already
+      #   * `truncate` - BigQuery overwrites the table data.
+      #   * `append` - BigQuery appends the data to the table.
+      #   * `empty` - An error will be returned if the destination table already
       #     contains data.
       #
       # @return [Gcloud::Bigquery::CopyJob]
@@ -507,16 +507,16 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
-      #   * +needed+ - Create the table if it does not exist.
-      #   * +never+ - The table must already exist. A 'notFound' error is
+      #   * `needed` - Create the table if it does not exist.
+      #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
       # @param [String] write Specifies how to handle data already present in
-      #   the destination table. The default value is +empty+.
+      #   the destination table. The default value is `empty`.
       #
       #   The following values are supported:
-      #   * +truncate+ - BigQuery overwrites the table data.
-      #   * +append+ - BigQuery appends the data to the table.
-      #   * +empty+ - An error will be returned if the destination table already
+      #   * `truncate` - BigQuery overwrites the table data.
+      #   * `append` - BigQuery appends the data to the table.
+      #   * `empty` - An error will be returned if the destination table already
       #     contains data.
       #
       # @return [Gcloud::Bigquery::Job]
@@ -544,19 +544,19 @@ module Gcloud
       #   Google Storage file or file URI pattern(s) to which BigQuery should
       #   extract the table data.
       # @param [String] format The exported file format. The default value is
-      #   +csv+.
+      #   `csv`.
       #
       #   The following values are supported:
-      #   * +csv+ - CSV
-      #   * +json+ - [Newline-delimited JSON](http://jsonlines.org/)
-      #   * +avro+ - [Avro](http://avro.apache.org/)
+      #   * `csv` - CSV
+      #   * `json` - [Newline-delimited JSON](http://jsonlines.org/)
+      #   * `avro` - [Avro](http://avro.apache.org/)
       # @param [String] compression The compression type to use for exported
-      #   files. Possible values include +GZIP+ and +NONE+. The default value is
-      #   +NONE+.
+      #   files. Possible values include `GZIP` and `NONE`. The default value is
+      #   `NONE`.
       # @param [String] delimiter Delimiter to use between fields in the
       #   exported data. Default is <code>,</code>.
       # @param [Boolean] header Whether to print out a header row in the
-      #   results. Default is +true+.
+      #   results. Default is `true`.
       #
       #
       # @return [Gcloud::Bigquery::ExtractJob]
@@ -596,48 +596,48 @@ module Gcloud
       # @param [File, Gcloud::Storage::File, String] file A file or the URI of a
       #   Google Cloud Storage file containing data to load into the table.
       # @param [String] format The exported file format. The default value is
-      #   +csv+.
+      #   `csv`.
       #
       #   The following values are supported:
-      #   * +csv+ - CSV
-      #   * +json+ - [Newline-delimited JSON](http://jsonlines.org/)
-      #   * +avro+ - [Avro](http://avro.apache.org/)
-      #   * +datastore_backup+ - Cloud Datastore backup
+      #   * `csv` - CSV
+      #   * `json` - [Newline-delimited JSON](http://jsonlines.org/)
+      #   * `avro` - [Avro](http://avro.apache.org/)
+      #   * `datastore_backup` - Cloud Datastore backup
       # @param [String] create Specifies whether the job is allowed to create
       #   new tables.
       #
       #   The following values are supported:
-      #   * +needed+ - Create the table if it does not exist.
-      #   * +never+ - The table must already exist. A 'notFound' error is
+      #   * `needed` - Create the table if it does not exist.
+      #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
       # @param [String] write Specifies how to handle data already present in
-      #   the table. The default value is +empty+.
+      #   the table. The default value is `empty`.
       #
       #   The following values are supported:
-      #   * +truncate+ - BigQuery overwrites the table data.
-      #   * +append+ - BigQuery appends the data to the table.
-      #   * +empty+ - An error will be returned if the table already contains
+      #   * `truncate` - BigQuery overwrites the table data.
+      #   * `append` - BigQuery appends the data to the table.
+      #   * `empty` - An error will be returned if the table already contains
       #     data.
-      # @param [Array<String>] projection_fields If the +format+ option is set
-      #   to +datastore_backup+, indicates which entity properties to load from
+      # @param [Array<String>] projection_fields If the `format` option is set
+      #   to `datastore_backup`, indicates which entity properties to load from
       #   a Cloud Datastore backup. Property names are case sensitive and must
       #   be top-level properties. If not set, BigQuery loads all properties. If
       #   any named property isn't found in the Cloud Datastore backup, an
       #   invalid error is returned.
       # @param [Boolean] jagged_rows Accept rows that are missing trailing
-      #   optional columns. The missing values are treated as nulls. If +false+,
+      #   optional columns. The missing values are treated as nulls. If `false`,
       #   records with missing trailing columns are treated as bad records, and
       #   if there are too many bad records, an invalid error is returned in the
-      #   job result. The default value is +false+. Only applicable to CSV,
+      #   job result. The default value is `false`. Only applicable to CSV,
       #   ignored for other formats.
       # @param [Boolean] quoted_newlines Indicates if BigQuery should allow
       #   quoted data sections that contain newline characters in a CSV file.
-      #   The default value is +false+.
+      #   The default value is `false`.
       # @param [String] encoding The character encoding of the data. The
-      #   supported values are +UTF-8+ or +ISO-8859-1+. The default value is
-      #   +UTF-8+.
+      #   supported values are `UTF-8` or `ISO-8859-1`. The default value is
+      #   `UTF-8`.
       # @param [String] delimiter Specifices the separator for fields in a CSV
-      #   file. BigQuery converts the string to +ISO-8859-1+ encoding, and then
+      #   file. BigQuery converts the string to `ISO-8859-1` encoding, and then
       #   uses the first byte of the encoded string to split the data in its
       #   raw, binary state. Default is <code>,</code>.
       # @param [Boolean] ignore_unknown Indicates if BigQuery should allow extra
@@ -645,17 +645,17 @@ module Gcloud
       #   extra values are ignored. If false, records with extra columns are
       #   treated as bad records, and if there are too many bad records, an
       #   invalid error is returned in the job result. The default value is
-      #   +false+.
+      #   `false`.
       #
-      #   The +format+ property determines what BigQuery treats as an extra
+      #   The `format` property determines what BigQuery treats as an extra
       #   value:
       #
-      #   * +CSV+: Trailing columns
-      #   * +JSON+: Named values that don't match any column names
+      #   * `CSV`: Trailing columns
+      #   * `JSON`: Named values that don't match any column names
       # @param [Integer] max_bad_records The maximum number of bad records that
       #   BigQuery can ignore when running the job. If the number of bad records
       #   exceeds this value, an invalid error is returned in the job result.
-      #   The default value is +0+, which requires that all records are valid.
+      #   The default value is `0`, which requires that all records are valid.
       # @param [String] quote The value that is used to quote data sections in a
       #   CSV file. BigQuery converts the string to ISO-8859-1 encoding, and
       #   then uses the first byte of the encoded string to split the data in
@@ -666,7 +666,7 @@ module Gcloud
       #   to true.
       # @param [Integer] skip_leading The number of rows at the top of a CSV
       #   file that BigQuery will skip when loading the data. The default value
-      #   is +0+. This property is useful if you have header rows in the file
+      #   is `0`. This property is useful if you have header rows in the file
       #   that should be skipped.
       #
       # @return [Gcloud::Bigquery::LoadJob]
@@ -763,7 +763,7 @@ module Gcloud
       # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
       #   containing the data.
       # @param [Boolean] skip_invalid Insert all valid rows of a request, even
-      #   if invalid rows exist. The default value is +false+, which causes the
+      #   if invalid rows exist. The default value is `false`, which causes the
       #   entire request to fail if any invalid rows exist.
       # @param [Boolean] ignore_unknown Accept rows that contain values that do
       #   not match the schema. The unknown values are ignored. Default is
@@ -802,7 +802,7 @@ module Gcloud
       ##
       # Permanently deletes the table.
       #
-      # @return [Boolean] Returns +true+ if the table was deleted.
+      # @return [Boolean] Returns `true` if the table was deleted.
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -27,11 +27,13 @@ module Gcloud
     # = Table
     #
     # A named resource representing a BigQuery table that holds zero or more
-    # records. Every table is defined by a schema
-    # that may contain nested and repeated fields. (For more information
-    # about nested and repeated fields, see {Preparing Data for
-    # BigQuery}[https://cloud.google.com/bigquery/preparing-data-for-bigquery].)
+    # records. Every table is defined by a schema that may contain nested and
+    # repeated fields.
     #
+    # @see https://cloud.google.com/bigquery/preparing-data-for-bigquery
+    #   Preparing Data for BigQuery
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -63,16 +65,16 @@ module Gcloud
     #
     class Table
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Table object.
-      def initialize #:nodoc:
+      # @private Create an empty Table object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -82,7 +84,7 @@ module Gcloud
       # The ID must contain only letters (a-z, A-Z), numbers (0-9),
       # or underscores (_). The maximum length is 1,024 characters.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table_id
         @gapi["tableReference"]["tableId"]
@@ -91,7 +93,7 @@ module Gcloud
       ##
       # The ID of the +Dataset+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def dataset_id
         @gapi["tableReference"]["datasetId"]
@@ -100,16 +102,17 @@ module Gcloud
       ##
       # The ID of the +Project+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def project_id
         @gapi["tableReference"]["projectId"]
       end
 
       ##
+      # @private
       # The gapi fragment containing the Project ID, Dataset ID, and Table ID as
       # a camel-cased hash.
-      def table_ref #:nodoc:
+      def table_ref
         table_ref = @gapi["tableReference"]
         table_ref = table_ref.to_hash if table_ref.respond_to? :to_hash
         table_ref
@@ -120,22 +123,21 @@ module Gcloud
       # format specified by the {Query
       # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
       # +project_name:datasetId.tableId+. To use this value in queries see
-      # #query_id.
+      # {#query_id}.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def id
         @gapi["id"]
       end
 
       ##
-      # The value returned by #id, wrapped in square brackets if the Project ID
-      # contains dashes, as specified by the {Query
+      # The value returned by {#id}, wrapped in square brackets if the Project
+      # ID contains dashes, as specified by the {Query
       # Reference}[https://cloud.google.com/bigquery/query-reference#from].
       # Useful in queries.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -145,7 +147,7 @@ module Gcloud
       #
       #   data = bigquery.query "SELECT name FROM #{table.query_id}"
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def query_id
         project_id["-"] ? "[#{id}]" : id
@@ -154,7 +156,7 @@ module Gcloud
       ##
       # The name of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name
         @gapi["friendlyName"]
@@ -163,7 +165,7 @@ module Gcloud
       ##
       # Updates the name of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name= new_name
         patch_gapi! name: new_name
@@ -172,7 +174,7 @@ module Gcloud
       ##
       # A string hash of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def etag
         ensure_full_data!
@@ -182,7 +184,7 @@ module Gcloud
       ##
       # A URL that can be used to access the dataset using the REST API.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def api_url
         ensure_full_data!
@@ -192,7 +194,7 @@ module Gcloud
       ##
       # The description of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description
         ensure_full_data!
@@ -202,7 +204,7 @@ module Gcloud
       ##
       # Updates the description of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description= new_description
         patch_gapi! description: new_description
@@ -211,7 +213,7 @@ module Gcloud
       ##
       # The number of bytes in the table.
       #
-      # :category: Data
+      # @!group Data
       #
       def bytes_count
         ensure_full_data!
@@ -221,7 +223,7 @@ module Gcloud
       ##
       # The number of rows in the table.
       #
-      # :category: Data
+      # @!group Data
       #
       def rows_count
         ensure_full_data!
@@ -231,7 +233,7 @@ module Gcloud
       ##
       # The time when this table was created.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def created_at
         ensure_full_data!
@@ -243,7 +245,7 @@ module Gcloud
       # If not present, the table will persist indefinitely.
       # Expired tables will be deleted and their storage reclaimed.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def expires_at
         ensure_full_data!
@@ -254,7 +256,7 @@ module Gcloud
       ##
       # The date when this table was last modified.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def modified_at
         ensure_full_data!
@@ -264,7 +266,7 @@ module Gcloud
       ##
       # Checks if the table's type is "TABLE".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table?
         @gapi["type"] == "TABLE"
@@ -273,7 +275,7 @@ module Gcloud
       ##
       # Checks if the table's type is "VIEW".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def view?
         @gapi["type"] == "VIEW"
@@ -283,7 +285,7 @@ module Gcloud
       # The geographic location where the table should reside. Possible
       # values include EU and US. The default value is US.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def location
         ensure_full_data!
@@ -295,20 +297,16 @@ module Gcloud
       # returned by the Google Cloud BigQuery {Rest API
       # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource].
       # This method can also be used to set, replace, or add to the schema by
-      # passing a block. See Table::Schema for available methods. To set the
-      # schema by passing a hash instead, use #schema=.
+      # passing a block. See {Table::Schema} for available methods. To set the
+      # schema by passing a hash instead, use {#schema=}.
       #
-      # === Parameters
-      #
-      # +replace+::
-      #   Whether to replace the existing schema with the new schema. If
-      #   +true+, the fields will replace the existing schema. If
+      # @param [Boolean] replace Whether to replace the existing schema with the
+      #   new schema. If +true+, the fields will replace the existing schema. If
       #   +false+, the fields will be added to the existing schema. When a table
       #   already contains data, schema changes must be additive. Thus, the
-      #   default value is +false+. (+Boolean+)
+      #   default value is +false+.
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -324,7 +322,7 @@ module Gcloud
       #     end
       #   end
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def schema replace: false
         ensure_full_data!
@@ -342,16 +340,12 @@ module Gcloud
       # Updates the schema of the table.
       # To update the schema using a block instead, use #schema.
       #
-      # === Parameters
-      #
-      # +schema+::
-      #   A hash containing keys and values as specified by the Google Cloud
-      #   BigQuery {Rest API
+      # @param [Hash] new_schema A hash containing keys and values as specified
+      #   by the Google Cloud BigQuery {Rest API
       #   }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
-      #   . (+Hash+)
+      #   .
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -375,7 +369,7 @@ module Gcloud
       #   }
       #   table.schema = schema
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def schema= new_schema
         patch_gapi! schema: new_schema
@@ -384,7 +378,7 @@ module Gcloud
       ##
       # The fields of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def fields
         f = schema["fields"]
@@ -396,7 +390,7 @@ module Gcloud
       ##
       # The names of the columns in the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def headers
         fields.map { |f| f["name"] }
@@ -405,22 +399,15 @@ module Gcloud
       ##
       # Retrieves data from the table.
       #
-      # === Parameters
+      # @param [String] token Page token, returned by a previous call,
+      #   identifying the result set.
       #
-      # +token+::
-      #   Page token, returned by a previous call, identifying the result set.
-      #   (+String+)
-      # +max+::
-      #   Maximum number of results to return. (+Integer+)
-      # +start+::
-      #   Zero-based index of the starting row to read. (+Integer+)
+      # @param [Integer] max Maximum number of results to return.
+      # @param [Integer] start Zero-based index of the starting row to read.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Data]
       #
-      # Gcloud::Bigquery::Data
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -434,7 +421,7 @@ module Gcloud
       #   end
       #   more_data = table.data token: data.token
       #
-      # :category: Data
+      # @!group Data
       #
       def data token: nil, max: nil, start: nil
         ensure_connection!
@@ -449,21 +436,23 @@ module Gcloud
 
       ##
       # Copies the data from the table to another table.
+      # The destination table argument can also be a string identifier as
+      # specified by the {Query
+      # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
+      # +project_name:datasetId.tableId+. This is useful for referencing tables
+      # in other projects and datasets.
       #
-      # === Parameters
-      #
-      # +destination_table+::
-      #   The destination for the copied data. (+Table+ or +String+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      # @param [Table, String] destination_table The destination for the copied
+      #   data.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies how to handle data already present in the destination table.
-      #   The default value is +empty+. (+String+)
+      # @param [String] write Specifies how to handle data already present in
+      #   the destination table. The default value is +empty+.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
@@ -471,12 +460,9 @@ module Gcloud
       #   * +empty+ - An error will be returned if the destination table already
       #     contains data.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::CopyJob]
       #
-      # Gcloud::Bigquery::CopyJob
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -487,12 +473,7 @@ module Gcloud
       #
       #   copy_job = table.copy destination_table
       #
-      # The destination table argument can also be a string identifier as
-      # specified by the {Query
-      # Reference}[https://cloud.google.com/bigquery/query-reference#from]:
-      # +project_name:datasetId.tableId+. This is useful for referencing tables
-      # in other projects and datasets.
-      #
+      # @example Passing a string identifier for the destination table:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -502,7 +483,7 @@ module Gcloud
       #
       #   copy_job = table.copy "other-project:other_dataset.other_table"
       #
-      # :category: Data
+      # @!group Data
       #
       def copy destination_table, create: nil, write: nil, dryrun: nil
         ensure_connection!
@@ -518,36 +499,31 @@ module Gcloud
       end
 
       ##
+      # @private
       # Links the table to a source table identified by a URI.
       #
-      # === Parameters
-      #
-      # +source_url+::
-      #   The URI of source table to link. (+String+)
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      # @param [String] source_url The URI of source table to link.
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies how to handle data already present in the table.
-      #   The default value is +empty+. (+String+)
+      # @param [String] write Specifies how to handle data already present in
+      #   the destination table. The default value is +empty+.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
-      #   * +empty+ - An error will be returned if the table already contains
-      #     data.
+      #   * +empty+ - An error will be returned if the destination table already
+      #     contains data.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::Job]
       #
-      # Gcloud::Bigquery::Job
+      # @!group Data
       #
-      # :category: Data
-      #
-      def link source_url, create: nil, write: nil, dryrun: nil #:nodoc:
+      def link source_url, create: nil, write: nil, dryrun: nil
         ensure_connection!
         options = { create: create, write: write, dryrun: dryrun }
         resp = connection.link_table table_ref, source_url, options
@@ -559,39 +535,33 @@ module Gcloud
       end
 
       ##
-      # Extract the data from the table to a Google Cloud Storage file. For
-      # more information, see {Exporting Data From BigQuery
-      # }[https://cloud.google.com/bigquery/exporting-data-from-bigquery].
+      # Extract the data from the table to a Google Cloud Storage file.
       #
-      # === Parameters
+      # @see https://cloud.google.com/bigquery/exporting-data-from-bigquery
+      #   Exporting Data From BigQuery
       #
-      # +extract_url+::
-      #   The Google Storage file or file URI pattern(s) to which BigQuery
-      #   should extract the table data.
-      #   (+Gcloud::Storage::File+ or +String+ or +Array+)
-      # +format+::
-      #   The exported file format. The default value is +csv+. (+String+)
+      # @param [Gcloud::Storage::File, String, Array<String>] extract_url The
+      #   Google Storage file or file URI pattern(s) to which BigQuery should
+      #   extract the table data.
+      # @param [String] format The exported file format. The default value is
+      #   +csv+.
       #
       #   The following values are supported:
       #   * +csv+ - CSV
       #   * +json+ - {Newline-delimited JSON}[http://jsonlines.org/]
       #   * +avro+ - {Avro}[http://avro.apache.org/]
-      # +compression+::
-      #   The compression type to use for exported files. Possible values
-      #   include +GZIP+ and +NONE+. The default value is +NONE+. (+String+)
-      # +delimiter+::
-      #   Delimiter to use between fields in the exported data. Default is
-      #   <code>,</code>. (+String+)
-      # +header+::
-      #   Whether to print out a header row in the results. Default is +true+.
-      #   (+Boolean+)
+      # @param [String] compression The compression type to use for exported
+      #   files. Possible values include +GZIP+ and +NONE+. The default value is
+      #   +NONE+.
+      # @param [String] delimiter Delimiter to use between fields in the
+      #   exported data. Default is <code>,</code>.
+      # @param [Boolean] header Whether to print out a header row in the
+      #   results. Default is +true+.
       #
-      # === Returns
       #
-      # Gcloud::Bigquery::ExtractJob
+      # @return [Gcloud::Bigquery::ExtractJob]
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -602,7 +572,7 @@ module Gcloud
       #   extract_job = table.extract "gs://my-bucket/file-name.json",
       #                               format: "json"
       #
-      # :category: Data
+      # @!group Data
       #
       def extract extract_url, format: nil, compression: nil, delimiter: nil,
                   header: nil, dryrun: nil
@@ -618,100 +588,90 @@ module Gcloud
       end
 
       ##
-      # Loads data into the table.
+      # Loads data into the table. You can pass a gcloud storage file path or
+      # a gcloud storage file instance. Or, you can upload a file directly.
+      # See {Loading Data with a POST Request}[
+      # https://cloud.google.com/bigquery/loading-data-post-request#multipart].
       #
-      # === Parameters
-      #
-      # +file+::
-      #   A file or the URI of a Google Cloud Storage file containing
-      #   data to load into the table.
-      #   (+File+ or +Gcloud::Storage::File+ or +String+)
-      # +format+::
-      #   The exported file format. The default value is +csv+. (+String+)
+      # @param [File, Gcloud::Storage::File, String] file A file or the URI of a
+      #   Google Cloud Storage file containing data to load into the table.
+      # @param [String] format The exported file format. The default value is
+      #   +csv+.
       #
       #   The following values are supported:
       #   * +csv+ - CSV
       #   * +json+ - {Newline-delimited JSON}[http://jsonlines.org/]
       #   * +avro+ - {Avro}[http://avro.apache.org/]
       #   * +datastore_backup+ - Cloud Datastore backup
-      # +create+::
-      #   Specifies whether the job is allowed to create new tables. (+String+)
+      # @param [String] create Specifies whether the job is allowed to create
+      #   new tables.
       #
       #   The following values are supported:
       #   * +needed+ - Create the table if it does not exist.
       #   * +never+ - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
-      # +write+::
-      #   Specifies how to handle data already present in the table.
-      #   The default value is +empty+. (+String+)
+      # @param [String] write Specifies how to handle data already present in
+      #   the table. The default value is +empty+.
       #
       #   The following values are supported:
       #   * +truncate+ - BigQuery overwrites the table data.
       #   * +append+ - BigQuery appends the data to the table.
       #   * +empty+ - An error will be returned if the table already contains
       #     data.
-      # +projection_fields+::
-      #   If the +format+ option is set to +datastore_backup+, indicates which
-      #   entity properties to load from a Cloud Datastore backup. Property
-      #   names are case sensitive and must be top-level properties. If not set,
-      #   BigQuery loads all properties. If any named property isn't found in
-      #   the Cloud Datastore backup, an invalid error is returned. (+Array+)
-      # +jagged_rows+::
-      #   Accept rows that are missing trailing optional columns. The missing
-      #   values are treated as nulls. If +false+, records with missing trailing
-      #   columns are treated as bad records, and if there are too many bad
-      #   records, an invalid error is returned in the job result. The default
-      #   value is +false+. Only applicable to CSV, ignored for other formats.
-      #   (+Boolean+)
-      # +quoted_newlines+::
-      #   Indicates if BigQuery should allow quoted data sections that contain
-      #   newline characters in a CSV file. The default value is +false+.
-      #   (+Boolean+)
-      # +encoding+::
-      #   The character encoding of the data. The supported values are +UTF-8+
-      #   or +ISO-8859-1+. The default value is +UTF-8+. (+String+)
-      # +delimiter+::
-      #   Specifices the separator for fields in a CSV file. BigQuery converts
-      #   the string to +ISO-8859-1+ encoding, and then uses the first byte of
-      #   the encoded string to split the data in its raw, binary state. Default
-      #   is <code>,</code>. (+String+)
-      # +ignore_unknown+::
-      #   Indicates if BigQuery should allow extra values that are not
-      #   represented in the table schema. If true, the extra values are
-      #   ignored. If false, records with extra columns are treated as bad
-      #   records, and if there are too many bad records, an invalid error is
-      #   returned in the job result. The default value is +false+. (+Boolean+)
+      # @param [Array<String>] projection_fields If the +format+ option is set
+      #   to +datastore_backup+, indicates which entity properties to load from
+      #   a Cloud Datastore backup. Property names are case sensitive and must
+      #   be top-level properties. If not set, BigQuery loads all properties. If
+      #   any named property isn't found in the Cloud Datastore backup, an
+      #   invalid error is returned.
+      # @param [Boolean] jagged_rows Accept rows that are missing trailing
+      #   optional columns. The missing values are treated as nulls. If +false+,
+      #   records with missing trailing columns are treated as bad records, and
+      #   if there are too many bad records, an invalid error is returned in the
+      #   job result. The default value is +false+. Only applicable to CSV,
+      #   ignored for other formats.
+      # @param [Boolean] quoted_newlines Indicates if BigQuery should allow
+      #   quoted data sections that contain newline characters in a CSV file.
+      #   The default value is +false+.
+      # @param [String] encoding The character encoding of the data. The
+      #   supported values are +UTF-8+ or +ISO-8859-1+. The default value is
+      #   +UTF-8+.
+      # @param [String] delimiter Specifices the separator for fields in a CSV
+      #   file. BigQuery converts the string to +ISO-8859-1+ encoding, and then
+      #   uses the first byte of the encoded string to split the data in its
+      #   raw, binary state. Default is <code>,</code>.
+      # @param [Boolean] ignore_unknown Indicates if BigQuery should allow extra
+      #   values that are not represented in the table schema. If true, the
+      #   extra values are ignored. If false, records with extra columns are
+      #   treated as bad records, and if there are too many bad records, an
+      #   invalid error is returned in the job result. The default value is
+      #   +false+.
       #
       #   The +format+ property determines what BigQuery treats as an extra
       #   value:
       #
       #   * +CSV+: Trailing columns
       #   * +JSON+: Named values that don't match any column names
-      # +max_bad_records+::
-      #   The maximum number of bad records that BigQuery can ignore when
-      #   running the job. If the number of bad records exceeds this value, an
-      #   invalid error is returned in the job result. The default value is +0+,
-      #   which requires that all records are valid. (+Integer+)
-      # +quote+::
-      #   The value that is used to quote data sections in a CSV file. BigQuery
-      #   converts the string to ISO-8859-1 encoding, and then uses the first
-      #   byte of the encoded string to split the data in its raw, binary state.
-      #   The default value is a double-quote <code>"</code>. If your data does
-      #   not contain quoted sections, set the property value to an empty
-      #   string. If your data contains quoted newline characters, you must also
-      #   set the allowQuotedNewlines property to true. (+String+)
-      # +skip_leading+::
-      #   The number of rows at the top of a CSV file that BigQuery will skip
-      #   when loading the data. The default value is +0+. This property is
-      #   useful if you have header rows in the file that should be skipped.
-      #   (+Integer+)
+      # @param [Integer] max_bad_records The maximum number of bad records that
+      #   BigQuery can ignore when running the job. If the number of bad records
+      #   exceeds this value, an invalid error is returned in the job result.
+      #   The default value is +0+, which requires that all records are valid.
+      # @param [String] quote The value that is used to quote data sections in a
+      #   CSV file. BigQuery converts the string to ISO-8859-1 encoding, and
+      #   then uses the first byte of the encoded string to split the data in
+      #   its raw, binary state. The default value is a double-quote
+      #   <code>"</code>. If your data does not contain quoted sections, set the
+      #   property value to an empty string. If your data contains quoted
+      #   newline characters, you must also set the allowQuotedNewlines property
+      #   to true.
+      # @param [Integer] skip_leading The number of rows at the top of a CSV
+      #   file that BigQuery will skip when loading the data. The default value
+      #   is +0+. This property is useful if you have header rows in the file
+      #   that should be skipped.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::LoadJob]
       #
-      # Gcloud::Bigquery::LoadJob
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -721,7 +681,7 @@ module Gcloud
       #
       #   load_job = table.load "gs://my-bucket/file-name.csv"
       #
-      # You can also pass a gcloud storage file instance.
+      # @example Pass a gcloud storage file instance:
       #
       #   require "gcloud"
       #   require "gcloud/storage"
@@ -736,10 +696,7 @@ module Gcloud
       #   file = bucket.file "file-name.csv"
       #   load_job = table.load file
       #
-      # Or, you can upload a file directly.
-      # See {Loading Data with a POST Request}[
-      # https://cloud.google.com/bigquery/loading-data-post-request#multipart].
-      #
+      # @example Upload a file directly:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -776,7 +733,7 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   bigquery = gcloud.bigquery
       #
-      # :category: Data
+      # @!group Data
       #
       def load file, format: nil, create: nil, write: nil,
                projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
@@ -798,29 +755,23 @@ module Gcloud
       ##
       # Inserts data into the table for near-immediate querying, without the
       # need to complete a #load operation before the data can appear in query
-      # results. See {Streaming Data Into BigQuery
-      # }[https://cloud.google.com/bigquery/streaming-data-into-bigquery].
+      # results.
       #
-      # === Parameters
+      # @see https://cloud.google.com/bigquery/streaming-data-into-bigquery
+      #   Streaming Data Into BigQuery
       #
-      # +rows+::
-      #   A hash object or array of hash objects containing the data.
-      #   (+Array+ or +Hash+)
-      # +skip_invalid+::
-      #   Insert all valid rows of a request, even if invalid rows exist. The
-      #   default value is +false+, which causes the entire request to fail if
-      #   any invalid rows exist. (+Boolean+)
-      # +ignore_unknown+::
-      #   Accept rows that contain values that do not match the schema. The
-      #   unknown values are ignored. Default is false, which treats unknown
-      #   values as errors. (+Boolean+)
+      # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
+      #   containing the data.
+      # @param [Boolean] skip_invalid Insert all valid rows of a request, even
+      #   if invalid rows exist. The default value is +false+, which causes the
+      #   entire request to fail if any invalid rows exist.
+      # @param [Boolean] ignore_unknown Accept rows that contain values that do
+      #   not match the schema. The unknown values are ignored. Default is
+      #   false, which treats unknown values as errors.
       #
-      # === Returns
+      # @return [Gcloud::Bigquery::InsertResponse]
       #
-      # Gcloud::Bigquery::InsertResponse
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -834,7 +785,7 @@ module Gcloud
       #   ]
       #   table.insert rows
       #
-      # :category: Data
+      # @!group Data
       #
       def insert rows, skip_invalid: nil, ignore_unknown: nil
         rows = [rows] if rows.is_a? Hash
@@ -851,12 +802,9 @@ module Gcloud
       ##
       # Permanently deletes the table.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the table was deleted.
       #
-      # +true+ if the table was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -866,7 +814,7 @@ module Gcloud
       #
       #   table.delete
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def delete
         ensure_connection!
@@ -881,7 +829,7 @@ module Gcloud
       ##
       # Reloads the table with current data from the BigQuery service.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def reload!
         ensure_connection!
@@ -895,8 +843,8 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # New Table from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Table from a Google API Client object.
+      def self.from_gapi gapi, conn
         klass = class_for gapi
         klass.new.tap do |f|
           f.gapi = gapi
@@ -967,8 +915,8 @@ module Gcloud
       end
 
       ##
-      # Determines if a resumable upload should be used.
-      def resumable_upload? file #:nodoc:
+      # @private Determines if a resumable upload should be used.
+      def resumable_upload? file
         ::File.size?(file).to_i > Upload.resumable_threshold
       end
 

--- a/lib/gcloud/bigquery/table/list.rb
+++ b/lib/gcloud/bigquery/table/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/bigquery/table/list.rb
+++ b/lib/gcloud/bigquery/table/list.rb
@@ -39,8 +39,8 @@ module Gcloud
         end
 
         ##
-        # New Table::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Table::List from a response object.
+        def self.from_response resp, conn
           tables = List.new(Array(resp.data["tables"]).map do |gapi_object|
             Table.from_gapi gapi_object, conn
           end)

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Bigquery

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -69,8 +69,8 @@ module Gcloud
         ##
         # @private
         # Returns the schema as hash containing the keys and values specified by
-        # the Google Cloud BigQuery {Rest API
-        # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
+        # the Google Cloud BigQuery [Rest API
+        # ](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource)
         # .
         def schema
           {
@@ -156,8 +156,8 @@ module Gcloud
         ##
         # Adds a record field to the schema. A block must be passed describing
         # the nested fields of the record. For more information about nested
-        # and repeated records, see {Preparing Data for BigQuery
-        # }[https://cloud.google.com/bigquery/preparing-data-for-bigquery].
+        # and repeated records, see [Preparing Data for BigQuery
+        # ](https://cloud.google.com/bigquery/preparing-data-for-bigquery).
         #
         # @param [String] name The field name. The name must contain only
         #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -44,17 +44,17 @@ module Gcloud
       #
       class Schema
         # @private
-        MODES = %w( NULLABLE REQUIRED REPEATED ) #:nodoc:
+        MODES = %w( NULLABLE REQUIRED REPEATED )
 
         # @private
-        TYPES = %w( STRING INTEGER FLOAT BOOLEAN TIMESTAMP RECORD ) #:nodoc:
+        TYPES = %w( STRING INTEGER FLOAT BOOLEAN TIMESTAMP RECORD )
 
         # @private
-        attr_reader :fields #:nodoc:
+        attr_reader :fields
 
         ##
         # @private  Initializes a new schema object with an existing schema.
-        def initialize schema = nil, nested = false #:nodoc:
+        def initialize schema = nil, nested = false
           fields = (schema && schema["fields"]) || []
           @original_fields = fields.dup
           @fields = fields.dup

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -20,11 +20,13 @@ module Gcloud
       # = Table Schema
       #
       # A builder for BigQuery table schemas, passed to block arguments to
-      # Dataset#create_table and Table#schema. Supports nested and
-      # repeated fields via a nested block. For more information about BigQuery
-      # schema definitions, see {Preparing Data for BigQuery
-      # }[https://cloud.google.com/bigquery/preparing-data-for-bigquery].
+      # {Dataset#create_table} and {Table#schema}. Supports nested and
+      # repeated fields via a nested block.
       #
+      # @see https://cloud.google.com/bigquery/preparing-data-for-bigquery
+      #   Preparing Data for BigQuery
+      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -41,13 +43,17 @@ module Gcloud
       #   end
       #
       class Schema
+        # @private
         MODES = %w( NULLABLE REQUIRED REPEATED ) #:nodoc:
+
+        # @private
         TYPES = %w( STRING INTEGER FLOAT BOOLEAN TIMESTAMP RECORD ) #:nodoc:
 
+        # @private
         attr_reader :fields #:nodoc:
 
         ##
-        # Initializes a new schema object with an existing schema.
+        # @private  Initializes a new schema object with an existing schema.
         def initialize schema = nil, nested = false #:nodoc:
           fields = (schema && schema["fields"]) || []
           @original_fields = fields.dup
@@ -55,16 +61,18 @@ module Gcloud
           @nested = nested
         end
 
-        def changed? #:nodoc:
+        # @private
+        def changed?
           @original_fields != @fields
         end
 
         ##
+        # @private
         # Returns the schema as hash containing the keys and values specified by
         # the Google Cloud BigQuery {Rest API
         # }[https://cloud.google.com/bigquery/docs/reference/v2/tables#resource]
         # .
-        def schema #:nodoc:
+        def schema
           {
             "fields" => @fields
           }
@@ -73,17 +81,14 @@ module Gcloud
         ##
         # Adds a string field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def string name, description: nil, mode: nil
           add_field name, :string, nil, description: description, mode: mode
         end
@@ -91,17 +96,14 @@ module Gcloud
         ##
         # Adds an integer field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def integer name, description: nil, mode: nil
           add_field name, :integer, nil, description: description, mode: mode
         end
@@ -109,17 +111,14 @@ module Gcloud
         ##
         # Adds a floating-point number field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def float name, description: nil, mode: nil
           add_field name, :float, nil, description: description, mode: mode
         end
@@ -127,17 +126,14 @@ module Gcloud
         ##
         # Adds a boolean field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def boolean name, description: nil, mode: nil
           add_field name, :boolean, nil, description: description, mode: mode
         end
@@ -145,17 +141,14 @@ module Gcloud
         ##
         # Adds a timestamp field to the schema.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         def timestamp name, description: nil, mode: nil
           add_field name, :timestamp, nil, description: description, mode: mode
         end
@@ -166,20 +159,16 @@ module Gcloud
         # and repeated records, see {Preparing Data for BigQuery
         # }[https://cloud.google.com/bigquery/preparing-data-for-bigquery].
         #
-        # === Parameters
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   +:nullable+, +:required+, and +:repeated+. The default value is
+        #   +:nullable+.
         #
-        # +name+::
-        #   The field name. The name must contain only letters (a-z, A-Z),
-        #   numbers (0-9), or underscores (_), and must start with a letter or
-        #   underscore. The maximum length is 128 characters. (+String+)
-        # +description+::
-        #   A description of the field. (+String+)
-        # +mode+::
-        #   The field's mode. The possible values are +:nullable+, +:required+,
-        #   and +:repeated+. The default value is +:nullable+. (+Symbol+)
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -17,7 +17,7 @@ module Gcloud
   module Bigquery
     class Table
       ##
-      # = Table Schema
+      # # Table Schema
       #
       # A builder for BigQuery table schemas, passed to block arguments to
       # {Dataset#create_table} and {Table#schema}. Supports nested and

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -87,8 +87,8 @@ module Gcloud
         #   characters.
         # @param [String] description A description of the field.
         # @param [Symbol] mode The field's mode. The possible values are
-        #   +:nullable+, +:required+, and +:repeated+. The default value is
-        #   +:nullable+.
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
         def string name, description: nil, mode: nil
           add_field name, :string, nil, description: description, mode: mode
         end
@@ -102,8 +102,8 @@ module Gcloud
         #   characters.
         # @param [String] description A description of the field.
         # @param [Symbol] mode The field's mode. The possible values are
-        #   +:nullable+, +:required+, and +:repeated+. The default value is
-        #   +:nullable+.
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
         def integer name, description: nil, mode: nil
           add_field name, :integer, nil, description: description, mode: mode
         end
@@ -117,8 +117,8 @@ module Gcloud
         #   characters.
         # @param [String] description A description of the field.
         # @param [Symbol] mode The field's mode. The possible values are
-        #   +:nullable+, +:required+, and +:repeated+. The default value is
-        #   +:nullable+.
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
         def float name, description: nil, mode: nil
           add_field name, :float, nil, description: description, mode: mode
         end
@@ -132,8 +132,8 @@ module Gcloud
         #   characters.
         # @param [String] description A description of the field.
         # @param [Symbol] mode The field's mode. The possible values are
-        #   +:nullable+, +:required+, and +:repeated+. The default value is
-        #   +:nullable+.
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
         def boolean name, description: nil, mode: nil
           add_field name, :boolean, nil, description: description, mode: mode
         end
@@ -147,8 +147,8 @@ module Gcloud
         #   characters.
         # @param [String] description A description of the field.
         # @param [Symbol] mode The field's mode. The possible values are
-        #   +:nullable+, +:required+, and +:repeated+. The default value is
-        #   +:nullable+.
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
         def timestamp name, description: nil, mode: nil
           add_field name, :timestamp, nil, description: description, mode: mode
         end
@@ -165,8 +165,8 @@ module Gcloud
         #   characters.
         # @param [String] description A description of the field.
         # @param [Symbol] mode The field's mode. The possible values are
-        #   +:nullable+, +:required+, and +:repeated+. The default value is
-        #   +:nullable+.
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
         #
         # @example
         #   require "gcloud"

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/bigquery/data"
 require "gcloud/bigquery/table/list"

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -20,7 +20,7 @@ require "gcloud/bigquery/errors"
 module Gcloud
   module Bigquery
     ##
-    # = View
+    # # View
     #
     # A view is a virtual table defined by a SQL query. You can query views in
     # the browser tool, or by using a query job.

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -67,7 +67,7 @@ module Gcloud
       end
 
       ##
-      # The ID of the +Dataset+ containing this table.
+      # The ID of the `Dataset` containing this table.
       #
       # @!group Attributes
       #
@@ -76,7 +76,7 @@ module Gcloud
       end
 
       ##
-      # The ID of the +Project+ containing this table.
+      # The ID of the `Project` containing this table.
       #
       # @!group Attributes
       #
@@ -300,10 +300,10 @@ module Gcloud
       #   whenever tables in the query are modified. The default value is true.
       #   For more information, see [query
       #   caching](https://developers.google.com/bigquery/querying-data).
-      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      # @param [Boolean] dryrun If set to `true`, BigQuery doesn't run the job.
       #   Instead, if the query is valid, BigQuery returns statistics about the
       #   job such as how many bytes would be processed. If the query is
-      #   invalid, an error returns. The default value is +false+.
+      #   invalid, an error returns. The default value is `false`.
       #
       # @return [Gcloud::Bigquery::QueryData]
       #
@@ -338,7 +338,7 @@ module Gcloud
       ##
       # Permanently deletes the table.
       #
-      # @return [Boolean] Returns +true+ if the table was deleted.
+      # @return [Boolean] Returns `true` if the table was deleted.
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -30,6 +30,7 @@ module Gcloud
     # queried. Queries are billed according to the total amount of data in all
     # table fields referenced directly or indirectly by the top-level query.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -40,16 +41,16 @@ module Gcloud
     #
     class View
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Table object.
-      def initialize #:nodoc:
+      # @private Create an empty Table object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -59,7 +60,7 @@ module Gcloud
       # The ID must contain only letters (a-z, A-Z), numbers (0-9),
       # or underscores (_). The maximum length is 1,024 characters.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table_id
         @gapi["tableReference"]["tableId"]
@@ -68,7 +69,7 @@ module Gcloud
       ##
       # The ID of the +Dataset+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def dataset_id
         @gapi["tableReference"]["datasetId"]
@@ -77,16 +78,17 @@ module Gcloud
       ##
       # The ID of the +Project+ containing this table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def project_id
         @gapi["tableReference"]["projectId"]
       end
 
       ##
+      # @private
       # The gapi fragment containing the Project ID, Dataset ID, and Table ID as
       # a camel-cased hash.
-      def table_ref #:nodoc:
+      def table_ref
         table_ref = @gapi["tableReference"]
         table_ref = table_ref.to_hash if table_ref.respond_to? :to_hash
         table_ref
@@ -95,7 +97,7 @@ module Gcloud
       ##
       # The name of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def name
         @gapi["friendlyName"]
@@ -104,7 +106,7 @@ module Gcloud
       ##
       # Updates the name of the table.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def name= new_name
         patch_gapi! name: new_name
@@ -113,7 +115,7 @@ module Gcloud
       ##
       # A string hash of the dataset.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def etag
         ensure_full_data!
@@ -123,7 +125,7 @@ module Gcloud
       ##
       # A URL that can be used to access the dataset using the REST API.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def api_url
         ensure_full_data!
@@ -133,7 +135,7 @@ module Gcloud
       ##
       # The description of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def description
         ensure_full_data!
@@ -143,7 +145,7 @@ module Gcloud
       ##
       # Updates the description of the table.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def description= new_description
         patch_gapi! description: new_description
@@ -152,7 +154,7 @@ module Gcloud
       ##
       # The time when this table was created.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def created_at
         ensure_full_data!
@@ -164,7 +166,7 @@ module Gcloud
       # If not present, the table will persist indefinitely.
       # Expired tables will be deleted and their storage reclaimed.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def expires_at
         ensure_full_data!
@@ -175,7 +177,7 @@ module Gcloud
       ##
       # The date when this table was last modified.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def modified_at
         ensure_full_data!
@@ -185,7 +187,7 @@ module Gcloud
       ##
       # Checks if the table's type is "TABLE".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def table?
         @gapi["type"] == "TABLE"
@@ -194,7 +196,7 @@ module Gcloud
       ##
       # Checks if the table's type is "VIEW".
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def view?
         @gapi["type"] == "VIEW"
@@ -204,7 +206,7 @@ module Gcloud
       # The geographic location where the table should reside. Possible
       # values include EU and US. The default value is US.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def location
         ensure_full_data!
@@ -214,7 +216,7 @@ module Gcloud
       ##
       # The schema of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def schema
         ensure_full_data!
@@ -227,7 +229,7 @@ module Gcloud
       ##
       # The fields of the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def fields
         f = schema["fields"]
@@ -239,7 +241,7 @@ module Gcloud
       ##
       # The names of the columns in the table.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def headers
         fields.map { |f| f["name"] }
@@ -248,7 +250,7 @@ module Gcloud
       ##
       # The query that executes each time the view is loaded.
       #
-      # :category: Attributes
+      # @!group Attributes
       #
       def query
         @gapi["view"]["query"] if @gapi["view"]
@@ -256,16 +258,13 @@ module Gcloud
 
       ##
       # Updates the query that executes each time the view is loaded.
-      # See the BigQuery {Query Reference
-      # }[https://cloud.google.com/bigquery/query-reference].
       #
-      # === Parameters
+      # @see https://cloud.google.com/bigquery/query-reference BigQuery Query
+      #   Reference
       #
-      # +new_query+::
-      #   The query that defines the view. (+String+)
+      # @param [String] new_query The query that defines the view.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -275,7 +274,7 @@ module Gcloud
       #
       #   view.query = "SELECT first_name FROM [my_project:my_dataset.my_table]"
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def query= new_query
         patch_gapi! query: new_query
@@ -284,40 +283,31 @@ module Gcloud
       ##
       # Runs a query to retrieve all data from the view.
       #
-      # === Parameters
+      # @param [Integer] max The maximum number of rows of data to return per
+      #   page of results. Setting this flag to a small value such as 1000 and
+      #   then paging through results might improve reliability when the query
+      #   result set is large. In addition to this limit, responses are also
+      #   limited to 10 MB. By default, there is no maximum row count, and only
+      #   the byte limit applies.
+      # @param [Integer] timeout How long to wait for the query to complete, in
+      #   milliseconds, before the request times out and returns. Note that this
+      #   is only a timeout for the request, not the query. If the query takes
+      #   longer to run than the timeout value, the call returns without any
+      #   results and with QueryData#complete? set to false. The default value
+      #   is 10000 milliseconds (10 seconds).
+      # @param [Boolean] cache Whether to look for the result in the query
+      #   cache. The query cache is a best-effort cache that will be flushed
+      #   whenever tables in the query are modified. The default value is true.
+      #   For more information, see {query
+      #   caching}[https://developers.google.com/bigquery/querying-data].
+      # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
+      #   Instead, if the query is valid, BigQuery returns statistics about the
+      #   job such as how many bytes would be processed. If the query is
+      #   invalid, an error returns. The default value is +false+.
       #
-      # +max+::
-      #   The maximum number of rows of data to return per page of results.
-      #   Setting this flag to a small value such as 1000 and then paging
-      #   through results might improve reliability when the query result set is
-      #   large. In addition to this limit, responses are also limited to 10 MB.
-      #   By default, there is no maximum row count, and only the byte limit
-      #   applies. (+Integer+)
-      # +timeout+::
-      #   How long to wait for the query to complete, in milliseconds, before
-      #   the request times out and returns. Note that this is only a timeout
-      #   for the request, not the query. If the query takes longer to run than
-      #   the timeout value, the call returns without any results and with
-      #   QueryData#complete? set to false. The default value is 10000
-      #   milliseconds (10 seconds). (+Integer+)
-      # +cache+::
-      #   Whether to look for the result in the query cache. The query cache is
-      #   a best-effort cache that will be flushed whenever tables in the query
-      #   are modified. The default value is true. For more information, see
-      #   {query caching}[https://developers.google.com/bigquery/querying-data].
-      #   (+Boolean+)
-      # +dryrun+::
-      #   If set to +true+, BigQuery doesn't run the job. Instead, if the query
-      #   is valid, BigQuery returns statistics about the job such as how many
-      #   bytes would be processed. If the query is invalid, an error returns.
-      #   The default value is +false+. (+Boolean+)
+      # @return [Gcloud::Bigquery::QueryData]
       #
-      # === Returns
-      #
-      # Gcloud::Bigquery::QueryData
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -331,7 +321,7 @@ module Gcloud
       #   end
       #   more_data = data.next if data.next?
       #
-      # :category: Data
+      # @!group Data
       #
       def data max: nil, timeout: nil, cache: nil, dryrun: nil
         sql = "SELECT * FROM #{@gapi['id']}"
@@ -348,12 +338,9 @@ module Gcloud
       ##
       # Permanently deletes the table.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the table was deleted.
       #
-      # +true+ if the table was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -363,7 +350,7 @@ module Gcloud
       #
       #   table.delete
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def delete
         ensure_connection!
@@ -378,7 +365,7 @@ module Gcloud
       ##
       # Reloads the table with current data from the BigQuery service.
       #
-      # :category: Lifecycle
+      # @!group Lifecycle
       #
       def reload!
         ensure_connection!
@@ -392,8 +379,8 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # New Table from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Table from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn

--- a/lib/gcloud/bigquery/view.rb
+++ b/lib/gcloud/bigquery/view.rb
@@ -298,8 +298,8 @@ module Gcloud
       # @param [Boolean] cache Whether to look for the result in the query
       #   cache. The query cache is a best-effort cache that will be flushed
       #   whenever tables in the query are modified. The default value is true.
-      #   For more information, see {query
-      #   caching}[https://developers.google.com/bigquery/querying-data].
+      #   For more information, see [query
+      #   caching](https://developers.google.com/bigquery/querying-data).
       # @param [Boolean] dryrun If set to +true+, BigQuery doesn't run the job.
       #   Instead, if the query is valid, BigQuery returns statistics about the
       #   job such as how many bytes would be processed. If the query is

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "json"
 require "signet/oauth_2/client"
 require "forwardable"
 require "googleauth"
 
-#--
-# Google Cloud Credentials
 module Gcloud
   ##
   # Represents the OAuth 2.0 signing logic.

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -20,10 +20,11 @@ require "googleauth"
 
 module Gcloud
   ##
+  # @private
   # Represents the OAuth 2.0 signing logic.
   # This class is intended to be inherited by API-specific classes
   # which overrides the SCOPE constant.
-  class Credentials #:nodoc:
+  class Credentials
     TOKEN_CREDENTIAL_URI = "https://accounts.google.com/o/oauth2/token"
     AUDIENCE = "https://accounts.google.com/o/oauth2/token"
     SCOPE = []

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -28,21 +28,21 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +project+::
-  #   Dataset identifier for the Datastore you are connecting to. (+String+)
-  # +keyfile+::
+  # `project`::
+  #   Dataset identifier for the Datastore you are connecting to. (`String`)
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
-  # +scope+::
+  #   readable. (`String` or `Hash`)
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scopes are:
   #
-  #   * +https://www.googleapis.com/auth/datastore+
-  #   * +https://www.googleapis.com/auth/userinfo.email+
+  #   * `https://www.googleapis.com/auth/datastore`
+  #   * `https://www.googleapis.com/auth/userinfo.email`
   #
   # ### Returns
   #

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -98,7 +98,7 @@ module Gcloud
   # ```
   #
   # You can learn more about various options for connection on the
-  # [Authentication Guide](link:AUTHENTICATION.md).
+  # [Authentication Guide](../AUTHENTICATION).
   #
   # To learn more about Datastore, read the
   # [Google Cloud Datastore Concepts Overview

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 require "gcloud/datastore/errors"
 require "gcloud/datastore/dataset"
 require "gcloud/datastore/transaction"
 require "gcloud/datastore/credentials"
 
-#--
-# Google Cloud Datastore
 module Gcloud
   ##
   # Creates a new object for connecting to the Datastore service.

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -24,30 +24,23 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Dataset identifier for the Datastore you are connecting to. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Dataset identifier for the Datastore you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/datastore`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Datastore::Dataset]
   #
-  # Gcloud::Datastore::Dataset
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/datastore"
   #
   #   dataset = Gcloud.datastore "my-todo-project",

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -86,14 +86,16 @@ module Gcloud
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new "my-todo-project",
-  #                       "/path/to/keyfile.json"
-  #   dataset = gcloud.datastore
-  #   entity = dataset.find "Task", "start"
-  #   entity["completed"] = true
-  #   dataset.save entity
+  # gcloud = Gcloud.new "my-todo-project",
+  #                     "/path/to/keyfile.json"
+  # dataset = gcloud.datastore
+  # entity = dataset.find "Task", "start"
+  # entity["completed"] = true
+  # dataset.save entity
+  # ```
   #
   # You can learn more about various options for connection on the
   # [Authentication Guide](link:AUTHENTICATION.md).
@@ -111,20 +113,24 @@ module Gcloud
   # <tt>name</tt> value. A single record can be retrieved by calling
   # Gcloud::Datastore::Dataset#find and passing the parts of the key:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   entity = dataset.find "Task", "start"
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # entity = dataset.find "Task", "start"
+  # ```
   #
   # Optionally, Gcloud::Datastore::Dataset#find can be given a Key object:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   key = dataset.key "Task", 12345
-  #   entity = dataset.find key
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # key = dataset.key "Task", 12345
+  # entity = dataset.find key
+  # ```
   #
   # See Gcloud::Datastore::Dataset#find
   #
@@ -133,50 +139,58 @@ module Gcloud
   # Multiple records can be found that match criteria.
   # (See Gcloud::Datastore::Query#where)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   query = dataset.query("List").
-  #     where("active", "=", true)
-  #   active_lists = dataset.run query
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # query = dataset.query("List").
+  #   where("active", "=", true)
+  # active_lists = dataset.run query
+  # ```
   #
   # Records can also be ordered. (See Gcloud::Datastore::Query#order)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   query = dataset.query("List").
-  #     where("active", "=", true).
-  #     order("name")
-  #   active_lists = dataset.run query
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # query = dataset.query("List").
+  #   where("active", "=", true).
+  #   order("name")
+  # active_lists = dataset.run query
+  # ```
   #
   # The number of records returned can be specified.
   # (See Gcloud::Datastore::Query#limit)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   query = dataset.query("List").
-  #     where("active", "=", true).
-  #     order("name").
-  #     limit(5)
-  #   active_lists = dataset.run query
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # query = dataset.query("List").
+  #   where("active", "=", true).
+  #   order("name").
+  #   limit(5)
+  # active_lists = dataset.run query
+  # ```
   #
   # Records' Key structures can also be queried.
   # (See Gcloud::Datastore::Query#ancestor)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
   #
-  #   list = dataset.find "List", "todos"
-  #   query = dataset.query("Task").
-  #     ancestor(list.key)
-  #   items = dataset.run query
+  # list = dataset.find "List", "todos"
+  # query = dataset.query("Task").
+  #   ancestor(list.key)
+  # items = dataset.run query
+  # ```
   #
   # See Gcloud::Datastore::Query and Gcloud::Datastore::Dataset#run
   #
@@ -186,27 +200,29 @@ module Gcloud
   # to return them all. The returned records will have a <tt>cursor</tt> if
   # there are more available.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
   #
-  #   list = dataset.find "List", "todos"
-  #   query = dataset.query("Task").
-  #     ancestor(list.key)
-  #   all_tasks = []
-  #   tmp_tasks = dataset.run query
-  #   while tmp_tasks.any? do
-  #     tmp_tasks.each do |task|
-  #       all_tasks << task
-  #     end
-  #     # break loop if no more tasks available
-  #     break if tmp_tasks.cursor.nil?
-  #     # set cursor on the query
-  #     query = query.cursor tmp_tasks.cursor
-  #     # query for more records
-  #     tmp_tasks = dataset.run query
+  # list = dataset.find "List", "todos"
+  # query = dataset.query("Task").
+  #   ancestor(list.key)
+  # all_tasks = []
+  # tmp_tasks = dataset.run query
+  # while tmp_tasks.any? do
+  #   tmp_tasks.each do |task|
+  #     all_tasks << task
   #   end
+  #   # break loop if no more tasks available
+  #   break if tmp_tasks.cursor.nil?
+  #   # set cursor on the query
+  #   query = query.cursor tmp_tasks.cursor
+  #   # query for more records
+  #   tmp_tasks = dataset.run query
+  # end
+  # ```
   #
   # See Gcloud::Datastore::Dataset::LookupResults and
   # Gcloud::Datastore::Dataset::QueryResults
@@ -217,16 +233,18 @@ module Gcloud
   # The entity must have a Key to be saved. If the Key is incomplete then
   # it will be completed when saved.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   entity = dataset.entity "User" do |e|
-  #     e["name"] = "Heidi Henderson"
-  #   end
-  #   entity.key.id #=> nil
-  #   dataset.save entity
-  #   entity.key.id #=> 123456789
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # entity = dataset.entity "User" do |e|
+  #   e["name"] = "Heidi Henderson"
+  # end
+  # entity.key.id #=> nil
+  # dataset.save entity
+  # entity.key.id #=> 123456789
+  # ```
   #
   # ## Updating Records
   #
@@ -235,29 +253,33 @@ module Gcloud
   # String, Integer, Date, Time, and even other Entity or Key objects. Changes
   # to the Entity's properties are persisted by calling Dataset#save.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   entity = dataset.find "User", "heidi"
-  #   # Read the status property
-  #   entity["status"] #=> "inactive"
-  #   # Write the status property
-  #   entity["status"] = "active"
-  #   # Persist the changes
-  #   dataset.save entity
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # entity = dataset.find "User", "heidi"
+  # # Read the status property
+  # entity["status"] #=> "inactive"
+  # # Write the status property
+  # entity["status"] = "active"
+  # # Persist the changes
+  # dataset.save entity
+  # ```
   #
   # ## Deleting Records
   #
   # Entities can be removed from Datastore by calling Dataset#delete and passing
   # the Entity object or the entity's Key object.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
-  #   entity = dataset.find "User", "heidi"
-  #   dataset.delete entity
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
+  # entity = dataset.find "User", "heidi"
+  # dataset.delete entity
+  # ```
   #
   # ## Transactions
   #
@@ -265,48 +287,52 @@ module Gcloud
   # within the Dataset#transaction block are run within the transaction scope,
   # and will be automatically committed when the block completes.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
   #
-  #   key = dataset.key "User", "heidi"
+  # key = dataset.key "User", "heidi"
   #
-  #   user = dataset.entity key do |u|
-  #     u["name"] = "Heidi Henderson"
-  #     u["email"] = "heidi@example.net"
+  # user = dataset.entity key do |u|
+  #   u["name"] = "Heidi Henderson"
+  #   u["email"] = "heidi@example.net"
+  # end
+  #
+  # dataset.transaction do |tx|
+  #   if tx.find(user.key).nil?
+  #     tx.save user
   #   end
-  #
-  #   dataset.transaction do |tx|
-  #     if tx.find(user.key).nil?
-  #       tx.save user
-  #     end
-  #   end
+  # end
+  # ```
   #
   # Alternatively, if no block is given the transaction object is returned
   # allowing you to commit or rollback manually.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dataset = gcloud.datastore
+  # gcloud = Gcloud.new
+  # dataset = gcloud.datastore
   #
-  #   key = dataset.key "User", "heidi"
+  # key = dataset.key "User", "heidi"
   #
-  #   user = dataset.entity key do |u|
-  #     u["name"] = "Heidi Henderson"
-  #     u["email"] = "heidi@example.net"
+  # user = dataset.entity key do |u|
+  #   u["name"] = "Heidi Henderson"
+  #   u["email"] = "heidi@example.net"
+  # end
+  #
+  # tx = dataset.transaction
+  # begin
+  #   if tx.find(user.key).nil?
+  #     tx.save user
   #   end
-  #
-  #   tx = dataset.transaction
-  #   begin
-  #     if tx.find(user.key).nil?
-  #       tx.save user
-  #     end
-  #     tx.commit
-  #   rescue
-  #     tx.rollback
-  #   end
+  #   tx.commit
+  # rescue
+  #   tx.rollback
+  # end
+  # ```
   #
   # See Gcloud::Datastore::Transaction and
   # Gcloud::Datastore::Dataset#transaction

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -35,8 +35,8 @@ module Gcloud
   #   readable. (+String+ or +Hash+)
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scopes are:
@@ -96,11 +96,11 @@ module Gcloud
   #   dataset.save entity
   #
   # You can learn more about various options for connection on the
-  # {Authentication Guide}[link:AUTHENTICATION.md].
+  # [Authentication Guide](link:AUTHENTICATION.md).
   #
   # To learn more about Datastore, read the
-  # {Google Cloud Datastore Concepts Overview
-  # }[https://cloud.google.com/datastore/docs/concepts/overview].
+  # [Google Cloud Datastore Concepts Overview
+  # ](https://cloud.google.com/datastore/docs/concepts/overview).
   #
   # ## Retrieving Records
   #

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -26,7 +26,7 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +project+::
   #   Dataset identifier for the Datastore you are connecting to. (+String+)
@@ -44,11 +44,11 @@ module Gcloud
   #   * +https://www.googleapis.com/auth/datastore+
   #   * +https://www.googleapis.com/auth/userinfo.email+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Datastore::Dataset
   #
-  # === Example
+  # ### Example
   #
   #   require "gcloud/datastore"
   #
@@ -73,7 +73,7 @@ module Gcloud
   end
 
   ##
-  # = Google Cloud Datastore
+  # # Google Cloud Datastore
   #
   # Google Cloud Datastore is a fully managed, schemaless database for storing
   # non-relational data. You should feel at home if you are familiar with
@@ -102,7 +102,7 @@ module Gcloud
   # {Google Cloud Datastore Concepts Overview
   # }[https://cloud.google.com/datastore/docs/concepts/overview].
   #
-  # == Retrieving Records
+  # ## Retrieving Records
   #
   # Records, called "entities" in Datastore, are retrieved by using a Key.
   # The Key is more than a numeric identifier, it is a complex data structure
@@ -128,7 +128,7 @@ module Gcloud
   #
   # See Gcloud::Datastore::Dataset#find
   #
-  # == Querying Records
+  # ## Querying Records
   #
   # Multiple records can be found that match criteria.
   # (See Gcloud::Datastore::Query#where)
@@ -180,7 +180,7 @@ module Gcloud
   #
   # See Gcloud::Datastore::Query and Gcloud::Datastore::Dataset#run
   #
-  # == Paginating Records
+  # ## Paginating Records
   #
   # All Records may not return at once, requiring multiple calls to Datastore
   # to return them all. The returned records will have a <tt>cursor</tt> if
@@ -211,7 +211,7 @@ module Gcloud
   # See Gcloud::Datastore::Dataset::LookupResults and
   # Gcloud::Datastore::Dataset::QueryResults
   #
-  # == Creating Records
+  # ## Creating Records
   #
   # New entities can be created and persisted buy calling Dataset#save.
   # The entity must have a Key to be saved. If the Key is incomplete then
@@ -228,7 +228,7 @@ module Gcloud
   #   dataset.save entity
   #   entity.key.id #=> 123456789
   #
-  # == Updating Records
+  # ## Updating Records
   #
   # Entities hold properties. A property has a name that is a string or symbol,
   # and a value that is an object. Most value objects are supported, including
@@ -247,7 +247,7 @@ module Gcloud
   #   # Persist the changes
   #   dataset.save entity
   #
-  # == Deleting Records
+  # ## Deleting Records
   #
   # Entities can be removed from Datastore by calling Dataset#delete and passing
   # the Entity object or the entity's Key object.
@@ -259,7 +259,7 @@ module Gcloud
   #   entity = dataset.find "User", "heidi"
   #   dataset.delete entity
   #
-  # == Transactions
+  # ## Transactions
   #
   # Complex logic can be wrapped in a Transaction. All queries and updates
   # within the Dataset#transaction block are run within the transaction scope,

--- a/lib/gcloud/datastore/connection.rb
+++ b/lib/gcloud/datastore/connection.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "faraday"
 

--- a/lib/gcloud/datastore/connection.rb
+++ b/lib/gcloud/datastore/connection.rb
@@ -18,12 +18,14 @@ require "faraday"
 module Gcloud
   module Datastore
     ##
+    # @private
+    #
     # Represent the HTTP connection to the Datastore,
     # as well as the Datastore API calls.
     #
     # This class only deals with Protocol Buffer objects,
     # and is not part of the public API.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1beta2"
       API_URL = "https://www.googleapis.com"
 
@@ -33,13 +35,15 @@ module Gcloud
 
       ##
       # The Credentials object for signing HTTP requests.
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Create a new Connection instance.
       #
+      # @example
       #   conn = Gcloud::Datastore.Connection.new "my-todo-project",
       #     Gcloud::Datastore::Credentials.new("/path/to/keyfile.json")
+      #
       def initialize dataset_id, credentials
         @dataset_id = dataset_id
         @credentials = credentials
@@ -114,24 +118,24 @@ module Gcloud
 
       ##
       # The default HTTP headers to be sent on all API calls.
-      def default_http_headers #:nodoc:
+      def default_http_headers
         @default_http_headers ||= {
           "User-Agent"   => "gcloud-node/#{Gcloud::VERSION}",
           "Content-Type" => "application/x-protobuf" }
       end
       ##
       # Update the default HTTP headers.
-      attr_writer :default_http_headers #:nodoc:
+      attr_writer :default_http_headers
 
       ##
       # The HTTP object that makes calls to Datastore.
       # This must be a Faraday object.
-      def http #:nodoc:
+      def http
         @http ||= Faraday.new url: http_host
       end
       ##
       # Update the HTTP object.
-      attr_writer :http #:nodoc:
+      attr_writer :http
 
       ##
       # The Datastore API URL.
@@ -146,7 +150,7 @@ module Gcloud
         @http_host = new_http_host
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@dataset_id})"
       end
 

--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/credentials"
 

--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -18,12 +18,14 @@ require "gcloud/credentials"
 module Gcloud
   module Datastore
     ##
+    # @private
+    #
     # Authentication credentials to Google Cloud.
     # The most common way to create this object is to provide the path
     # to the JSON keyfile downloaded from Google Cloud.
     #
-    # https://developers.google.com/accounts/docs/application-default-credentials
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @see https://developers.google.com/accounts/docs/application-default-credentials
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/datastore",
                "https://www.googleapis.com/auth/userinfo.email"]
       PATH_ENV_VARS = %w(DATASTORE_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
@@ -32,7 +34,7 @@ module Gcloud
 
       ##
       # Sign OAuth 2.0 API calls.
-      def sign_http_request request #:nodoc:
+      def sign_http_request request
         if @client
           @client.fetch_access_token! if @client.expired?
           @client.generate_authenticated_request request: request

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/gce"
 require "gcloud/datastore/connection"

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -25,7 +25,7 @@ require "gcloud/datastore/dataset/query_results"
 module Gcloud
   module Datastore
     ##
-    # = Dataset
+    # # Dataset
     #
     # Dataset is the data saved in a project's Datastore.
     # Dataset is analogous to a database in relational database world.

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -31,9 +31,12 @@ module Gcloud
     # Dataset is analogous to a database in relational database world.
     #
     # Gcloud::Datastore::Dataset is the main object for interacting with
-    # Google Datastore. Gcloud::Datastore::Entity objects are created,
+    # Google Datastore. {Gcloud::Datastore::Entity} objects are created,
     # read, updated, and deleted by Gcloud::Datastore::Dataset.
     #
+    # See {Gcloud#datastore}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -44,15 +47,15 @@ module Gcloud
     #
     #   tasks = dataset.run query
     #
-    # See Gcloud#datastore
     class Dataset
-      attr_accessor :connection #:nodoc:
+      # @private
+      attr_accessor :connection
 
       ##
-      # Creates a new Dataset instance.
+      # @private Creates a new Dataset instance.
       #
-      # See Gcloud#datastore
-      def initialize project, credentials #:nodoc:
+      # See {Gcloud#datastore}
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -61,8 +64,7 @@ module Gcloud
       ##
       # The Datastore project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -76,8 +78,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["DATASTORE_DATASET"] ||
           ENV["DATASTORE_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
@@ -88,19 +90,12 @@ module Gcloud
       ##
       # Generate IDs for a Key before creating an entity.
       #
-      # === Parameters
+      # @param [Key] incomplete_key A Key without +id+ or +name+ set.
+      # @param [String] count The number of new key IDs to create.
       #
-      # +incomplete_key+::
-      #   A Key without +id+ or +name+ set. (+Key+)
-      # +count+::
-      #   The number of new key IDs to create. (+Integer+)
+      # @return [Array<Gcloud::Datastore::Key>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Datastore::Key
-      #
-      # === Example
-      #
+      # @example
       #   empty_key = dataset.key "Task"
       #   task_keys = dataset.allocate_ids empty_key, 5
       #
@@ -119,18 +114,12 @@ module Gcloud
       ##
       # Persist one or more entities to the Datastore.
       #
-      # === Parameters
+      # @param [Entity] *entities One or more entity objects to be saved without
+      #   +id+ or +name+ set.
       #
-      # +entities+::
-      #   One or more entity objects to be saved without +id+ or +name+ set.
-      #   (+Entity+)
+      # @return [Array<Gcloud::Datastore::Entity>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Datastore::Entity
-      #
-      # === Example
-      #
+      # @example
       #   dataset.save task1, task2
       #
       def save *entities
@@ -144,27 +133,17 @@ module Gcloud
       ##
       # Retrieve an entity by providing key information.
       #
-      # === Parameters
+      # @param [Key, String] key_or_kind A Key object or +kind+ string value.
+      # @param [Integer, String, nil] id_or_name The Key's +id+ or +name+ value
+      #   if a +kind+ was provided in the first parameter.
       #
-      # +key_or_kind+::
-      #   A Key object or +kind+ string value. (+Key+ or +String+)
-      # +id_or_name+::
-      #   The Key's +id+ or +name+ value if a +kind+ was provided in the first
-      #   parameter. (+Integer+ or +String+ or +nil+)
+      # @return [Gcloud::Datastore::Entity, nil]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Entity or +nil+
-      #
-      # === Example
-      #
-      # Finding an entity with a key:
-      #
+      # @example Finding an entity with a key:
       #   key = dataset.key "Task", 123456
       #   task = dataset.find key
       #
-      # Finding an entity with a +kind+ and +id+/+name+:
-      #
+      # @example Finding an entity with a +kind+ and +id+/+name+:
       #   task = dataset.find "Task", 123456
       #
       def find key_or_kind, id_or_name = nil
@@ -179,17 +158,11 @@ module Gcloud
       ##
       # Retrieve the entities for the provided keys.
       #
-      # === Parameters
+      # @param [Key] *keys One or more Key objects to find records for.
       #
-      # +keys+::
-      #   One or more Key objects to find records for. (+Key+)
+      # @return [Gcloud::Datastore::Dataset::LookupResults]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Dataset::LookupResults
-      #
-      # === Example
-      #
+      # @example
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
       #   key1 = dataset.key "Task", 123456
@@ -208,17 +181,12 @@ module Gcloud
       ##
       # Remove entities from the Datastore.
       #
-      # === Parameters
+      # @param [Entity, Key] *entities_or_keys One or more Entity or Key objects
+      #   to remove.
       #
-      # +entities_or_keys+::
-      #   One or more Entity or Key objects to remove. (+Entity+ or +Key+)
+      # @return [Boolean] Returns +true+ if successful
       #
-      # === Returns
-      #
-      # +true+ if successful
-      #
-      # === Example
-      #
+      # @example
       #   gcloud = Gcloud.new
       #   dataset = gcloud.datastore
       #   dataset.delete entity1, entity2
@@ -237,26 +205,17 @@ module Gcloud
       ##
       # Retrieve entities specified by a Query.
       #
-      # === Parameters
+      # @param [Query] query The Query object with the search criteria.
+      # @param [String] namespace The namespace the query is to run within.
       #
-      # +query+::
-      #   The Query object with the search criteria. (+Query+)
-      # +namespace+::
-      #   The namespace the query is to run within. (+String+)
+      # @return [Gcloud::Datastore::Dataset::QueryResults]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Dataset::QueryResults
-      #
-      # === Examples
-      #
+      # @example
       #   query = dataset.query("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query
       #
-      # The query can optionally run within namespace when the +namespace+
-      # option is provided:
-      #
+      # @example Run the query within a namespace with the +namespace+ option:
       #   query = Gcloud::Datastore::Query.new.kind("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query, namespace: "ns~todo-project"
@@ -274,10 +233,7 @@ module Gcloud
       ##
       # Creates a Datastore Transaction.
       #
-      # === Example
-      #
-      # Runs the given block in a database transaction:
-      #
+      # @example Runs the given block in a database transaction:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -294,8 +250,7 @@ module Gcloud
       #     end
       #   end
       #
-      # Alternatively, if no block is given a Transaction object is returned:
-      #
+      # @example If no block is given, a Transaction object is returned:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -333,23 +288,16 @@ module Gcloud
       # Create a new Query instance. This is a convenience method to make the
       # creation of Query objects easier.
       #
-      # === Parameters
+      # @param [String] *kinds The kind of entities to query. This is optional.
       #
-      # +kinds+::
-      #   The kind of entities to query. This is optional. (+String+)
+      # @return [Gcloud::Datastore::Query]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Query
-      #
-      # === Example
-      #
+      # @example
       #   query = dataset.query("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   query = Gcloud::Datastore::Query.new.
       #     kind("Task").
       #     where("completed", "=", true)
@@ -365,23 +313,16 @@ module Gcloud
       # Create a new Key instance. This is a convenience method to make the
       # creation of Key objects easier.
       #
-      # === Parameters
+      # @param [String] kind The kind of the Key. This is optional.
+      # @param [Integer, String] id_or_name The id or name of the Key. This is
+      #   optional.
       #
-      # +kind+::
-      #   The kind of the Key. This is optional. (+String+)
-      # +id_or_name+::
-      #   The id or name of the Key. This is optional. (+Integer+ or +String+)
+      # @return [Gcloud::Datastore::Key]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Key
-      #
-      # === Example
-      #
+      # @example
       #   key = dataset.key "User", "heidi@example.com"
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
       def key kind = nil, id_or_name = nil
@@ -392,50 +333,37 @@ module Gcloud
       # Create a new empty Entity instance. This is a convenience method to make
       # the creation of Entity objects easier.
       #
-      # === Parameters
+      # @param [Key, String, nil] key_or_kind A Key object or +kind+ string
+      #   value. This is optional.
+      # @param [Integer, String, nil] id_or_name The Key's +id+ or +name+ value
+      #   if a +kind+ was provided in the first parameter.
       #
-      # +key_or_kind+::
-      #   A Key object or +kind+ string value. This is optional. (+Key+ or
-      #   +String+ or +nil+)
-      # +id_or_name+::
-      #   The Key's +id+ or +name+ value if a +kind+ was provided in the first
-      #   parameter. (+Integer+ or +String+ or +nil+)
+      # @return [Gcloud::Datastore::Entity]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Entity
-      #
-      # === Examples
-      #
+      # @example
       #   entity = dataset.entity
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   entity = Gcloud::Datastore::Entity.new
       #
-      # The key can also be passed in as an object:
-      #
+      # @example The key can also be passed in as an object:
       #   key = dataset.key "User", "heidi@example.com"
       #   entity = dataset.entity key
       #
-      # Or the key values can be passed in as parameters:
-      #
+      # @example Or the key values can be passed in as parameters:
       #   entity = dataset.entity "User", "heidi@example.com"
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   entity = Gcloud::Datastore::Entity.new
       #   entity.key = key
       #
-      # The newly created entity object can also be configured using a block:
-      #
+      # @example The newly created entity can also be configured using a block:
       #   user = dataset.entity "User", "heidi@example.com" do |u|
       #     u["name"] = "Heidi Henderson"
       #  end
       #
-      # This code is equivalent to the following:
-      #
+      # @example The previous example is equivalent to:
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   entity = Gcloud::Datastore::Entity.new
       #   entity.key = key
@@ -477,15 +405,15 @@ module Gcloud
       end
 
       ##
-      # Save a key to be given an ID when comitted.
-      def auto_id_register entity #:nodoc:
+      # @private Save a key to be given an ID when comitted.
+      def auto_id_register entity
         @_auto_id_entities ||= []
         @_auto_id_entities << entity
       end
 
       ##
-      # Update saved keys with new IDs post-commit.
-      def auto_id_assign_ids auto_ids #:nodoc:
+      # @private Update saved keys with new IDs post-commit.
+      def auto_id_assign_ids auto_ids
         @_auto_id_entities ||= []
         Array(auto_ids).each_with_index do |key, index|
           entity = @_auto_id_entities[index]
@@ -495,9 +423,9 @@ module Gcloud
       end
 
       ##
-      # Add entities to a Mutation, and register they key to be
+      # @private Add entities to a Mutation, and register they key to be
       # updated with an auto ID if needed.
-      def save_entities_to_mutation entities, mutation #:nodoc:
+      def save_entities_to_mutation entities, mutation
         entities.each do |entity|
           if entity.key.id.nil? && entity.key.name.nil?
             mutation.insert_auto_id << entity.to_proto

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -90,7 +90,7 @@ module Gcloud
       ##
       # Generate IDs for a Key before creating an entity.
       #
-      # @param [Key] incomplete_key A Key without +id+ or +name+ set.
+      # @param [Key] incomplete_key A Key without `id` or `name` set.
       # @param [String] count The number of new key IDs to create.
       #
       # @return [Array<Gcloud::Datastore::Key>]
@@ -115,7 +115,7 @@ module Gcloud
       # Persist one or more entities to the Datastore.
       #
       # @param [Entity] *entities One or more entity objects to be saved without
-      #   +id+ or +name+ set.
+      #   `id` or `name` set.
       #
       # @return [Array<Gcloud::Datastore::Entity>]
       #
@@ -133,9 +133,9 @@ module Gcloud
       ##
       # Retrieve an entity by providing key information.
       #
-      # @param [Key, String] key_or_kind A Key object or +kind+ string value.
-      # @param [Integer, String, nil] id_or_name The Key's +id+ or +name+ value
-      #   if a +kind+ was provided in the first parameter.
+      # @param [Key, String] key_or_kind A Key object or `kind` string value.
+      # @param [Integer, String, nil] id_or_name The Key's `id` or `name` value
+      #   if a `kind` was provided in the first parameter.
       #
       # @return [Gcloud::Datastore::Entity, nil]
       #
@@ -143,7 +143,7 @@ module Gcloud
       #   key = dataset.key "Task", 123456
       #   task = dataset.find key
       #
-      # @example Finding an entity with a +kind+ and +id+/+name+:
+      # @example Finding an entity with a `kind` and `id`/`name`:
       #   task = dataset.find "Task", 123456
       #
       def find key_or_kind, id_or_name = nil
@@ -184,7 +184,7 @@ module Gcloud
       # @param [Entity, Key] *entities_or_keys One or more Entity or Key objects
       #   to remove.
       #
-      # @return [Boolean] Returns +true+ if successful
+      # @return [Boolean] Returns `true` if successful
       #
       # @example
       #   gcloud = Gcloud.new
@@ -215,7 +215,7 @@ module Gcloud
       #     where("completed", "=", true)
       #   tasks = dataset.run query
       #
-      # @example Run the query within a namespace with the +namespace+ option:
+      # @example Run the query within a namespace with the `namespace` option:
       #   query = Gcloud::Datastore::Query.new.kind("Task").
       #     where("completed", "=", true)
       #   tasks = dataset.run query, namespace: "ns~todo-project"
@@ -333,10 +333,10 @@ module Gcloud
       # Create a new empty Entity instance. This is a convenience method to make
       # the creation of Entity objects easier.
       #
-      # @param [Key, String, nil] key_or_kind A Key object or +kind+ string
+      # @param [Key, String, nil] key_or_kind A Key object or `kind` string
       #   value. This is optional.
-      # @param [Integer, String, nil] id_or_name The Key's +id+ or +name+ value
-      #   if a +kind+ was provided in the first parameter.
+      # @param [Integer, String, nil] id_or_name The Key's `id` or `name` value
+      #   if a `kind` was provided in the first parameter.
       #
       # @return [Gcloud::Datastore::Entity]
       #

--- a/lib/gcloud/datastore/dataset/lookup_results.rb
+++ b/lib/gcloud/datastore/dataset/lookup_results.rb
@@ -24,14 +24,16 @@ module Gcloud
       # contains the entities as well as the Keys that were deferred from
       # the results and the Entities that were missing in the dataset.
       #
+      # Please be cautious when treating the QueryResults as an Array.
+      # Many common Array methods will return a new Array instance.
+      #
+      # @example
       #   entities = dataset.find_all key1, key2, key3
       #   entities.size #=> 3
       #   entities.deferred #=> []
       #   entities.missing #=> []
       #
-      # Please be cautious when treating the LookupResults as an Array. Many
-      # common Array methods will return a new Array instance.
-      #
+      # @example Caution, many Array methods will return a new Array instance:
       #   entities = dataset.find_all key1, key2, key3
       #   entities.size #=> 3
       #   entities.deferred #=> []

--- a/lib/gcloud/datastore/dataset/lookup_results.rb
+++ b/lib/gcloud/datastore/dataset/lookup_results.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/datastore/dataset/query_results.rb
+++ b/lib/gcloud/datastore/dataset/query_results.rb
@@ -24,13 +24,15 @@ module Gcloud
       # the Entities from the query as well as the query's cursor and
       # more_results value.
       #
+      # Please be cautious when treating the QueryResults as an Array.
+      # Many common Array methods will return a new Array instance.
+      #
+      # @example
       #   entities = dataset.run query
       #   entities.size #=> 3
       #   entities.cursor #=> "c3VwZXJhd2Vzb21lIQ"
       #
-      # Please be cautious when treating the QueryResults as an Array.
-      # Many common Array methods will return a new Array instance.
-      #
+      # @example Caution, many Array methods will return a new Array instance:
       #   entities = dataset.run query
       #   entities.size #=> 3
       #   entities.end_cursor #=> "c3VwZXJhd2Vzb21lIQ"

--- a/lib/gcloud/datastore/dataset/query_results.rb
+++ b/lib/gcloud/datastore/dataset/query_results.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -48,7 +48,7 @@ module Gcloud
       #
       # @param [String, Symbol] prop_name The name of the property.
       #
-      # @return [Object, nil] Returns +nil+ if the property doesn't exist
+      # @return [Object, nil] Returns `nil` if the property doesn't exist
       #
       # @example Properties can be retrieved with a string name:
       #   require "gcloud"
@@ -110,7 +110,7 @@ module Gcloud
       #     puts "property #{name} has a value of #{value}"
       #   end
       #
-      # @example A property's existence can be determined by calling +exist?+:
+      # @example A property's existence can be determined by calling `exist?`:
       #   entity.properties.exist? :name #=> true
       #   entity.properties.exist? "name" #=> true
       #   entity.properties.exist? :expiration #=> false
@@ -128,7 +128,7 @@ module Gcloud
       # Sets the Key that identifies the entity.
       #
       # Once the entity is saved, the key is frozen and immutable. Trying to set
-      # a key when immutable will raise a +RuntimeError+.
+      # a key when immutable will raise a `RuntimeError`.
       #
       # @example The Key can be set before the entity is saved:
       #   require "gcloud"

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/datastore/key"
 require "gcloud/datastore/properties"

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -20,7 +20,7 @@ require "gcloud/datastore/proto"
 module Gcloud
   module Datastore
     ##
-    # = Entity
+    # # Entity
     #
     # Entity represents a Datastore record.
     # Every Entity has a {Key}, and a list of properties.

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -23,8 +23,9 @@ module Gcloud
     # = Entity
     #
     # Entity represents a Datastore record.
-    # Every Entity has a Key, and a list of properties.
+    # Every Entity has a {Key}, and a list of properties.
     #
+    # @example
     #   entity = Gcloud::Datastore::Entity.new
     #   entity.key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
     #   entity["name"] = "Heidi Henderson"
@@ -45,19 +46,11 @@ module Gcloud
       ##
       # Retrieve a property value by providing the name.
       #
-      # === Parameters
+      # @param [String, Symbol] prop_name The name of the property.
       #
-      # +prop_name+::
-      #   The name of the property. (+String+ or +Symbol+)
+      # @return [Object, nil] Returns +nil+ if the property doesn't exist
       #
-      # === Returns
-      #
-      # Object if the property exists, +nil+ if the property doesn't exist
-      #
-      # === Example
-      #
-      # Properties can be retrieved with a string name:
-      #
+      # @example Properties can be retrieved with a string name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -65,8 +58,7 @@ module Gcloud
       #   user = dataset.find "User", "heidi@example.com"
       #   user["name"] #=> "Heidi Henderson"
       #
-      # Or with a symbol name:
-      #
+      # @example Or with a symbol name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -81,17 +73,10 @@ module Gcloud
       ##
       # Set a property value by name.
       #
-      # === Parameters
+      # @param [String, Symbol] prop_name The name of the property.
+      # @param [Object] prop_value The value of the property.
       #
-      # +prop_name+::
-      #   The name of the property. (+String+ or +Symbol+)
-      # +prop_value+::
-      #   The value of the property. (+Object+)
-      #
-      # === Example
-      #
-      # Properties can be set with a string name:
-      #
+      # @example Properties can be set with a string name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -99,8 +84,7 @@ module Gcloud
       #   user = dataset.find "User", "heidi@example.com"
       #   user["name"] = "Heidi H. Henderson"
       #
-      # Or with a symbol name:
-      #
+      # @example Or with a symbol name:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -116,12 +100,9 @@ module Gcloud
       # Retrieve properties in a hash-like structure.
       # Properties can be accessed or set by string or symbol.
       #
-      # === Returns
+      # @return [Gcloud::Datastore::Properties]
       #
-      # Gcloud::Datastore::Properties
-      #
-      # === Example
-      #
+      # @example
       #   entity.properties[:name] = "Heidi H. Henderson"
       #   entity.properties["name"] #=> "Heidi H. Henderson"
       #
@@ -129,19 +110,16 @@ module Gcloud
       #     puts "property #{name} has a value of #{value}"
       #   end
       #
-      # A property's existance can be determined by calling exist?
-      #
+      # @example A property's existence can be determined by calling +exist?+:
       #   entity.properties.exist? :name #=> true
       #   entity.properties.exist? "name" #=> true
       #   entity.properties.exist? :expiration #=> false
       #
-      # A property can be removed from the entity.
-      #
+      # @example A property can be removed from the entity:
       #   entity.properties.delete :name
       #   entity.save
       #
-      # The properties can be converted to a hash:
-      #
+      # @example The properties can be converted to a hash:
       #   prop_hash = entity.properties.to_h
       #
       attr_reader :properties
@@ -149,10 +127,10 @@ module Gcloud
       ##
       # Sets the Key that identifies the entity.
       #
-      # === Example
+      # Once the entity is saved, the key is frozen and immutable. Trying to set
+      # a key when immutable will raise a +RuntimeError+.
       #
-      # The Key can be set before the entity is saved.
-      #
+      # @example The Key can be set before the entity is saved:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -161,9 +139,7 @@ module Gcloud
       #   entity.key = Gcloud::Datastore::Key.new "User"
       #   dataset.save entity
       #
-      # Once the entity is saved, the key is frozen and immutable.
-      # Trying to set a key when immutable will raise a +RuntimeError+.
-      #
+      # @example Once the entity is saved, the key is frozen and immutable:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -182,8 +158,7 @@ module Gcloud
       ##
       # Indicates if the record is persisted. Default is false.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -203,15 +178,14 @@ module Gcloud
       # Indicates if a property is flagged to be excluded from the
       # Datastore indexes. The default value is false.
       #
-      # Single property values will return a single flag setting.
-      #
+      # @example Single property values will return a single flag setting:
       #   entity["age"] = 21
       #   entity.exclude_from_indexes? "age" #=> false
       #
-      # Array property values will return an array of flag settings.
-      #
+      # @example Array property values will return an array of flag settings:
       #   entity["tags"] = ["ruby", "code"]
       #   entity.exclude_from_indexes? "tags" #=> [false, false]
+      #
       def exclude_from_indexes? name
         value = self[name]
         flag = @_exclude_indexes[name.to_s]
@@ -255,9 +229,8 @@ module Gcloud
       end
 
       ##
-      # Convert the Entity to a protocol buffer object.
-      # This is not part of the public API.
-      def to_proto #:nodoc:
+      # @private Convert the Entity to a protocol buffer object.
+      def to_proto
         entity = Proto::Entity.new.tap do |e|
           e.key = @key.to_proto
           e.property = Proto.to_proto_properties @properties.to_h
@@ -267,9 +240,8 @@ module Gcloud
       end
 
       ##
-      # Create a new Entity from a protocol buffer object.
-      # This is not part of the public API.
-      def self.from_proto proto #:nodoc:
+      # @private Create a new Entity from a protocol buffer object.
+      def self.from_proto proto
         entity = Entity.new
         entity.key = Key.from_proto proto.key
         Array(proto.property).each do |p|
@@ -285,11 +257,11 @@ module Gcloud
       # Disabled rubocop because this is intentionally complex.
 
       ##
-      # Map the exclude flag object to value.
+      # @private Map the exclude flag object to value.
       # The flag object can be a boolean, Proc, or Array.
       # Procs will be called and passed in the value.
       # This will return an array of flags for an array value.
-      def map_exclude_flag_to_value flag, value #:nodoc:
+      def map_exclude_flag_to_value flag, value
         if value.is_a? Array
           if flag.is_a? Proc
             value.map { |v| !!flag.call(v) }
@@ -310,8 +282,8 @@ module Gcloud
       end
 
       ##
-      # Update the exclude data after a new object is created.
-      def update_exclude_indexes! entity #:nodoc:
+      # @private Update the exclude data after a new object is created.
+      def update_exclude_indexes! entity
         @_exclude_indexes = {}
         Array(entity.property).each do |property|
           @_exclude_indexes[property.name] = property.value.indexed
@@ -323,8 +295,8 @@ module Gcloud
       end
 
       ##
-      # Update the indexed values before the object is saved.
-      def update_properties_indexed! entity #:nodoc:
+      # @private Update the indexed values before the object is saved.
+      def update_properties_indexed! entity
         Array(entity.property).each do |property|
           excluded = exclude_from_indexes? property.name
           if excluded.is_a? Array

--- a/lib/gcloud/datastore/errors.rb
+++ b/lib/gcloud/datastore/errors.rb
@@ -18,21 +18,21 @@ require "gcloud/errors"
 module Gcloud
   module Datastore
     ##
-    # = Datastore Error
+    # # Datastore Error
     #
     # Base Datastore exception class.
     class Error < Gcloud::Error
     end
 
     ##
-    # = KeyfileError
+    # # KeyfileError
     #
     # Raised when a keyfile is not correct.
     class KeyfileError < Gcloud::Datastore::Error
     end
 
     ##
-    # = ApiError
+    # # ApiError
     #
     # Raised when an API call is not successful.
     class ApiError < Gcloud::Datastore::Error
@@ -53,14 +53,14 @@ module Gcloud
     end
 
     ##
-    # = PropertyError
+    # # PropertyError
     #
     # Raised when a property is not correct.
     class PropertyError < Gcloud::Datastore::Error
     end
 
     ##
-    # = TransactionError
+    # # TransactionError
     #
     # General error for Transaction problems.
     class TransactionError < Gcloud::Datastore::Error

--- a/lib/gcloud/datastore/errors.rb
+++ b/lib/gcloud/datastore/errors.rb
@@ -44,7 +44,8 @@ module Gcloud
       # The response object of the failed HTTP request.
       attr_reader :response
 
-      def initialize method, response = nil #:nodoc:
+      # @private
+      def initialize method, response = nil
         super("API call to #{method} was not successful")
         @method = method
         @response = response
@@ -67,7 +68,8 @@ module Gcloud
       # An error that occurred within the transaction. (optional)
       attr_reader :inner
 
-      def initialize message, inner = nil #:nodoc:
+      # @private
+      def initialize message, inner = nil
         super(message)
         @inner = inner
       end

--- a/lib/gcloud/datastore/errors.rb
+++ b/lib/gcloud/datastore/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/errors"
 

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/datastore/proto"
 

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -18,7 +18,7 @@ require "gcloud/datastore/proto"
 module Gcloud
   module Datastore
     ##
-    # = Key
+    # # Key
     #
     # Every Datastore record has an identifying key, which includes the record's
     # entity kind and a unique identifier. The identifier may be either a key

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -25,17 +25,16 @@ module Gcloud
     # name string, assigned explicitly by the application, or an integer numeric
     # ID, assigned automatically by Datastore.
     #
+    # @example
     #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
+    #
     class Key
       ##
       # The kind of the Key.
       #
-      # === Returns
+      # @return [String]
       #
-      # +String+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User"
       #   key.kind #=> "User"
       #   key.kind = "Task"
@@ -45,12 +44,9 @@ module Gcloud
       ##
       # The dataset_id of the Key.
       #
-      # === Returns
+      # @return [String]
       #
-      # +String+
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -65,12 +61,9 @@ module Gcloud
       ##
       # The namespace of the Key.
       #
-      # === Returns
+      # @return [String, nil]
       #
-      # +String+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -85,19 +78,13 @@ module Gcloud
       ##
       # Create a new Key instance.
       #
-      # === Parameters
+      # @param [String] kind The kind of the Key. This is optional.
+      # @param [Integer, String] id_or_name The id or name of the Key. This is
+      #   optional.
       #
-      # +kind+::
-      #   The kind of the Key. This is optional. (+String+)
-      # +id_or_name+::
-      #   The id or name of the Key. This is optional. (+Integer+ or +String+)
+      # @return [Gcloud::Datastore::Dataset::Key]
       #
-      # === Returns
-      #
-      # Gcloud::Datastore::Dataset::Key
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
       def initialize kind = nil, id_or_name = nil
@@ -110,15 +97,12 @@ module Gcloud
       end
 
       ##
-      # Set the id of the Key.
+      # @private Set the id of the Key.
       # If a name is already present it will be removed.
       #
-      # === Returns
+      # @return [Integer, nil]
       #
-      # +Integer+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   key.id #=> nil
       #   key.name #=> "heidi@example.com"
@@ -126,7 +110,7 @@ module Gcloud
       #   key.id #=> 654321
       #   key.name #=> nil
       #
-      def id= new_id #:nodoc:
+      def id= new_id
         @name = nil if new_id
         @id = new_id
       end
@@ -134,27 +118,21 @@ module Gcloud
       ##
       # The id of the Key.
       #
-      # === Returns
+      # @return [Integer, nil]
       #
-      # +Integer+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", 123456
       #   key.id #=> 123456
       #
       attr_reader :id
 
       ##
-      # Set the name of the Key.
+      # @private Set the name of the Key.
       # If an id is already present it will be removed.
       #
-      # === Returns
+      # @return [String, nil]
       #
-      # +String+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", 123456
       #   key.id #=> 123456
       #   key.name #=> nil
@@ -162,7 +140,7 @@ module Gcloud
       #   key.id #=> nil
       #   key.name #=> "heidi@example.com"
       #
-      def name= new_name #:nodoc:
+      def name= new_name
         @id = nil if new_name
         @name = new_name
       end
@@ -170,30 +148,24 @@ module Gcloud
       ##
       # The name of the Key.
       #
-      # === Returns
+      # @return [String, nil]
       #
-      # +String+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   key.name #=> "heidi@example.com"
       #
       attr_reader :name
 
       ##
-      # Set the parent of the Key.
+      # @private Set the parent of the Key.
       #
-      # === Returns
+      # @return [Key, nil]
       #
-      # +Key+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "List", "todos"
       #   key.parent = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #
-      def parent= new_parent #:nodoc:
+      def parent= new_parent
         # store key if given an entity
         new_parent = new_parent.key if new_parent.respond_to? :key
         @parent = new_parent
@@ -202,12 +174,9 @@ module Gcloud
       ##
       # The parent of the Key.
       #
-      # === Returns
+      # @return [Key, nil]
       #
-      # +Key+ or +nil+
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -226,12 +195,9 @@ module Gcloud
       # Each inner array contains two values, the kind and the id or name.
       # If neither an id or name exist then nil will be returned.
       #
-      # === Returns
+      # @return [Array<Array<(String, String)>>]
       #
-      # Array of arrays
-      #
-      # === Example
-      #
+      # @example
       #   key = Gcloud::Datastore::Key.new "List", "todos"
       #   key.parent = Gcloud::Datastore::Key.new "User", "heidi@example.com"
       #   key.path #=> [["User", "heidi@example.com"], ["List", "todos"]]
@@ -245,7 +211,7 @@ module Gcloud
       # Determine if the key is complete.
       # A complete key has either an id or a name.
       #
-      # Inverse of #incomplete?
+      # Inverse of {#incomplete?}
       def complete?
         !incomplete?
       end
@@ -254,15 +220,14 @@ module Gcloud
       # Determine if the key is incomplete.
       # An incomplete key has neither an id nor a name.
       #
-      # Inverse of #complete?
+      # Inverse of {#complete?}
       def incomplete?
         kind.nil? || (id.nil? && (name.nil? || name.empty?))
       end
 
       ##
-      # Convert the Key to a protocol buffer object.
-      # This is not part of the public API.
-      def to_proto #:nodoc:
+      # @private Convert the Key to a protocol buffer object.
+      def to_proto
         Proto::Key.new.tap do |k|
           k.path_element = path.map do |pe_kind, pe_id_or_name|
             Proto.new_path_element pe_kind, pe_id_or_name
@@ -274,9 +239,8 @@ module Gcloud
       # rubocop:disable all
 
       ##
-      # Create a new Key from a protocol buffer object.
-      # This is not part of the public API.
-      def self.from_proto proto #:nodoc:
+      # @private Create a new Key from a protocol buffer object.
+      def self.from_proto proto
         # Disable rules because the complexity here is neccessary.
         key_proto = proto.dup
         key = Key.new

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -16,7 +16,7 @@
 module Gcloud
   module Datastore
     ##
-    # = Properties
+    # # Properties
     #
     # Hash-like data structure for Datastore properties.
     #

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Datastore

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -20,7 +20,7 @@ module Gcloud
     #
     # Hash-like data structure for Datastore properties.
     #
-    # See Entity#properties
+    # See {Entity#properties}
     class Properties
       def initialize properties = {}
         @hash = {}

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -21,6 +21,8 @@ module Gcloud
     # rubocop:disable all
 
     ##
+    # @private
+    #
     # Proto is the namespace that contains all Protocol Buffer objects.
     #
     # The methods in this module are for convenience in using the
@@ -30,7 +32,7 @@ module Gcloud
     # this module's existance, may change in the future.
     #
     # You have been warned.
-    module Proto #:nodoc:
+    module Proto
       def self.from_proto_value proto_value
         if !proto_value.timestamp_microseconds_value.nil?
           microseconds = proto_value.timestamp_microseconds_value
@@ -111,7 +113,7 @@ module Gcloud
         Time.at(microseconds / 1000000, microseconds % 1000000).utc
       end
 
-      #:nodoc:
+      @private
       PROP_FILTER_OPS = {
         "<"   => PropertyFilter::Operator::LESS_THAN,
         "lt"  => PropertyFilter::Operator::LESS_THAN,
@@ -245,7 +247,8 @@ module Gcloud
         end
       end
 
-      class Key #:nodoc:
+      # @private
+      class Key
         def dup
           proto_request_body = ""
           self.encode proto_request_body

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/proto/datastore_v1.pb"
 require "gcloud/datastore/errors"

--- a/lib/gcloud/datastore/query.rb
+++ b/lib/gcloud/datastore/query.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/datastore/entity"
 require "gcloud/datastore/key"

--- a/lib/gcloud/datastore/query.rb
+++ b/lib/gcloud/datastore/query.rb
@@ -20,7 +20,7 @@ require "gcloud/datastore/proto"
 module Gcloud
   module Datastore
     ##
-    # = Query
+    # # Query
     #
     # Represents the search criteria against a Datastore.
     #

--- a/lib/gcloud/datastore/query.rb
+++ b/lib/gcloud/datastore/query.rb
@@ -24,16 +24,20 @@ module Gcloud
     #
     # Represents the search criteria against a Datastore.
     #
+    # @example
     #   query = Gcloud::Datastore::Query.new
     #   query.kind("Task").
     #     where("completed", "=", true)
     #
     #   entities = dataset.run query
+    #
     class Query
       ##
       # Returns a new query object.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
+      #
       def initialize
         @_query = Proto::Query.new
       end
@@ -41,10 +45,12 @@ module Gcloud
       ##
       # Add the kind of entities to query.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind "Task"
       #
       #   all_tasks = dataset.run query
+      #
       def kind *kinds
         @_query.kind ||= Proto::KindExpression.new
         @_query.kind.name ||= []
@@ -55,11 +61,13 @@ module Gcloud
       ##
       # Add a property filter to the query.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     where("completed", "=", true)
       #
       #   completed_tasks = dataset.run query
+      #
       def where name, operator, value
         # Initialize filter
         @_query.filter ||= Proto.new_filter.tap do |f|
@@ -78,11 +86,13 @@ module Gcloud
       ##
       # Add a filter for entities that inherit from a key.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     ancestor(parent.key)
       #
       #   completed_tasks = dataset.run query
+      #
       def ancestor parent
         # Use key if given an entity
         parent = parent.key if parent.respond_to? :key
@@ -95,11 +105,13 @@ module Gcloud
       # To sort in descending order, provide a second argument
       # of a string or symbol that starts with "d".
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     order("due", :desc)
       #
       #   sorted_tasks = dataset.run query
+      #
       def order name, direction = :asc
         @_query.order ||= []
         po = Proto::PropertyOrder.new
@@ -113,11 +125,13 @@ module Gcloud
       ##
       # Set a limit on the number of results to be returned.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     limit(10)
       #
       #   paginated_tasks = dataset.run query
+      #
       def limit num
         @_query.limit = num
         self
@@ -126,12 +140,14 @@ module Gcloud
       ##
       # Set an offset for the results to be returned.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     limit(10).
       #     offset(20)
       #
       #   paginated_tasks = dataset.run query
+      #
       def offset num
         @_query.offset = num
         self
@@ -140,12 +156,14 @@ module Gcloud
       ##
       # Set the cursor to start the results at.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     limit(10).
       #     cursor(task_cursor)
       #
       #   paginated_tasks = dataset.run query
+      #
       def start cursor
         @_query.start_cursor = Proto.decode_cursor cursor
         self
@@ -155,11 +173,13 @@ module Gcloud
       ##
       # Retrieve only select properties from the matched entities.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     select("completed", "due")
       #
       #   partial_tasks = dataset.run query
+      #
       def select *names
         @_query.projection ||= []
         @_query.projection += Proto.new_property_expressions(*names)
@@ -170,18 +190,21 @@ module Gcloud
       ##
       # Group results by a list of properties.
       #
+      # @example
       #   query = Gcloud::Datastore::Query.new
       #   query.kind("Task").
       #     group_by("completed")
       #
       #   grouped_tasks = dataset.run query
+      #
       def group_by *names
         @_query.group_by ||= []
         @_query.group_by += Proto.new_property_references(*names)
         self
       end
 
-      def to_proto #:nodoc:
+      # @private
+      def to_proto
         @_query
       end
     end

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Datastore

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -16,7 +16,7 @@
 module Gcloud
   module Datastore
     ##
-    # = Transaction
+    # # Transaction
     #
     # Special Connection instance for running transactions.
     #

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -20,14 +20,14 @@ module Gcloud
     #
     # Special Connection instance for running transactions.
     #
-    # See Gcloud::Datastore::Dataset.transaction
+    # See {Gcloud::Datastore::Dataset.transaction}
     class Transaction < Dataset
       attr_reader :id
 
       ##
-      # Creates a new Transaction instance.
+      # @private Creates a new Transaction instance.
       # Takes a Connection instead of project and Credentials.
-      def initialize connection #:nodoc:
+      def initialize connection
         @connection = connection
         reset!
         start
@@ -36,11 +36,13 @@ module Gcloud
       ##
       # Persist entities in a transaction.
       #
+      # @example
       #   dataset.transaction do |tx|
       #     if tx.find(user.key).nil?
       #       tx.save task1, task2
       #     end
       #   end
+      #
       def save *entities
         save_entities_to_mutation entities, shared_mutation
         # Do not save or assign auto_ids yet
@@ -50,11 +52,13 @@ module Gcloud
       ##
       # Remove entities in a transaction.
       #
+      # @example
       #   dataset.transaction do |tx|
       #     if tx.find(user.key).nil?
       #       tx.delete task1, task2
       #     end
       #   end
+      #
       def delete *entities
         shared_mutation.tap do |m|
           m.delete = entities.map { |entity| entity.key.to_proto }
@@ -99,7 +103,7 @@ module Gcloud
 
       ##
       # Reset the transaction.
-      # Transaction#start must be called afterwards.
+      # {Transaction#start} must be called afterwards.
       def reset!
         @shared_mutation = nil
         @id = nil
@@ -109,9 +113,9 @@ module Gcloud
       protected
 
       ##
-      # Mutation to be shared across save, delete, and commit calls.
+      # @private Mutation to be shared across save, delete, and commit calls.
       # This enables updates to happen when commit is called.
-      def shared_mutation #:nodoc:
+      def shared_mutation
         @shared_mutation ||= Proto.new_mutation
       end
     end

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -90,12 +90,14 @@ module Gcloud
   # qualified](https://en.wikipedia.org/wiki/Fully_qualified_domain_name)) as
   # you follow along with these examples.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.create_zone "example-com", "example.com."
-  #   puts zone.id # unique identifier defined by the server
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.create_zone "example-com", "example.com."
+  # puts zone.id # unique identifier defined by the server
+  # ```
   #
   # For more information, see [Managing
   # Zones](https://cloud.google.com/dns/zones/).
@@ -104,22 +106,26 @@ module Gcloud
   #
   # You can retrieve all the zones in your project.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zones = dns.zones
-  #   zones.each do |zone|
-  #     puts "#{zone.name} - #{zone.dns}"
-  #   end
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zones = dns.zones
+  # zones.each do |zone|
+  #   puts "#{zone.name} - #{zone.dns}"
+  # end
+  # ```
   #
   # You can also retrieve a single zone by either name or id.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # ```
   #
   # ## Listing Records
   #
@@ -127,16 +133,18 @@ module Gcloud
   # Record instances for it, providing configuration for Cloud DNS nameservers.
   # Let's take a look at these records.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   records = zone.records
-  #   records.count #=> 2
-  #   records.map &:type #=> ["NS", "SOA"]
-  #   zone.records.first.data.count #=> 4
-  #   zone.records.first.data #=> ["ns-cloud-d1.googledomains.com.", ...]
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # records = zone.records
+  # records.count #=> 2
+  # records.map &:type #=> ["NS", "SOA"]
+  # zone.records.first.data.count #=> 4
+  # zone.records.first.data #=> ["ns-cloud-d1.googledomains.com.", ...]
+  # ```
   #
   # Note that Record#data returns an array. The Cloud DNS service only allows
   # the zone to have one Record instance for each name and type combination. It
@@ -148,14 +156,16 @@ module Gcloud
   # You can easily add your own records to the zone. Each call to Zone#add
   # results in a new Cloud DNS Change instance.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   change = zone.add "www", "A", 86400, ["1.2.3.4"]
-  #   change.additions.map &:type #=> ["A", "SOA"]
-  #   change.deletions.map &:type #=> ["SOA"]
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # change = zone.add "www", "A", 86400, ["1.2.3.4"]
+  # change.additions.map &:type #=> ["A", "SOA"]
+  # change.deletions.map &:type #=> ["SOA"]
+  # ```
   #
   # Whenever you change the set of records belonging to a zone, the zone's start
   # of authority (SOA) record should be updated with a higher serial number. The
@@ -167,89 +177,103 @@ module Gcloud
   # subdomain (e.g., `www`) fragment for convenience, but notice that the
   # retrieved record's domain name is always fully-qualified.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   records = zone.records "www", "A"
-  #   records.first.name #=> "www.example.com."
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # records = zone.records "www", "A"
+  # records.first.name #=> "www.example.com."
+  # ```
   #
   # You can use Zone#replace to update the `ttl` and `data` for a record.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   change = zone.replace "www", "A", 86400, ["5.6.7.8"]
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # change = zone.replace "www", "A", 86400, ["5.6.7.8"]
+  # ```
   #
   # Or, you can use Zone#modify to update just the `ttl` or `data`, without the
   # risk of inadvertently changing values that you wish to leave unchanged.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   change = zone.modify "www", "A" do |r|
-  #     r.ttl = 3600 # change only the TTL
-  #   end
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # change = zone.modify "www", "A" do |r|
+  #   r.ttl = 3600 # change only the TTL
+  # end
+  # ```
   #
   # You can also delete records by name and type.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   change = zone.remove "www", "A"
-  #   record = change.deletions.first
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # change = zone.remove "www", "A"
+  # record = change.deletions.first
+  # ```
   #
   # The best way to add, remove, and update multiple records in a single
   # [transaction](https://cloud.google.com/dns/records) is to call Zone#update
   # with a block. See Zone::Transaction.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   change = zone.update do |tx|
-  #     tx.add     "www", "A",  86400, "1.2.3.4"
-  #     tx.remove  "example.com.", "TXT"
-  #     tx.replace "example.com.", "MX", 86400, ["10 mail1.example.com.",
-  #                                              "20 mail2.example.com."]
-  #     tx.modify "www.example.com.", "CNAME" do |r|
-  #       r.ttl = 86400 # only change the TTL
-  #     end
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # change = zone.update do |tx|
+  #   tx.add     "www", "A",  86400, "1.2.3.4"
+  #   tx.remove  "example.com.", "TXT"
+  #   tx.replace "example.com.", "MX", 86400, ["10 mail1.example.com.",
+  #                                            "20 mail2.example.com."]
+  #   tx.modify "www.example.com.", "CNAME" do |r|
+  #     r.ttl = 86400 # only change the TTL
   #   end
+  # end
+  # ```
   #
   # Finally, you can add and delete records by reference, using Zone#update.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   to_add = zone.record "www", "AAAA", 86400, ["2607:f8b0:400a:801::1005"]
-  #   to_delete = zone.records "www", "A"
-  #   change = zone.update to_add, to_delete
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # to_add = zone.record "www", "AAAA", 86400, ["2607:f8b0:400a:801::1005"]
+  # to_delete = zone.records "www", "A"
+  # change = zone.update to_add, to_delete
+  # ```
   #
   # ## Listing Changes
   #
   # Because the transactions you execute against your zone do not always
   # complete immediately, you can retrieve and inspect changes.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   changes = zone.changes
-  #   changes.each do |change|
-  #     puts "#{change.id} - #{change.started_at} - #{change.status}"
-  #   end
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # changes = zone.changes
+  # changes.each do |change|
+  #   puts "#{change.id} - #{change.started_at} - #{change.status}"
+  # end
+  # ```
   #
   # ## Importing and exporting zone files
   #
@@ -257,22 +281,27 @@ module Gcloud
   # the zone to have one Record instance for each name and type combination,
   # lines may be merged as needed into records with multiple `data` values.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
-  #   change = zone.import "path/to/db.example.com"
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
+  # change = zone.import "path/to/db.example.com"
+  # ```
   #
   # You can also export to a zone file.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   dns = gcloud.dns
-  #   zone = dns.zone "example-com"
+  # gcloud = Gcloud.new
+  # dns = gcloud.dns
+  # zone = dns.zone "example-com"
   #
-  #   zone.export "path/to/db.example.com"
+  # zone.export "path/to/db.example.com"
+  # ```
+  #
   module Dns
   end
 end

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -32,8 +32,8 @@ module Gcloud
   #   readable. (+String+ or +Hash+)
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -70,24 +70,24 @@ module Gcloud
   # provides a cost-effective way to make your applications and services
   # available to your users. This programmable, authoritative DNS service can be
   # used to easily publish and manage DNS records using the same infrastructure
-  # relied upon by Google. To learn more, read {What is Google Cloud
-  # DNS?}[https://cloud.google.com/dns/what-is-cloud-dns].
+  # relied upon by Google. To learn more, read [What is Google Cloud
+  # DNS?](https://cloud.google.com/dns/what-is-cloud-dns).
   #
   # Gcloud's goal is to provide an API that is familiar and comfortable to
   # Rubyists. Authentication is handled by Gcloud#dns. You can provide
   # the project and credential information to connect to the Cloud DNS service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you. You can read more about the options for connecting in the
-  # {Authentication Guide}[link:AUTHENTICATION.md].
+  # [Authentication Guide](link:AUTHENTICATION.md).
   #
   # ## Creating Zones
   #
   # To get started with Google Cloud DNS, use your DNS Project to create a new
   # Zone. The second argument to Project#create_zone must be a unique
-  # domain name for which you can {verify
-  # ownership}[https://www.google.com/webmasters/verification/home]. Substitute
-  # a domain name of your own (ending with a dot to signify that it is {fully
-  # qualified}[https://en.wikipedia.org/wiki/Fully_qualified_domain_name]) as
+  # domain name for which you can [verify
+  # ownership](https://www.google.com/webmasters/verification/home). Substitute
+  # a domain name of your own (ending with a dot to signify that it is [fully
+  # qualified](https://en.wikipedia.org/wiki/Fully_qualified_domain_name)) as
   # you follow along with these examples.
   #
   #   require "gcloud"
@@ -97,8 +97,8 @@ module Gcloud
   #   zone = dns.create_zone "example-com", "example.com."
   #   puts zone.id # unique identifier defined by the server
   #
-  # For more information, see {Managing
-  # Zones}[https://cloud.google.com/dns/zones/].
+  # For more information, see [Managing
+  # Zones](https://cloud.google.com/dns/zones/).
   #
   # ## Listing Zones
   #
@@ -207,7 +207,7 @@ module Gcloud
   #   record = change.deletions.first
   #
   # The best way to add, remove, and update multiple records in a single
-  # {transaction}[https://cloud.google.com/dns/records] is to call Zone#update
+  # [transaction](https://cloud.google.com/dns/records) is to call Zone#update
   # with a block. See Zone::Transaction.
   #
   #   require "gcloud"

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new `Project` instance connected to the DNS service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Identifier for a DNS project. If not present, the default project for
-  #   the credentials is used. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Identifier for a DNS project. If not present, the
+  #   default project for the credentials is used.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   #
-  # ### Returns
+  # @return [Gcloud::Dns::Project]
   #
-  # Gcloud::Dns::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud"
   #
   #   dns = Gcloud.dns "my-dns-project",

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -78,7 +78,7 @@ module Gcloud
   # the project and credential information to connect to the Cloud DNS service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you. You can read more about the options for connecting in the
-  # [Authentication Guide](link:AUTHENTICATION.md).
+  # [Authentication Guide](../AUTHENTICATION).
   #
   # ## Creating Zones
   #

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 require "gcloud/dns/project"
 
-#--
-# Google Cloud DNS
 module Gcloud
   ##
   # Creates a new `Project` instance connected to the DNS service.

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -19,26 +19,26 @@ require "gcloud/dns/project"
 # Google Cloud DNS
 module Gcloud
   ##
-  # Creates a new +Project+ instance connected to the DNS service.
+  # Creates a new `Project` instance connected to the DNS service.
   # Each call creates a new connection.
   #
   # ### Parameters
   #
-  # +project+::
+  # `project`::
   #   Identifier for a DNS project. If not present, the default project for
-  #   the credentials is used. (+String+)
-  # +keyfile+::
+  #   the credentials is used. (`String`)
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
-  # +scope+::
+  #   readable. (`String` or `Hash`)
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/ndev.clouddns.readwrite+
+  #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   #
   # ### Returns
   #
@@ -141,7 +141,7 @@ module Gcloud
   # Note that Record#data returns an array. The Cloud DNS service only allows
   # the zone to have one Record instance for each name and type combination. It
   # supports multiple "resource records" (in this case, the four nameserver
-  # addresses) via this +data+ collection.
+  # addresses) via this `data` collection.
   #
   # ## Managing Records
   #
@@ -164,7 +164,7 @@ module Gcloud
   # modify this behavior, of course. See Zone#update for details.
   #
   # You can retrieve records by name and type. The name argument can be a
-  # subdomain (e.g., +www+) fragment for convenience, but notice that the
+  # subdomain (e.g., `www`) fragment for convenience, but notice that the
   # retrieved record's domain name is always fully-qualified.
   #
   #   require "gcloud"
@@ -175,7 +175,7 @@ module Gcloud
   #   records = zone.records "www", "A"
   #   records.first.name #=> "www.example.com."
   #
-  # You can use Zone#replace to update the +ttl+ and +data+ for a record.
+  # You can use Zone#replace to update the `ttl` and `data` for a record.
   #
   #   require "gcloud"
   #
@@ -184,7 +184,7 @@ module Gcloud
   #   zone = dns.zone "example-com"
   #   change = zone.replace "www", "A", 86400, ["5.6.7.8"]
   #
-  # Or, you can use Zone#modify to update just the +ttl+ or +data+, without the
+  # Or, you can use Zone#modify to update just the `ttl` or `data`, without the
   # risk of inadvertently changing values that you wish to leave unchanged.
   #
   #   require "gcloud"
@@ -255,7 +255,7 @@ module Gcloud
   #
   # You can import from a zone file. Because the Cloud DNS service only allows
   # the zone to have one Record instance for each name and type combination,
-  # lines may be merged as needed into records with multiple +data+ values.
+  # lines may be merged as needed into records with multiple `data` values.
   #
   #   require "gcloud"
   #

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -22,7 +22,7 @@ module Gcloud
   # Creates a new +Project+ instance connected to the DNS service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +project+::
   #   Identifier for a DNS project. If not present, the default project for
@@ -40,11 +40,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/ndev.clouddns.readwrite+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Dns::Project
   #
-  # === Example
+  # ### Example
   #
   #   require "gcloud"
   #
@@ -64,7 +64,7 @@ module Gcloud
   end
 
   ##
-  # = Google Cloud DNS
+  # # Google Cloud DNS
   #
   # Google Cloud DNS is a high-performance, resilient, global DNS service that
   # provides a cost-effective way to make your applications and services
@@ -80,7 +80,7 @@ module Gcloud
   # care of for you. You can read more about the options for connecting in the
   # {Authentication Guide}[link:AUTHENTICATION.md].
   #
-  # == Creating Zones
+  # ## Creating Zones
   #
   # To get started with Google Cloud DNS, use your DNS Project to create a new
   # Zone. The second argument to Project#create_zone must be a unique
@@ -100,7 +100,7 @@ module Gcloud
   # For more information, see {Managing
   # Zones}[https://cloud.google.com/dns/zones/].
   #
-  # == Listing Zones
+  # ## Listing Zones
   #
   # You can retrieve all the zones in your project.
   #
@@ -121,7 +121,7 @@ module Gcloud
   #   dns = gcloud.dns
   #   zone = dns.zone "example-com"
   #
-  # == Listing Records
+  # ## Listing Records
   #
   # When you create a zone, the Cloud DNS service automatically creates two
   # Record instances for it, providing configuration for Cloud DNS nameservers.
@@ -143,7 +143,7 @@ module Gcloud
   # supports multiple "resource records" (in this case, the four nameserver
   # addresses) via this +data+ collection.
   #
-  # == Managing Records
+  # ## Managing Records
   #
   # You can easily add your own records to the zone. Each call to Zone#add
   # results in a new Cloud DNS Change instance.
@@ -236,7 +236,7 @@ module Gcloud
   #   to_delete = zone.records "www", "A"
   #   change = zone.update to_add, to_delete
   #
-  # == Listing Changes
+  # ## Listing Changes
   #
   # Because the transactions you execute against your zone do not always
   # complete immediately, you can retrieve and inspect changes.
@@ -251,7 +251,7 @@ module Gcloud
   #     puts "#{change.id} - #{change.started_at} - #{change.status}"
   #   end
   #
-  # == Importing and exporting zone files
+  # ## Importing and exporting zone files
   #
   # You can import from a zone file. Because the Cloud DNS service only allows
   # the zone to have one Record instance for each name and type combination,

--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -19,7 +19,7 @@ require "time"
 module Gcloud
   module Dns
     ##
-    # = DNS Change
+    # # DNS Change
     #
     # Represents a request containing additions or deletions or records.
     # Additions and deletions can be done in bulk, in a single atomic

--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -26,6 +26,7 @@ module Gcloud
     # transaction, and take effect at the same time in each authoritative DNS
     # server.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -38,16 +39,16 @@ module Gcloud
     #
     class Change
       ##
-      # The Zone object this Change belongs to.
-      attr_accessor :zone #:nodoc:
+      # @private The Zone object this Change belongs to.
+      attr_accessor :zone
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Change object.
-      def initialize #:nodoc:
+      # @private Create an empty Change object.
+      def initialize
         @zone = nil
         @gapi = {}
       end
@@ -120,8 +121,7 @@ module Gcloud
       # Refreshes the change until the status is +done+.
       # The delay between refreshes will incrementally increase.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -143,8 +143,8 @@ module Gcloud
       end
 
       ##
-      # New Change from a Google API Client object.
-      def self.from_gapi gapi, zone #:nodoc:
+      # @private New Change from a Google API Client object.
+      def self.from_gapi gapi, zone
         new.tap do |f|
           f.gapi = gapi
           f.zone = zone

--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -75,21 +75,21 @@ module Gcloud
       end
 
       ##
-      # Status of the operation. Values are +"done"+ and +"pending"+.
+      # Status of the operation. Values are `"done"` and `"pending"`.
       #
       def status
         @gapi["status"]
       end
 
       ##
-      # Checks if the status is +"done"+.
+      # Checks if the status is `"done"`.
       def done?
         return false if status.nil?
         "done".casecmp(status).zero?
       end
 
       ##
-      # Checks if the status is +"pending"+.
+      # Checks if the status is `"pending"`.
       def pending?
         return false if status.nil?
         "pending".casecmp(status).zero?
@@ -118,7 +118,7 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # Refreshes the change until the status is +done+.
+      # Refreshes the change until the status is `done`.
       # The delay between refreshes will incrementally increase.
       #
       # @example

--- a/lib/gcloud/dns/change.rb
+++ b/lib/gcloud/dns/change.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/dns/change/list"
 require "time"

--- a/lib/gcloud/dns/change/list.rb
+++ b/lib/gcloud/dns/change/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/dns/change/list.rb
+++ b/lib/gcloud/dns/change/list.rb
@@ -47,8 +47,8 @@ module Gcloud
         end
 
         ##
-        # New Changes::List from a response object.
-        def self.from_response resp, zone #:nodoc:
+        # @private New Changes::List from a response object.
+        def self.from_response resp, zone
           changes = new(Array(resp.data["changes"]).map do |gapi_object|
             Change.from_gapi gapi_object, zone
           end)

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -19,17 +19,16 @@ require "google/api_client"
 module Gcloud
   module Dns
     ##
-    # Represents the connection to DNS,
-    # as well as expose the API calls.
-    class Connection #:nodoc:
+    # @private Represents the connection to DNS, as well as expose the API calls
+    class Connection
       API_VERSION = "v1"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
-      def initialize project, credentials #:nodoc:
+      def initialize project, credentials
         @project = project
         @credentials = credentials
         @client = Google::APIClient.new application_name:    "gcloud-ruby",
@@ -136,7 +135,7 @@ module Gcloud
 
       ##
       # Fully Qualified Domain Name
-      def self.fqdn name, origin_dns #:nodoc:
+      def self.fqdn name, origin_dns
         name = name.to_s.strip
         return name if self.ip_addr? name
         name = origin_dns if name.empty?
@@ -148,16 +147,16 @@ module Gcloud
 
       require "ipaddr"
       # Fix to make ip_addr? work on ruby 1.9
-      IPAddr::Error = ArgumentError unless defined? IPAddr::Error #:nodoc:
+      IPAddr::Error = ArgumentError unless defined? IPAddr::Error
 
-      def self.ip_addr? name #:nodoc:
+      def self.ip_addr? name
         IPAddr.new name
         true
       rescue IPAddr::Error
         false
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
     end

--- a/lib/gcloud/dns/connection.rb
+++ b/lib/gcloud/dns/connection.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/version"
 require "google/api_client"

--- a/lib/gcloud/dns/credentials.rb
+++ b/lib/gcloud/dns/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Dns
     ##
-    # Represents the Oauth2 signing logic for DNS.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the Oauth2 signing logic for DNS.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/ndev.clouddns.readwrite"]
       PATH_ENV_VARS = %w(DNS_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(DNS_KEYFILE_JSON GCLOUD_KEYFILE_JSON

--- a/lib/gcloud/dns/credentials.rb
+++ b/lib/gcloud/dns/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/credentials"
 

--- a/lib/gcloud/dns/errors.rb
+++ b/lib/gcloud/dns/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/errors"
 

--- a/lib/gcloud/dns/errors.rb
+++ b/lib/gcloud/dns/errors.rb
@@ -33,13 +33,15 @@ module Gcloud
       # The errors encountered.
       attr_reader :errors
 
-      def initialize message, code, errors = [] #:nodoc:
+      # @private
+      def initialize message, code, errors = []
         super message
         @code   = code
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         if resp.data? && resp.data["error"]
           from_response_data resp.data["error"]
         else
@@ -47,11 +49,13 @@ module Gcloud
         end
       end
 
-      def self.from_response_data error #:nodoc:
+      # @private
+      def self.from_response_data error
         new error["message"], error["code"], error["errors"]
       end
 
-      def self.from_response_status resp #:nodoc:
+      # @private
+      def self.from_response_status resp
         if resp.status == 404
           new "#{resp.error_message}: #{resp.request.uri.request_uri}",
               resp.status

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -20,7 +20,7 @@ module Gcloud
   module Dns
     ##
     # @private
-    # = DNS Importer
+    # # DNS Importer
     #
     # Reads a {DNS zone
     # file}[https://en.wikipedia.org/wiki/Zone_file] and parses it, creating a

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -29,10 +29,10 @@ module Gcloud
     # file records to a Zone.
     #
     # Because the Google Cloud DNS API only accepts a single resource record for
-    # each +name+ and +type+ combination (with multiple +data+ elements), the
+    # each `name` and `type` combination (with multiple `data` elements), the
     # zone file's records are merged as necessary. During this merge, the lowest
-    # +ttl+ of the merged records is used. If none of the merged records have a
-    # +ttl+ value, the zone file's global TTL is used for the record.
+    # `ttl` of the merged records is used. If none of the merged records have a
+    # `ttl` value, the zone file's global TTL is used for the record.
     #
     # The following record types are supported: A, AAAA, CNAME, MX, NAPTR, NS,
     # PTR, SOA, SPF, SRV, and TXT.

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "zonefile"
 require "gcloud/dns/record"

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -22,8 +22,8 @@ module Gcloud
     # @private
     # # DNS Importer
     #
-    # Reads a {DNS zone
-    # file}[https://en.wikipedia.org/wiki/Zone_file] and parses it, creating a
+    # Reads a [DNS zone
+    # file](https://en.wikipedia.org/wiki/Zone_file) and parses it, creating a
     # collection of Record instances. The returned records are unsaved,
     # as they are not yet associated with a Zone. Use {Zone#import} to add zone
     # file records to a Zone.

--- a/lib/gcloud/dns/importer.rb
+++ b/lib/gcloud/dns/importer.rb
@@ -19,12 +19,13 @@ require "gcloud/dns/record"
 module Gcloud
   module Dns
     ##
+    # @private
     # = DNS Importer
     #
     # Reads a {DNS zone
     # file}[https://en.wikipedia.org/wiki/Zone_file] and parses it, creating a
     # collection of Record instances. The returned records are unsaved,
-    # as they are not yet associated with a Zone. Use Zone#import to add zone
+    # as they are not yet associated with a Zone. Use {Zone#import} to add zone
     # file records to a Zone.
     #
     # Because the Google Cloud DNS API only accepts a single resource record for
@@ -35,16 +36,13 @@ module Gcloud
     #
     # The following record types are supported: A, AAAA, CNAME, MX, NAPTR, NS,
     # PTR, SOA, SPF, SRV, and TXT.
-    class Importer #:nodoc:
+    class Importer
       ##
       # Creates a new Importer that immediately parses the provided zone file
       # data and creates Record instances.
       #
-      # === Parameters
-      #
-      # +path_or_io+::
-      #   The path to a zone file on the filesystem, or an IO instance from
-      #   which zone file data can be read. (+String+ or +IO+)
+      # @param [String, IO] path_or_io The path to a zone file on the
+      #   filesystem, or an IO instance from which zone file data can be read.
       #
       def initialize zone, path_or_io
         @zone = zone
@@ -59,16 +57,12 @@ module Gcloud
       ##
       # Returns the Record instances created from the zone file.
       #
-      # === Parameters
+      # @param [String, Array<String>] only Include only records of this type or
+      #   types.
+      # @param [String, Array<String>] except Exclude records of this type or
+      #   types.
       #
-      # +only+::
-      #   Include only records of this type or types. (+String+ or +Array+)
-      # +except+::
-      #   Exclude records of this type or types. (+String+ or +Array+)
-      #
-      # === Returns
-      #
-      # An array of unsaved Record instances.
+      # @return [Array<Record>] An array of unsaved {Record} instances
       #
       def records only: nil, except: nil
         ret = @records

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -22,7 +22,7 @@ require "gcloud/dns/errors"
 module Gcloud
   module Dns
     ##
-    # = Project
+    # # Project
     #
     # The project is a top level container for resources including Cloud DNS
     # ManagedZones. Projects can be created only in the {Google Developers

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/gce"
 require "gcloud/dns/connection"

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -138,7 +138,7 @@ module Gcloud
       #
       # @param [String, Integer] zone_id The name or id of a zone.
       #
-      # @return [Gcloud::Dns::Zone, nil] Returns +nil+ if the zone does not
+      # @return [Gcloud::Dns::Zone, nil] Returns `nil` if the zone does not
       #   exist.
       #
       # @example

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -28,6 +28,7 @@ module Gcloud
     # ManagedZones. Projects can be created only in the {Google Developers
     # Console}[https://console.developers.google.com].
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -37,21 +38,21 @@ module Gcloud
     #     puts record.name
     #   end
     #
-    # See Gcloud#dns
+    # See {Gcloud#dns}
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Creates a new Connection instance.
+      # @private Creates a new Connection instance.
       #
-      # See Gcloud.dns
-      def initialize project, credentials #:nodoc:
+      # See {Gcloud.dns}
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -61,8 +62,7 @@ module Gcloud
       ##
       # The unique ID string for the current project.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project", "/path/to/keyfile.json"
@@ -125,8 +125,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["DNS_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -136,17 +136,12 @@ module Gcloud
       ##
       # Retrieves an existing zone by name or id.
       #
-      # === Parameters
+      # @param [String, Integer] zone_id The name or id of a zone.
       #
-      # +zone_id+::
-      #   The name or id of a zone. (+String+ or +Integer+)
+      # @return [Gcloud::Dns::Zone, nil] Returns +nil+ if the zone does not
+      #   exist.
       #
-      # === Returns
-      #
-      # Gcloud::Dns::Zone or +nil+ if the zone does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -169,20 +164,13 @@ module Gcloud
       ##
       # Retrieves the list of zones belonging to the project.
       #
-      # === Parameters
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of zones to return.
       #
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of zones to return. (+Integer+)
+      # @return [Array<Gcloud::Dns::Zone>] (See {Gcloud::Dns::Zone::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Dns::Zone (See Gcloud::Dns::Zone::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -192,9 +180,7 @@ module Gcloud
       #     puts zone.name
       #   end
       #
-      # If you have a significant number of zones, you may need to paginate
-      # through them: (See Gcloud::Dns::Zone::List)
-      #
+      # @example With pagination: (See {Gcloud::Dns::Zone::List})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -222,30 +208,22 @@ module Gcloud
       ##
       # Creates a new zone.
       #
-      # === Parameters
+      # @param [String] zone_name User assigned name for this resource. Must be
+      #   unique within the project. The name must be 1-32 characters long, must
+      #   begin with a letter, end with a letter or digit, and only contain
+      #   lowercase letters, digits or dashes.
+      # @param [String] zone_dns The DNS name of this managed zone, for instance
+      #   "example.com.".
+      # @param [String] description A string of at most 1024 characters
+      #   associated with this resource for the user's convenience. Has no
+      #   effect on the managed zone's function.
+      # @param [String] name_server_set A NameServerSet is a set of DNS name
+      #   servers that all host the same ManagedZones. Most users will leave
+      #   this field unset.
       #
-      # +zone_name+::
-      #   User assigned name for this resource. Must be unique within the
-      #   project. The name must be 1-32 characters long, must begin with a
-      #   letter, end with a letter or digit, and only contain lowercase
-      #   letters, digits or dashes. (+String+)
-      # +zone_dns+::
-      #   The DNS name of this managed zone, for instance "example.com.".
-      #   (+String+)
-      # +description+::
-      #   A string of at most 1024 characters associated with this resource for
-      #   the user's convenience. Has no effect on the managed zone's function.
-      #   (+String+)
-      # +name_server_set+::
-      #   A NameServerSet is a set of DNS name servers that all host the same
-      #   ManagedZones. Most users will leave this field unset. (+String+)
+      # @return [Gcloud::Dns::Zone]
       #
-      # === Returns
-      #
-      # Gcloud::Dns::Zone
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -25,8 +25,8 @@ module Gcloud
     # # Project
     #
     # The project is a top level container for resources including Cloud DNS
-    # ManagedZones. Projects can be created only in the {Google Developers
-    # Console}[https://console.developers.google.com].
+    # ManagedZones. Projects can be created only in the [Google Developers
+    # Console](https://console.developers.google.com).
     #
     # @example
     #   require "gcloud"

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -18,7 +18,7 @@ require "gcloud/dns/record/list"
 module Gcloud
   module Dns
     ##
-    # = DNS Record
+    # # DNS Record
     #
     # Represents a set of DNS resource records (RRs) for a given {#name} and
     # {#type} in a {Zone}. Since it is a value object, a newly created Record

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -20,12 +20,13 @@ module Gcloud
     ##
     # = DNS Record
     #
-    # Represents a set of DNS resource records (RRs) for a given #name and #type
-    # in a Zone. Since it is a value object, a newly created Record instance
-    # is transient until it is added to a Zone with Zone#update. Note that
-    # Zone#add and the Zone#update block parameter can be used instead of
-    # Zone#record or +Record.new+ to create new records.
+    # Represents a set of DNS resource records (RRs) for a given {#name} and
+    # {#type} in a {Zone}. Since it is a value object, a newly created Record
+    # instance is transient until it is added to a Zone with {Zone#update}. Note
+    # that {Zone#add} and the {Zone#update} block parameter can be used instead
+    # of {Zone#record} or +Record.new+ to create new records.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -38,21 +39,28 @@ module Gcloud
     #   change = zone.update record
     #   zone.records.count #=> 3
     #
-    #
     class Record
       ##
-      # The owner of the record. For example: +example.com.+. (+String+)
+      # The owner of the record. For example: +example.com.+.
+      #
+      # @return [String]
+      #
       attr_accessor :name
 
       ##
       # The identifier of a {supported record type
       # }[https://cloud.google.com/dns/what-is-cloud-dns#supported_record_types]
-      # . For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+      # . For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      #
+      # @return [String]
+      #
       attr_accessor :type
 
       ##
       # The number of seconds that the record can be cached by resolvers.
-      # (+Integer+)
+      #
+      # @return [Integer]
+      #
       attr_accessor :ttl
 
       ##
@@ -61,30 +69,27 @@ module Gcloud
       # and {RFC
       # 1034 (section 3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1].
       # For example: ["10 mail.example.com.", "20 mail2.example.com."].
-      # (+Array+ of +String+)
+      #
+      # @return [Array<String>]
+      #
       attr_accessor :data
 
       ##
       # Creates a Record value object.
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The owner of the record. For example: +example.com.+. (+String+)
-      # +type+::
-      #   The identifier of a {supported record
+      # @param [String] name The owner of the record. For example:
+      #   +example.com.+.
+      # @param [String] type The identifier of a {supported record
       #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
-      # +ttl+::
-      #   The number of seconds that the record can be cached by resolvers.
-      #   (+Integer+)
-      # +data+::
-      #   The resource record data, as determined by +type+ and defined in {RFC
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      # @param [Integer] ttl The number of seconds that the record can be cached
+      #   by resolvers.
+      # @param [String, Array<String>] data The resource record data, as
+      #   determined by +type+ and defined in {RFC
       #   1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5] and
       #   {RFC 1034
       #   (section 3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1].
       #   For example: ["10 mail.example.com.", "20 mail2.example.com."].
-      #   (+String+ or +Array+ of +String+)
       #
       def initialize name, type, ttl, data
         fail ArgumentError, "name is required" unless name
@@ -98,9 +103,9 @@ module Gcloud
       end
 
       ##
-      # Returns an array of strings in the zone file format, one
+      # @private Returns an array of strings in the zone file format, one
       # for each element in the record's data array.
-      def to_zonefile_records #:nodoc:
+      def to_zonefile_records
         data.map do |rrdata|
           "#{name} #{ttl} IN #{type} #{rrdata}"
         end
@@ -109,7 +114,8 @@ module Gcloud
       ##
       # Returns a deep copy of the record. Useful for updating records, since
       # the original, unmodified record must be passed for deletion when using
-      # Zone#update.
+      # {Zone#update}.
+      #
       def dup
         other = super
         other.data = data.map(&:dup)
@@ -117,32 +123,36 @@ module Gcloud
       end
 
       ##
-      # New Record from a Google API Client object.
-      def self.from_gapi gapi #:nodoc:
+      # @private New Record from a Google API Client object.
+      def self.from_gapi gapi
         new gapi["name"], gapi["type"], gapi["ttl"], gapi["rrdatas"]
       end
 
       ##
-      # Convert the record object to a Google API hash.
-      def to_gapi #:nodoc:
+      # @private Convert the record object to a Google API hash.
+      def to_gapi
         { "name" => name, "type" => type, "ttl" => ttl, "rrdatas" => data }
       end
 
-      def hash #:nodoc:
+      # @private
+      def hash
         [name, type, ttl, data].hash
       end
 
-      def eql? other #:nodoc:
+      # @private
+      def eql? other
         return false unless other.is_a? self.class
         name == other.name && type == other.type &&
           ttl == other.ttl && data == other.data
       end
 
-      def == other #:nodoc:
+      # @private
+      def == other
         self.eql? other
       end
 
-      def <=> other #:nodoc:
+      # @private
+      def <=> other
         return nil unless other.is_a? self.class
         [name, type, ttl, data] <=>
           [other.name, other.type, other.ttl, other.data]

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/dns/record/list"
 

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -48,8 +48,8 @@ module Gcloud
       attr_accessor :name
 
       ##
-      # The identifier of a {supported record type
-      # }[https://cloud.google.com/dns/what-is-cloud-dns#supported_record_types]
+      # The identifier of a [supported record type
+      # ](https://cloud.google.com/dns/what-is-cloud-dns#supported_record_types)
       # . For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
       #
       # @return [String]
@@ -65,9 +65,9 @@ module Gcloud
 
       ##
       # The array of resource record data, as determined by +type+ and defined
-      # in {RFC 1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5]
-      # and {RFC
-      # 1034 (section 3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1].
+      # in [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
+      # and [RFC
+      # 1034 (section 3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1).
       # For example: ["10 mail.example.com.", "20 mail2.example.com."].
       #
       # @return [Array<String>]
@@ -79,16 +79,16 @@ module Gcloud
       #
       # @param [String] name The owner of the record. For example:
       #   +example.com.+.
-      # @param [String] type The identifier of a {supported record
-      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      # @param [String] type The identifier of a [supported record
+      #   type](https://cloud.google.com/dns/what-is-cloud-dns).
       #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
       # @param [Integer] ttl The number of seconds that the record can be cached
       #   by resolvers.
       # @param [String, Array<String>] data The resource record data, as
-      #   determined by +type+ and defined in {RFC
-      #   1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5] and
-      #   {RFC 1034
-      #   (section 3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1].
+      #   determined by +type+ and defined in [RFC
+      #   1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5) and
+      #   [RFC 1034
+      #   (section 3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1).
       #   For example: ["10 mail.example.com.", "20 mail2.example.com."].
       #
       def initialize name, type, ttl, data

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -24,7 +24,7 @@ module Gcloud
     # {#type} in a {Zone}. Since it is a value object, a newly created Record
     # instance is transient until it is added to a Zone with {Zone#update}. Note
     # that {Zone#add} and the {Zone#update} block parameter can be used instead
-    # of {Zone#record} or +Record.new+ to create new records.
+    # of {Zone#record} or `Record.new` to create new records.
     #
     # @example
     #   require "gcloud"
@@ -41,7 +41,7 @@ module Gcloud
     #
     class Record
       ##
-      # The owner of the record. For example: +example.com.+.
+      # The owner of the record. For example: `example.com.`.
       #
       # @return [String]
       #
@@ -50,7 +50,7 @@ module Gcloud
       ##
       # The identifier of a [supported record type
       # ](https://cloud.google.com/dns/what-is-cloud-dns#supported_record_types)
-      # . For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      # . For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
       #
       # @return [String]
       #
@@ -64,7 +64,7 @@ module Gcloud
       attr_accessor :ttl
 
       ##
-      # The array of resource record data, as determined by +type+ and defined
+      # The array of resource record data, as determined by `type` and defined
       # in [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
       # and [RFC
       # 1034 (section 3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1).
@@ -78,14 +78,14 @@ module Gcloud
       # Creates a Record value object.
       #
       # @param [String] name The owner of the record. For example:
-      #   +example.com.+.
+      #   `example.com.`.
       # @param [String] type The identifier of a [supported record
       #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
       # @param [Integer] ttl The number of seconds that the record can be cached
       #   by resolvers.
       # @param [String, Array<String>] data The resource record data, as
-      #   determined by +type+ and defined in [RFC
+      #   determined by `type` and defined in [RFC
       #   1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5) and
       #   [RFC 1034
       #   (section 3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1).

--- a/lib/gcloud/dns/record/list.rb
+++ b/lib/gcloud/dns/record/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/dns/record/list.rb
+++ b/lib/gcloud/dns/record/list.rb
@@ -47,11 +47,10 @@ module Gcloud
         end
 
         ##
-        # Retrieves all records by repeatedly loading pages until #next? returns
-        # false. Returns the list instance for method chaining.
+        # Retrieves all records by repeatedly loading pages until {#next?}
+        # returns false. Returns the list instance for method chaining.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -69,8 +68,8 @@ module Gcloud
         end
 
         ##
-        # New Records::List from a response object.
-        def self.from_response resp, zone #:nodoc:
+        # @private New Records::List from a response object.
+        def self.from_response resp, zone
           records = new(Array(resp.data["rrsets"]).map do |gapi_object|
             Record.from_gapi gapi_object
           end)

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -23,7 +23,7 @@ require "time"
 module Gcloud
   module Dns
     ##
-    # = DNS Zone
+    # # DNS Zone
     #
     # The managed zone is the container for DNS records for the same DNS name
     # suffix and has a set of name servers that accept and responds to queries.

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -274,8 +274,8 @@ module Gcloud
       #
       # @param [String] name Return only records with this domain or subdomain
       #   name.
-      # @param [String] type Return only records with this {record
-      #   type}[https://cloud.google.com/dns/what-is-cloud-dns]. If present, the
+      # @param [String] type Return only records with this [record
+      #   type](https://cloud.google.com/dns/what-is-cloud-dns). If present, the
       #   +name+ parameter must also be present.
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
@@ -360,8 +360,8 @@ module Gcloud
       alias_method :new_record, :record
 
       ##
-      # Exports the zone to a local {DNS zone
-      # file}[https://en.wikipedia.org/wiki/Zone_file].
+      # Exports the zone to a local [DNS zone
+      # file](https://en.wikipedia.org/wiki/Zone_file).
       #
       # @param [String] path The path on the local file system to write the data
       #   to.The path provided must be writable.
@@ -384,8 +384,8 @@ module Gcloud
       end
 
       ##
-      # Imports resource records from a {DNS zone
-      # file}[https://en.wikipedia.org/wiki/Zone_file], adding the new records
+      # Imports resource records from a [DNS zone
+      # file](https://en.wikipedia.org/wiki/Zone_file), adding the new records
       # to the zone, without removing any existing records from the zone.
       #
       # Because the Google Cloud DNS API only accepts a single resource record
@@ -447,7 +447,7 @@ module Gcloud
       # API request.
       #
       # The best way to add, remove, and update multiple records in a single
-      # {transaction}[https://cloud.google.com/dns/records] is with a block. See
+      # [transaction](https://cloud.google.com/dns/records) is with a block. See
       # {Zone::Transaction}.
       #
       # If the SOA record for the zone is not present in +additions+ or
@@ -543,16 +543,16 @@ module Gcloud
       #
       # @param [String] name The owner of the record. For example:
       #   +example.com.+.
-      # @param [String] type The identifier of a {supported record
-      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      # @param [String] type The identifier of a [supported record
+      #   type](https://cloud.google.com/dns/what-is-cloud-dns).
       #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
       # @param [Integer] ttl The number of seconds that the record can be cached
       #   by resolvers.
       # @param [String, Array<String>] data The resource record data, as
-      #   determined by +type+ and defined in {RFC
-      #   1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5] and
-      #   {RFC 1034
-      #   (section 3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1].
+      #   determined by +type+ and defined in [RFC
+      #   1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5) and
+      #   [RFC 1034
+      #   (section 3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1).
       #   For example: +192.0.2.1+ or +example.com.+.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
@@ -585,8 +585,8 @@ module Gcloud
       #
       # @param [String] name The owner of the record. For example:
       #   +example.com.+.
-      # @param [String] type The identifier of a {supported record
-      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      # @param [String] type The identifier of a [supported record
+      #   type](https://cloud.google.com/dns/what-is-cloud-dns).
       #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
@@ -619,16 +619,16 @@ module Gcloud
       #
       # @param [String] name The owner of the record. For example:
       #   +example.com.+.
-      # @param [String] type The identifier of a {supported record
-      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      # @param [String] type The identifier of a [supported record
+      #   type](https://cloud.google.com/dns/what-is-cloud-dns).
       #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
       # @param [Integer] ttl The number of seconds that the record can be cached
       #   by resolvers.
       # @param [String, Array<String>] data The resource record data, as
       #   determined by +type+ and defined in
-      #   {RFC 1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5]
-      #   and {RFC 1034 (section
-      #   3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1]. For
+      #   [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
+      #   and [RFC 1034 (section
+      #   3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1). For
       #   example: +192.0.2.1+ or +example.com.+.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
@@ -666,8 +666,8 @@ module Gcloud
       #
       # @param [String] name The owner of the record. For example:
       #   +example.com.+.
-      # @param [String] type The identifier of a {supported record
-      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+      # @param [String] type The identifier of a [supported record
+      #   type](https://cloud.google.com/dns/what-is-cloud-dns).
       #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
@@ -696,8 +696,8 @@ module Gcloud
 
       ##
       # This helper converts the given domain name or subdomain (e.g., +www+)
-      # fragment to a {fully qualified domain name
-      # (FQDN)}[https://en.wikipedia.org/wiki/Fully_qualified_domain_name] for
+      # fragment to a [fully qualified domain name
+      # (FQDN)](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) for
       # the zone's #dns. If the argument is already a FQDN, it is returned
       # unchanged.
       #

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -119,11 +119,11 @@ module Gcloud
       ##
       # Permanently deletes the zone.
       #
-      # @param [Boolean] force If +true+, ensures the deletion of the zone by
-      #   first deleting all records. If +false+ and the zone contains
-      #   non-essential records, the request will fail. Default is +false+.
+      # @param [Boolean] force If `true`, ensures the deletion of the zone by
+      #   first deleting all records. If `false` and the zone contains
+      #   non-essential records, the request will fail. Default is `false`.
       #
-      # @return [Boolean] Returns +true+ if the zone was deleted.
+      # @return [Boolean] Returns `true` if the zone was deleted.
       #
       # @example
       #   require "gcloud"
@@ -133,7 +133,7 @@ module Gcloud
       #   zone = dns.zone "example-com"
       #   zone.delete
       #
-      # @example The zone can be forcefully deleted with the +force+ option:
+      # @example The zone can be forcefully deleted with the `force` option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -176,7 +176,7 @@ module Gcloud
       #
       # @param [String] change_id The id of a change.
       #
-      # @return [Gcloud::Dns::Change, nil] Returns +nil+ if the change does not
+      # @return [Gcloud::Dns::Change, nil] Returns `nil` if the change does not
       #   exist.
       #
       # @example
@@ -211,8 +211,8 @@ module Gcloud
       # @param [Symbol, String] order Sort the changes by change sequence.
       #
       #   Acceptable values are:
-      #   * +asc+ - Sort by ascending change sequence
-      #   * +desc+ - Sort by descending change sequence
+      #   * `asc` - Sort by ascending change sequence
+      #   * `desc` - Sort by descending change sequence
       #
       # @return [Array<Gcloud::Dns::Change>] (See {Gcloud::Dns::Change::List})
       #
@@ -269,14 +269,14 @@ module Gcloud
       ##
       # Retrieves the list of records belonging to the zone.
       # Records can be filtered by name and type. The name argument can be a
-      # subdomain (e.g., +www+) fragment for convenience, but notice that the
+      # subdomain (e.g., `www`) fragment for convenience, but notice that the
       # retrieved record's domain name is always fully-qualified.
       #
       # @param [String] name Return only records with this domain or subdomain
       #   name.
       # @param [String] type Return only records with this [record
       #   type](https://cloud.google.com/dns/what-is-cloud-dns). If present, the
-      #   +name+ parameter must also be present.
+      #   `name` parameter must also be present.
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
       # @param [Integer] max Maximum number of records to return.
@@ -389,10 +389,10 @@ module Gcloud
       # to the zone, without removing any existing records from the zone.
       #
       # Because the Google Cloud DNS API only accepts a single resource record
-      # for each +name+ and +type+ combination (with multiple +data+ elements),
+      # for each `name` and `type` combination (with multiple `data` elements),
       # the zone file's records are merged as necessary. During this merge, the
-      # lowest +ttl+ of the merged records is used. If none of the merged
-      # records have a +ttl+ value, the zone file's global TTL is used for the
+      # lowest `ttl` of the merged records is used. If none of the merged
+      # records have a `ttl` value, the zone file's global TTL is used for the
       # record.
       #
       # The zone file's SOA and NS records are not imported, because the zone
@@ -400,7 +400,7 @@ module Gcloud
       # records point to Cloud DNS name servers.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See {#update} for details.
+      # prevented with the `skip_soa` option. See {#update} for details.
       #
       # The Google Cloud DNS service requires that record names and data use
       # fully-qualified addresses. The @ symbol is not accepted, nor are
@@ -450,12 +450,12 @@ module Gcloud
       # [transaction](https://cloud.google.com/dns/records) is with a block. See
       # {Zone::Transaction}.
       #
-      # If the SOA record for the zone is not present in +additions+ or
-      # +deletions+ (and if present in one, it should be present in the other),
+      # If the SOA record for the zone is not present in `additions` or
+      # `deletions` (and if present in one, it should be present in the other),
       # it will be added to both, and its serial number will be incremented by
-      # adding +1+. This update to the SOA record can be prevented with the
-      # +skip_soa+ option. To provide your own value or behavior for the new
-      # serial number, use the +soa_serial+ option.
+      # adding `1`. This update to the SOA record can be prevented with the
+      # `skip_soa` option. To provide your own value or behavior for the new
+      # serial number, use the `soa_serial` option.
       #
       # @param [Record, Array<Record>] additions The Record or array of records
       #   to add.
@@ -539,21 +539,21 @@ module Gcloud
       # and delete records in the same transaction, use #update.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See {#update} for details.
+      # prevented with the `skip_soa` option. See {#update} for details.
       #
       # @param [String] name The owner of the record. For example:
-      #   +example.com.+.
+      #   `example.com.`.
       # @param [String] type The identifier of a [supported record
       #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
       # @param [Integer] ttl The number of seconds that the record can be cached
       #   by resolvers.
       # @param [String, Array<String>] data The resource record data, as
-      #   determined by +type+ and defined in [RFC
+      #   determined by `type` and defined in [RFC
       #   1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5) and
       #   [RFC 1034
       #   (section 3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1).
-      #   For example: +192.0.2.1+ or +example.com.+.
+      #   For example: `192.0.2.1` or `example.com.`.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
       # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
@@ -581,13 +581,13 @@ module Gcloud
       # in the same transaction, use #update.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See {#update} for details.
+      # prevented with the `skip_soa` option. See {#update} for details.
       #
       # @param [String] name The owner of the record. For example:
-      #   +example.com.+.
+      #   `example.com.`.
       # @param [String] type The identifier of a [supported record
       #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
       # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
@@ -610,26 +610,26 @@ module Gcloud
       end
 
       ##
-      # Replaces existing records on the Zone. Records matching the +name+ and
-      # +type+ are replaced. In order to update existing records, or add and
+      # Replaces existing records on the Zone. Records matching the `name` and
+      # `type` are replaced. In order to update existing records, or add and
       # delete records in the same transaction, use #update.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See {#update} for details.
+      # prevented with the `skip_soa` option. See {#update} for details.
       #
       # @param [String] name The owner of the record. For example:
-      #   +example.com.+.
+      #   `example.com.`.
       # @param [String] type The identifier of a [supported record
       #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
       # @param [Integer] ttl The number of seconds that the record can be cached
       #   by resolvers.
       # @param [String, Array<String>] data The resource record data, as
-      #   determined by +type+ and defined in
+      #   determined by `type` and defined in
       #   [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
       #   and [RFC 1034 (section
       #   3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1). For
-      #   example: +192.0.2.1+ or +example.com.+.
+      #   example: `192.0.2.1` or `example.com.`.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
       # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
@@ -658,17 +658,17 @@ module Gcloud
       end
 
       ##
-      # Modifies records on the Zone. Records matching the +name+ and +type+ are
+      # Modifies records on the Zone. Records matching the `name` and `type` are
       # yielded to the block where they can be modified.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See {#update} for details.
+      # prevented with the `skip_soa` option. See {#update} for details.
       #
       # @param [String] name The owner of the record. For example:
-      #   +example.com.+.
+      #   `example.com.`.
       # @param [String] type The identifier of a [supported record
       #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
       # @param [Boolean] skip_soa Do not automatically update the SOA record
       #   serial number. See {#update} for details.
       # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
@@ -695,7 +695,7 @@ module Gcloud
       end
 
       ##
-      # This helper converts the given domain name or subdomain (e.g., +www+)
+      # This helper converts the given domain name or subdomain (e.g., `www`)
       # fragment to a [fully qualified domain name
       # (FQDN)](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) for
       # the zone's #dns. If the argument is already a FQDN, it is returned

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -30,6 +30,7 @@ module Gcloud
     # A project can have multiple managed zones, but they must each have a
     # unique name.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -39,21 +40,20 @@ module Gcloud
     #     puts record.name
     #   end
     #
-    # For more information, see {Managing
-    # Zones}[https://cloud.google.com/dns/zones/].
+    # @see https://cloud.google.com/dns/zones/ Managing Zones
     #
     class Zone
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Zone object.
-      def initialize #:nodoc:
+      # @private Create an empty Zone object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -119,19 +119,13 @@ module Gcloud
       ##
       # Permanently deletes the zone.
       #
-      # === Parameters
+      # @param [Boolean] force If +true+, ensures the deletion of the zone by
+      #   first deleting all records. If +false+ and the zone contains
+      #   non-essential records, the request will fail. Default is +false+.
       #
-      # +force+::
-      #   If +true+, ensures the deletion of the zone by first deleting all
-      #   records. If +false+ and the zone contains non-essential records, the
-      #   request will fail. Default is +false+. (+Boolean+)
+      # @return [Boolean] Returns +true+ if the zone was deleted.
       #
-      # === Returns
-      #
-      # +true+ if the zone was deleted.
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -139,8 +133,7 @@ module Gcloud
       #   zone = dns.zone "example-com"
       #   zone.delete
       #
-      # The zone can be forcefully deleted with the +force+ option:
-      #
+      # @example The zone can be forcefully deleted with the +force+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -164,8 +157,7 @@ module Gcloud
       # Removes non-essential records from the zone. Only NS and SOA records
       # will be kept.
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -182,17 +174,12 @@ module Gcloud
       ##
       # Retrieves an existing change by id.
       #
-      # === Parameters
+      # @param [String] change_id The id of a change.
       #
-      # +change_id+::
-      #   The id of a change. (+String+)
+      # @return [Gcloud::Dns::Change, nil] Returns +nil+ if the change does not
+      #   exist.
       #
-      # === Returns
-      #
-      # Gcloud::Dns::Change or +nil+ if the change does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -218,26 +205,18 @@ module Gcloud
       ##
       # Retrieves the list of changes belonging to the zone.
       #
-      # === Parameters
-      #
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of changes to return. (+Integer+)
-      # +order+::
-      #   Sort the changes by change sequence. (+Symbol+ or +String+)
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of changes to return.
+      # @param [Symbol, String] order Sort the changes by change sequence.
       #
       #   Acceptable values are:
       #   * +asc+ - Sort by ascending change sequence
       #   * +desc+ - Sort by descending change sequence
       #
-      # === Returns
+      # @return [Array<Gcloud::Dns::Change>] (See {Gcloud::Dns::Change::List})
       #
-      # Array of Gcloud::Dns::Change (See Gcloud::Dns::Change::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -248,8 +227,7 @@ module Gcloud
       #     puts "#{change.id} - #{change.started_at} - #{change.status}"
       #   end
       #
-      # The changes can be sorted by change sequence:
-      #
+      # @example The changes can be sorted by change sequence:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -257,9 +235,7 @@ module Gcloud
       #   zone = dns.zone "example-com"
       #   changes = zone.changes order: :desc
       #
-      # If you have a significant number of changes, you may need to paginate
-      # through them: (See Gcloud::Dns::Change::List)
-      #
+      # @example With pagination: (See {Gcloud::Dns::Change::List})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -292,27 +268,22 @@ module Gcloud
 
       ##
       # Retrieves the list of records belonging to the zone.
+      # Records can be filtered by name and type. The name argument can be a
+      # subdomain (e.g., +www+) fragment for convenience, but notice that the
+      # retrieved record's domain name is always fully-qualified.
       #
-      # === Parameters
+      # @param [String] name Return only records with this domain or subdomain
+      #   name.
+      # @param [String] type Return only records with this {record
+      #   type}[https://cloud.google.com/dns/what-is-cloud-dns]. If present, the
+      #   +name+ parameter must also be present.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of records to return.
       #
-      # +name+::
-      #   Return only records with this domain or subdomain name. (+String+)
-      # +type+::
-      #   Return only records with this {record
-      #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-      #   If present, the +name+ parameter must also be present. (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of records to return. (+Integer+)
+      # @return [Array<Gcloud::Dns::Record>] (See {Gcloud::Dns::Record::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Dns::Record (See Gcloud::Dns::Record::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -323,10 +294,7 @@ module Gcloud
       #     puts record.name
       #   end
       #
-      # Records can be filtered by name and type. The name argument can be a
-      # subdomain (e.g., +www+) fragment for convenience, but notice that the
-      # retrieved record's domain name is always fully-qualified.
-      #
+      # @example Records can be filtered by name and type:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -335,9 +303,7 @@ module Gcloud
       #   records = zone.records "www", "A"
       #   records.first.name #=> "www.example.com."
       #
-      # If you have a significant number of records, you may need to paginate
-      # through them: (See Gcloud::Dns::Record::List)
-      #
+      # @example With pagination: (See {Gcloud::Dns::Record::List})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -352,9 +318,7 @@ module Gcloud
       #     records = records.next
       #   end
       #
-      # Or, instead of paging manually, you can retrieve all of the pages in a
-      # single call: (See Gcloud::Dns::Record::List#all)
-      #
+      # @example Retrieve all pages: (See {Gcloud::Dns::Record::List#all})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -379,12 +343,9 @@ module Gcloud
       ##
       # Creates a new, unsaved Record that can be added to a Zone.
       #
-      # === Returns
+      # @return [Gcloud::Dns::Record]
       #
-      # Gcloud::Dns::Record
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -402,18 +363,12 @@ module Gcloud
       # Exports the zone to a local {DNS zone
       # file}[https://en.wikipedia.org/wiki/Zone_file].
       #
-      # === Parameters
+      # @param [String] path The path on the local file system to write the data
+      #   to.The path provided must be writable.
       #
-      # +path+::
-      #   The path on the local file system to write the data to.
-      #   The path provided must be writable. (+String+)
+      # @return [File] An object on the local file system.
       #
-      # === Returns
-      #
-      # +::File+ object on the local file system
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -445,7 +400,7 @@ module Gcloud
       # records point to Cloud DNS name servers.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See #update for details.
+      # prevented with the +skip_soa+ option. See {#update} for details.
       #
       # The Google Cloud DNS service requires that record names and data use
       # fully-qualified addresses. The @ symbol is not accepted, nor are
@@ -453,28 +408,22 @@ module Gcloud
       # such values, you may need to pre-process it in order for the import
       # operation to succeed.
       #
-      # === Parameters
+      # @param [String, IO] path_or_io The path to a zone file on the
+      #   filesystem, or an IO instance from which zone file data can be read.
+      # @param [String, Array<String>] only Include only records of this type or
+      #   types.
+      # @param [String, Array<String>] except Exclude records of this type or
+      #   types.
+      # @param [Boolean] skip_soa Do not automatically update the SOA record
+      #   serial number. See {#update} for details.
+      # @param [Integer, lambda, Proc] soa_serial A value (or a lambda or Proc
+      #   returning a value) for the new SOA record serial number. See {#update}
+      #   for details.
       #
-      # +path_or_io+::
-      #   The path to a zone file on the filesystem, or an IO instance from
-      #   which zone file data can be read. (+String+ or +IO+)
-      # +only+::
-      #   Include only records of this type or types. (+String+ or +Array+)
-      # +except+::
-      #   Exclude records of this type or types. (+String+ or +Array+)
-      # +skip_soa+::
-      #   Do not automatically update the SOA record serial number. See #update
-      #   for details. (+Boolean+)
-      # +soa_serial+::
-      #   A value (or a lambda or Proc returning a value) for the new SOA record
-      #   serial number. See #update for details. (+Integer+, lambda, or +Proc+)
+      # @return [Gcloud::Dns::Change] A new change adding the imported Record
+      #   instances.
       #
-      # === Returns
-      #
-      # A new Change adding the imported Record instances.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -497,6 +446,10 @@ module Gcloud
       # Adds and removes Records from the zone. All changes are made in a single
       # API request.
       #
+      # The best way to add, remove, and update multiple records in a single
+      # {transaction}[https://cloud.google.com/dns/records] is with a block. See
+      # {Zone::Transaction}.
+      #
       # If the SOA record for the zone is not present in +additions+ or
       # +deletions+ (and if present in one, it should be present in the other),
       # it will be added to both, and its serial number will be incremented by
@@ -504,28 +457,18 @@ module Gcloud
       # +skip_soa+ option. To provide your own value or behavior for the new
       # serial number, use the +soa_serial+ option.
       #
-      # === Parameters
+      # @param [Record, Array<Record>] additions The Record or array of records
+      #   to add.
+      # @param [Record, Array<Record>] deletions The Record or array of records
+      #   to remove.
+      # @param [Boolean] skip_soa Do not automatically update the SOA record
+      #   serial number.
+      # @param [Integer, lambda, Proc] soa_serial A value (or a lambda or Proc
+      #   returning a value) for the new SOA record serial number.
       #
-      # +additions+::
-      #   The Record or array of records to add. (Record or +Array+)
-      # +deletions+::
-      #   The Record or array of records to remove. (Record or +Array+)
-      # +skip_soa+::
-      #   Do not automatically update the SOA record serial number. (+Boolean+)
-      # +soa_serial+::
-      #   A value (or a lambda or Proc returning a value) for the new SOA record
-      #   serial number. (+Integer+, lambda, or +Proc+)
+      # @return [Gcloud::Dns::Change]
       #
-      # === Returns
-      #
-      # Gcloud::Dns::Change
-      #
-      # === Examples
-      #
-      # The best way to add, remove, and update multiple records in a single
-      # {transaction}[https://cloud.google.com/dns/records] is with a block. See
-      # Zone::Transaction.
-      #
+      # @example Using a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -541,8 +484,7 @@ module Gcloud
       #     end
       #   end
       #
-      # Or you can provide the record objects to add and remove.
-      #
+      # @example Or you can provide the record objects to add and remove:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -552,9 +494,7 @@ module Gcloud
       #   old_record = zone.record "example.com.", "A", 18600, ["1.2.3.4"]
       #   change = zone.update [new_record], [old_record]
       #
-      # You can provide a lambda or Proc that receives the current SOA record
-      # serial number and returns a new serial number.
-      #
+      # @example Using a lambda or Proc to update the current SOA serial number:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -599,39 +539,30 @@ module Gcloud
       # and delete records in the same transaction, use #update.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See #update for details.
+      # prevented with the +skip_soa+ option. See {#update} for details.
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The owner of the record. For example: +example.com.+. (+String+)
-      # +type+::
-      #   The identifier of a {supported record
+      # @param [String] name The owner of the record. For example:
+      #   +example.com.+.
+      # @param [String] type The identifier of a {supported record
       #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
-      # +ttl+::
-      #   The number of seconds that the record can be cached by resolvers.
-      #   (+Integer+)
-      # +data+::
-      #   The resource record data, as determined by +type+ and defined in {RFC
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      # @param [Integer] ttl The number of seconds that the record can be cached
+      #   by resolvers.
+      # @param [String, Array<String>] data The resource record data, as
+      #   determined by +type+ and defined in {RFC
       #   1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5] and
       #   {RFC 1034
       #   (section 3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1].
-      #   For example: +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of
-      #   +String+)
-      # +skip_soa+::
-      #   Do not automatically update the SOA record serial number. See #update
-      #   for details. (+Boolean+)
-      # +soa_serial+::
-      #   A value (or a lambda or Proc returning a value) for the new SOA record
-      #   serial number. See #update for details. (+Integer+, lambda, or +Proc+)
+      #   For example: +192.0.2.1+ or +example.com.+.
+      # @param [Boolean] skip_soa Do not automatically update the SOA record
+      #   serial number. See {#update} for details.
+      # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
+      #   returning a value) for the new SOA record serial number. See {#update}
+      #   for details.
       #
-      # === Returns
+      # @return [Gcloud::Dns::Change]
       #
-      # Gcloud::Dns::Change
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -650,29 +581,22 @@ module Gcloud
       # in the same transaction, use #update.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See #update for details.
+      # prevented with the +skip_soa+ option. See {#update} for details.
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The owner of the record. For example: +example.com.+. (+String+)
-      # +type+::
-      #   The identifier of a {supported record
+      # @param [String] name The owner of the record. For example:
+      #   +example.com.+.
+      # @param [String] type The identifier of a {supported record
       #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
-      # +skip_soa+::
-      #   Do not automatically update the SOA record serial number. See #update
-      #   for details. (+Boolean+)
-      # +soa_serial+::
-      #   A value (or a lambda or Proc returning a value) for the new SOA record
-      #   serial number. See #update for details. (+Integer+, lambda, or +Proc+)
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      # @param [Boolean] skip_soa Do not automatically update the SOA record
+      #   serial number. See {#update} for details.
+      # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
+      #   returning a value) for the new SOA record serial number. See {#update}
+      #   for details.
       #
-      # === Returns
+      # @return [Gcloud::Dns::Change]
       #
-      # Gcloud::Dns::Change
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -691,39 +615,30 @@ module Gcloud
       # delete records in the same transaction, use #update.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See #update for details.
+      # prevented with the +skip_soa+ option. See {#update} for details.
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The owner of the record. For example: +example.com.+. (+String+)
-      # +type+::
-      #   The identifier of a {supported record
+      # @param [String] name The owner of the record. For example:
+      #   +example.com.+.
+      # @param [String] type The identifier of a {supported record
       #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
-      # +ttl+::
-      #   The number of seconds that the record can be cached by resolvers.
-      #   (+Integer+)
-      # +data+::
-      #   The resource record data, as determined by +type+ and defined in
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      # @param [Integer] ttl The number of seconds that the record can be cached
+      #   by resolvers.
+      # @param [String, Array<String>] data The resource record data, as
+      #   determined by +type+ and defined in
       #   {RFC 1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5]
       #   and {RFC 1034 (section
       #   3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1]. For
-      #   example: +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of
-      #   +String+)
-      # +skip_soa+::
-      #   Do not automatically update the SOA record serial number. See #update
-      #   for details. (+Boolean+)
-      # +soa_serial+::
-      #   A value (or a lambda or Proc returning a value) for the new SOA record
-      #   serial number. See #update for details. (+Integer+, lambda, or +Proc+)
+      #   example: +192.0.2.1+ or +example.com.+.
+      # @param [Boolean] skip_soa Do not automatically update the SOA record
+      #   serial number. See {#update} for details.
+      # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
+      #   returning a value) for the new SOA record serial number. See {#update}
+      #   for details.
       #
-      # === Returns
+      # @return [Gcloud::Dns::Change]
       #
-      # Gcloud::Dns::Change
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -737,7 +652,8 @@ module Gcloud
                skip_soa: skip_soa, soa_serial: soa_serial
       end
 
-      def to_zonefile #:nodoc:
+      # @private
+      def to_zonefile
         records.all.map(&:to_zonefile_records).flatten.join("\n")
       end
 
@@ -746,29 +662,22 @@ module Gcloud
       # yielded to the block where they can be modified.
       #
       # This operation automatically updates the SOA record serial number unless
-      # prevented with the +skip_soa+ option. See #update for details.
+      # prevented with the +skip_soa+ option. See {#update} for details.
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The owner of the record. For example: +example.com.+. (+String+)
-      # +type+::
-      #   The identifier of a {supported record
+      # @param [String] name The owner of the record. For example:
+      #   +example.com.+.
+      # @param [String] type The identifier of a {supported record
       #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
-      # +skip_soa+::
-      #   Do not automatically update the SOA record serial number. See #update
-      #   for details. (+Boolean+)
-      # +soa_serial+::
-      #   A value (or a lambda or Proc returning a value) for the new SOA record
-      #   serial number. See #update for details. (+Integer+, lambda, or +Proc+)
+      #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+      # @param [Boolean] skip_soa Do not automatically update the SOA record
+      #   serial number. See {#update} for details.
+      # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
+      #   returning a value) for the new SOA record serial number. See {#update}
+      #   for details.
       #
-      # === Returns
+      # @return [Gcloud::Dns::Change]
       #
-      # Gcloud::Dns::Change
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -792,17 +701,12 @@ module Gcloud
       # the zone's #dns. If the argument is already a FQDN, it is returned
       # unchanged.
       #
-      # === Parameters
+      # @param [String] domain_name The name to convert to a fully qualified
+      #   domain name.
       #
-      # +domain_name+::
-      #   The name to convert to a fully qualified domain name. (+String+)
+      # @return [String] A fully qualified domain name.
       #
-      # === Returns
-      #
-      # A fully qualified domain name. (+String+)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -817,8 +721,8 @@ module Gcloud
       end
 
       ##
-      # New Zone from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Zone from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/dns/change"
 require "gcloud/dns/zone/transaction"

--- a/lib/gcloud/dns/zone/list.rb
+++ b/lib/gcloud/dns/zone/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/dns/zone/list.rb
+++ b/lib/gcloud/dns/zone/list.rb
@@ -52,8 +52,8 @@ module Gcloud
         end
 
         ##
-        # New Zones::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Zones::List from a response object.
+        def self.from_response resp, conn
           zones = new(Array(resp.data["managedZones"]).map do |gapi_object|
             Zone.from_gapi gapi_object, conn
           end)

--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -56,16 +56,16 @@ module Gcloud
         #
         # @param [String] name The owner of the record. For example:
         #   +example.com.+.
-        # @param [String] type The identifier of a {supported record
-        #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+        # @param [String] type The identifier of a [supported record
+        #   type](https://cloud.google.com/dns/what-is-cloud-dns).
         #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
         # @param [Integer] ttl The number of seconds that the record can be
         #   cached by resolvers.
         # @param [String, Array<String>] data The resource record data, as
         #   determined by +type+ and defined in
-        #   {RFC 1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5]
-        #   and {RFC 1034 (section
-        #   3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1]. For
+        #   [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
+        #   and [RFC 1034 (section
+        #   3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1). For
         #   example: +192.0.2.1+ or +example.com.+.
         #
         # @example
@@ -88,8 +88,8 @@ module Gcloud
         #
         # @param [String] name The owner of the record. For example:
         #   +example.com.+.
-        # @param [String] type The identifier of a {supported record
-        #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+        # @param [String] type The identifier of a [supported record
+        #   type](https://cloud.google.com/dns/what-is-cloud-dns).
         #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
         #
         # @example
@@ -112,16 +112,16 @@ module Gcloud
         #
         # @param [String] name The owner of the record. For example:
         #   +example.com.+.
-        # @param [String] type The identifier of a {supported record
-        #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+        # @param [String] type The identifier of a [supported record
+        #   type](https://cloud.google.com/dns/what-is-cloud-dns).
         #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
         # @param [Integer] ttl The number of seconds that the record can be
         #   cached by resolvers.
         # @param [String, Array<String>] data The resource record data, as
         #   determined by +type+ and defined in
-        #   {RFC 1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5]
-        #   and {RFC 1034 (section
-        #   3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1]. For
+        #   [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
+        #   and [RFC 1034 (section
+        #   3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1). For
         #   example: +192.0.2.1+ or +example.com.+.
         #
         # @example
@@ -146,8 +146,8 @@ module Gcloud
         #
         # @param [String] name The owner of the record. For example:
         #   +example.com.+.
-        # @param [String] type The identifier of a {supported record
-        #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
+        # @param [String] type The identifier of a [supported record
+        #   type](https://cloud.google.com/dns/what-is-cloud-dns).
         #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
         #
         # @example

--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -55,18 +55,18 @@ module Gcloud
         # Adds a record to the Zone.
         #
         # @param [String] name The owner of the record. For example:
-        #   +example.com.+.
+        #   `example.com.`.
         # @param [String] type The identifier of a [supported record
         #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+        #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
         # @param [Integer] ttl The number of seconds that the record can be
         #   cached by resolvers.
         # @param [String, Array<String>] data The resource record data, as
-        #   determined by +type+ and defined in
+        #   determined by `type` and defined in
         #   [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
         #   and [RFC 1034 (section
         #   3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1). For
-        #   example: +192.0.2.1+ or +example.com.+.
+        #   example: `192.0.2.1` or `example.com.`.
         #
         # @example
         #   require "gcloud"
@@ -87,10 +87,10 @@ module Gcloud
         # are removed.
         #
         # @param [String] name The owner of the record. For example:
-        #   +example.com.+.
+        #   `example.com.`.
         # @param [String] type The identifier of a [supported record
         #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+        #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
         #
         # @example
         #   require "gcloud"
@@ -107,22 +107,22 @@ module Gcloud
         end
 
         ##
-        # Replaces existing records on the Zone. Records matching the +name+ and
-        # +type+ are replaced.
+        # Replaces existing records on the Zone. Records matching the `name` and
+        # `type` are replaced.
         #
         # @param [String] name The owner of the record. For example:
-        #   +example.com.+.
+        #   `example.com.`.
         # @param [String] type The identifier of a [supported record
         #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+        #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
         # @param [Integer] ttl The number of seconds that the record can be
         #   cached by resolvers.
         # @param [String, Array<String>] data The resource record data, as
-        #   determined by +type+ and defined in
+        #   determined by `type` and defined in
         #   [RFC 1035 (section 5)](http://tools.ietf.org/html/rfc1035#section-5)
         #   and [RFC 1034 (section
         #   3.6.1)](http://tools.ietf.org/html/rfc1034#section-3.6.1). For
-        #   example: +192.0.2.1+ or +example.com.+.
+        #   example: `192.0.2.1` or `example.com.`.
         #
         # @example
         #   require "gcloud"
@@ -141,14 +141,14 @@ module Gcloud
         end
 
         ##
-        # Modifies records on the Zone. Records matching the +name+ and +type+
+        # Modifies records on the Zone. Records matching the `name` and `type`
         # are yielded to the block where they can be modified.
         #
         # @param [String] name The owner of the record. For example:
-        #   +example.com.+.
+        #   `example.com.`.
         # @param [String] type The identifier of a [supported record
         #   type](https://cloud.google.com/dns/what-is-cloud-dns).
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+        #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
         #
         # @example
         #   require "gcloud"

--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Dns

--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -17,7 +17,7 @@ module Gcloud
   module Dns
     class Zone
       ##
-      # = DNS Zone Transaction
+      # # DNS Zone Transaction
       #
       # This object is used by {Zone#update} when passed a block. These methods
       # are used to update the records that are sent to the Google Cloud DNS

--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -19,10 +19,11 @@ module Gcloud
       ##
       # = DNS Zone Transaction
       #
-      # This object is used by Zone#update when passed a block. These methods
+      # This object is used by {Zone#update} when passed a block. These methods
       # are used to update the records that are sent to the Google Cloud DNS
       # API.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -39,11 +40,12 @@ module Gcloud
       #   end
       #
       class Transaction
-        attr_reader :additions, :deletions #:nodoc:
+        # @private
+        attr_reader :additions, :deletions
 
         ##
-        # Creates a new transaction.
-        def initialize zone #:nodoc:
+        # @private Creates a new transaction.
+        def initialize zone
           @zone = zone
           @additions = []
           @deletions = []
@@ -52,27 +54,21 @@ module Gcloud
         ##
         # Adds a record to the Zone.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The owner of the record. For example: +example.com.+. (+String+)
-        # +type+::
-        #   The identifier of a {supported record
+        # @param [String] name The owner of the record. For example:
+        #   +example.com.+.
+        # @param [String] type The identifier of a {supported record
         #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
-        # +ttl+::
-        #   The number of seconds that the record can be cached by resolvers.
-        #   (+Integer+)
-        # +data+::
-        #   The resource record data, as determined by +type+ and defined in
+        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+        # @param [Integer] ttl The number of seconds that the record can be
+        #   cached by resolvers.
+        # @param [String, Array<String>] data The resource record data, as
+        #   determined by +type+ and defined in
         #   {RFC 1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5]
         #   and {RFC 1034 (section
         #   3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1]. For
-        #   example: +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of
-        #   +String+)
+        #   example: +192.0.2.1+ or +example.com.+.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -90,17 +86,13 @@ module Gcloud
         # Removes records from the Zone. The records are looked up before they
         # are removed.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The owner of the record. For example: +example.com.+. (+String+)
-        # +type+::
-        #   The identifier of a {supported record
+        # @param [String] name The owner of the record. For example:
+        #   +example.com.+.
+        # @param [String] type The identifier of a {supported record
         #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -118,27 +110,21 @@ module Gcloud
         # Replaces existing records on the Zone. Records matching the +name+ and
         # +type+ are replaced.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The owner of the record. For example: +example.com.+. (+String+)
-        # +type+::
-        #   The identifier of a {supported record
+        # @param [String] name The owner of the record. For example:
+        #   +example.com.+.
+        # @param [String] type The identifier of a {supported record
         #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
-        # +ttl+::
-        #   The number of seconds that the record can be cached by resolvers.
-        #   (+Integer+)
-        # +data+::
-        #   The resource record data, as determined by +type+ and defined in
+        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
+        # @param [Integer] ttl The number of seconds that the record can be
+        #   cached by resolvers.
+        # @param [String, Array<String>] data The resource record data, as
+        #   determined by +type+ and defined in
         #   {RFC 1035 (section 5)}[http://tools.ietf.org/html/rfc1035#section-5]
         #   and {RFC 1034 (section
         #   3.6.1)}[http://tools.ietf.org/html/rfc1034#section-3.6.1]. For
-        #   example: +192.0.2.1+ or +example.com.+. (+String+ or +Array+ of
-        #   +String+)
+        #   example: +192.0.2.1+ or +example.com.+.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -158,17 +144,13 @@ module Gcloud
         # Modifies records on the Zone. Records matching the +name+ and +type+
         # are yielded to the block where they can be modified.
         #
-        # === Parameters
-        #
-        # +name+::
-        #   The owner of the record. For example: +example.com.+. (+String+)
-        # +type+::
-        #   The identifier of a {supported record
+        # @param [String] name The owner of the record. For example:
+        #   +example.com.+.
+        # @param [String] type The identifier of a {supported record
         #   type}[https://cloud.google.com/dns/what-is-cloud-dns].
-        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+. (+String+)
+        #   For example: +A+, +AAAA+, +CNAME+, +MX+, or +TXT+.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/errors.rb
+++ b/lib/gcloud/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#--
-# Google Cloud Errors
+
 module Gcloud
   ##
   # Base Gcloud exception class.

--- a/lib/gcloud/gce.rb
+++ b/lib/gcloud/gce.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "faraday"
 
-#--
-# Google Cloud Compute Engine
 module Gcloud
   ##
   # Represents the Google Compute Engine environment.

--- a/lib/gcloud/gce.rb
+++ b/lib/gcloud/gce.rb
@@ -17,8 +17,9 @@ require "faraday"
 
 module Gcloud
   ##
+  # @private
   # Represents the Google Compute Engine environment.
-  module GCE #:nodoc:
+  module GCE
     CHECK_URI = "http://169.254.169.254"
     PROJECT_URI = "#{CHECK_URI}/computeMetadata/v1/project/project-id"
 

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 require "gcloud/pubsub/project"
 
-#--
-# Google Cloud Pub/Sub
 module Gcloud
   ##
   # Creates a new object for connecting to the Pub/Sub service.

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -25,21 +25,21 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +project+::
+  # `project`::
   #   Project identifier for the Pub/Sub service you are connecting to.
-  #   (+String+)
-  # +keyfile+::
+  #   (`String`)
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
-  # +scope+::
+  #   readable. (`String` or `Hash`)
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/pubsub+
+  #   * `https://www.googleapis.com/auth/pubsub`
   #
   # ### Returns
   #
@@ -305,7 +305,7 @@ module Gcloud
   #
   # ## Listening for Messages
   #
-  # Long running workers are easy to create with +listen+, which runs an
+  # Long running workers are easy to create with `listen`, which runs an
   # infinitely blocking loop to process messages as they are received. (See
   # Subscription#listen)
   #
@@ -320,7 +320,7 @@ module Gcloud
   #   end
   #
   # Messages are retrieved in batches for efficiency. The number of messages
-  # pulled per batch can be limited with the +max+ option:
+  # pulled per batch can be limited with the `max` option:
   #
   #   require "gcloud"
   #
@@ -334,7 +334,7 @@ module Gcloud
   #
   # When processing time and the acknowledgement deadline are a concern,
   # messages can be automatically acknowledged as they are pulled with the
-  # +autoack+ option:
+  # `autoack` option:
   #
   #   require "gcloud"
   #
@@ -351,7 +351,7 @@ module Gcloud
   # All calls to the Pub/Sub service use the same project and credentials
   # provided to the Gcloud#pubsub method. However, it is common to reference
   # topics or subscriptions in other projects, which can be achieved by using
-  # the +project+ option. The main credentials must have permissions to the
+  # the `project` option. The main credentials must have permissions to the
   # topics and subscriptions in other projects.
   #
   #   require "gcloud"

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Project identifier for the Pub/Sub service you are connecting to.
-  #   (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Project identifier for the Pub/Sub service you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/pubsub`
   #
-  # ### Returns
+  # @return [Gcloud::Pubsub::Project]
   #
-  # Gcloud::Pubsub::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/pubsub"
   #
   #   pubsub = Gcloud.pubsub

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -23,7 +23,7 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +project+::
   #   Project identifier for the Pub/Sub service you are connecting to.
@@ -41,11 +41,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/pubsub+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Pubsub::Project
   #
-  # === Example
+  # ### Example
   #
   #   require "gcloud/pubsub"
   #
@@ -65,7 +65,7 @@ module Gcloud
   end
 
   ##
-  # = Google Cloud Pub/Sub
+  # # Google Cloud Pub/Sub
   #
   # Google Cloud Pub/Sub is designed to provide reliable, many-to-many,
   # asynchronous messaging between applications. Publisher applications can
@@ -91,7 +91,7 @@ module Gcloud
   # To learn more about Pub/Sub, read the {Google Cloud Pub/Sub Overview
   # }[https://cloud.google.com/pubsub/overview].
   #
-  # == Retrieving Topics
+  # ## Retrieving Topics
   #
   # A Topic is a named resource to which messages are sent by publishers.
   # A Topic is found by its name. (See Project#topic)
@@ -102,7 +102,7 @@ module Gcloud
   #   pubsub = gcloud.pubsub
   #   topic = pubsub.topic "my-topic"
   #
-  # == Creating a Topic
+  # ## Creating a Topic
   #
   # A Topic is created from a Project. (See Project#create_topic)
   #
@@ -112,7 +112,7 @@ module Gcloud
   #   pubsub = gcloud.pubsub
   #   topic = pubsub.create_topic "my-topic"
   #
-  # == Retrieving Subscriptions
+  # ## Retrieving Subscriptions
   #
   # A Subscription is a named resource representing the stream of messages from
   # a single, specific Topic, to be delivered to the subscribing application.
@@ -127,7 +127,7 @@ module Gcloud
   #   subscription = topic.subscription "my-topic-subscription"
   #   puts subscription.name
   #
-  # == Creating a Subscription
+  # ## Creating a Subscription
   #
   # A Subscription is created from a Topic. (See Topic#subscribe and
   # Project#subscribe)
@@ -154,7 +154,7 @@ module Gcloud
   #                         deadline: 120,
   #                         endpoint: "https://example.com/push"
   #
-  # == Publishing Messages
+  # ## Publishing Messages
   #
   # Messages are published to a topic. Any message published to a topic without
   # a subscription will be lost. Ensure the topic has a subscription before
@@ -194,7 +194,7 @@ module Gcloud
   #     batch.publish "new-message-3", foo: :bif
   #   end
   #
-  # == Pulling Messages
+  # ## Pulling Messages
   #
   # Messages are pulled from a Subscription. (See Subscription#pull)
   #
@@ -227,7 +227,7 @@ module Gcloud
   #   sub = pubsub.subscription "my-topic-sub"
   #   msgs = sub.wait_for_messages
   #
-  # == Acknowledging a Message
+  # ## Acknowledging a Message
   #
   # Messages that are received can be acknowledged in Pub/Sub, marking the
   # message to be removed so it cannot be pulled again.
@@ -256,7 +256,7 @@ module Gcloud
   #   received_messages = sub.pull
   #   sub.acknowledge received_messages
   #
-  # == Modifying a Deadline
+  # ## Modifying a Deadline
   #
   # A message must be acknowledged after it is pulled, or Pub/Sub will mark the
   # message for redelivery. The message acknowledgement deadline can delayed if
@@ -303,7 +303,7 @@ module Gcloud
   #   received_messages = sub.pull
   #   sub.delay 120, received_messages
   #
-  # == Listening for Messages
+  # ## Listening for Messages
   #
   # Long running workers are easy to create with +listen+, which runs an
   # infinitely blocking loop to process messages as they are received. (See
@@ -346,7 +346,7 @@ module Gcloud
   #     # process msg
   #   end
   #
-  # == Working Across Projects
+  # ## Working Across Projects
   #
   # All calls to the Pub/Sub service use the same project and credentials
   # provided to the Gcloud#pubsub method. However, it is common to reference

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -33,8 +33,8 @@ module Gcloud
   #   readable. (+String+ or +Hash+)
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -88,8 +88,8 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  # To learn more about Pub/Sub, read the {Google Cloud Pub/Sub Overview
-  # }[https://cloud.google.com/pubsub/overview].
+  # To learn more about Pub/Sub, read the [Google Cloud Pub/Sub Overview
+  # ](https://cloud.google.com/pubsub/overview).
   #
   # ## Retrieving Topics
   #

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -80,13 +80,15 @@ module Gcloud
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   topic = pubsub.topic "my-topic"
-  #   topic.publish "task completed"
+  # topic = pubsub.topic "my-topic"
+  # topic.publish "task completed"
+  # ```
   #
   # To learn more about Pub/Sub, read the [Google Cloud Pub/Sub Overview
   # ](https://cloud.google.com/pubsub/overview).
@@ -96,21 +98,25 @@ module Gcloud
   # A Topic is a named resource to which messages are sent by publishers.
   # A Topic is found by its name. (See Project#topic)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
-  #   topic = pubsub.topic "my-topic"
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
+  # topic = pubsub.topic "my-topic"
+  # ```
   #
   # ## Creating a Topic
   #
   # A Topic is created from a Project. (See Project#create_topic)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
-  #   topic = pubsub.create_topic "my-topic"
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
+  # topic = pubsub.create_topic "my-topic"
+  # ```
   #
   # ## Retrieving Subscriptions
   #
@@ -118,41 +124,47 @@ module Gcloud
   # a single, specific Topic, to be delivered to the subscribing application.
   # A Subscription is found by its name. (See Topic#subscription)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   topic = pubsub.topic "my-topic"
-  #   subscription = topic.subscription "my-topic-subscription"
-  #   puts subscription.name
+  # topic = pubsub.topic "my-topic"
+  # subscription = topic.subscription "my-topic-subscription"
+  # puts subscription.name
+  # ```
   #
   # ## Creating a Subscription
   #
   # A Subscription is created from a Topic. (See Topic#subscribe and
   # Project#subscribe)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   topic = pubsub.topic "my-topic"
-  #   sub = topic.subscribe "my-topic-sub"
-  #   puts sub.name # => "my-topic-sub"
+  # topic = pubsub.topic "my-topic"
+  # sub = topic.subscribe "my-topic-sub"
+  # puts sub.name # => "my-topic-sub"
+  # ```
   #
   # The subscription can be created that specifies the number of seconds to
   # wait to be acknowledged as well as an endpoint URL to push the messages to:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   topic = pubsub.topic "my-topic"
-  #   sub = topic.subscribe "my-topic-sub",
-  #                         deadline: 120,
-  #                         endpoint: "https://example.com/push"
+  # topic = pubsub.topic "my-topic"
+  # sub = topic.subscribe "my-topic-sub",
+  #                       deadline: 120,
+  #                       endpoint: "https://example.com/push"
+  # ```
   #
   # ## Publishing Messages
   #
@@ -160,72 +172,84 @@ module Gcloud
   # a subscription will be lost. Ensure the topic has a subscription before
   # publishing. (See Topic#publish and Project#publish)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   topic = pubsub.topic "my-topic"
-  #   msg = topic.publish "new-message"
+  # topic = pubsub.topic "my-topic"
+  # msg = topic.publish "new-message"
+  # ```
   #
   # Messages can also be published with attributes:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   topic = pubsub.topic "my-topic"
-  #   msg = topic.publish "new-message",
-  #                       foo: :bar,
-  #                       this: :that
+  # topic = pubsub.topic "my-topic"
+  # msg = topic.publish "new-message",
+  #                     foo: :bar,
+  #                     this: :that
+  # ```
   #
   # Multiple messages can be published at the same time by passing a block:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   topic = pubsub.topic "my-topic"
-  #   msgs = topic.publish do |batch|
-  #     batch.publish "new-message-1", foo: :bar
-  #     batch.publish "new-message-2", foo: :baz
-  #     batch.publish "new-message-3", foo: :bif
-  #   end
+  # topic = pubsub.topic "my-topic"
+  # msgs = topic.publish do |batch|
+  #   batch.publish "new-message-1", foo: :bar
+  #   batch.publish "new-message-2", foo: :baz
+  #   batch.publish "new-message-3", foo: :bif
+  # end
+  # ```
   #
   # ## Pulling Messages
   #
   # Messages are pulled from a Subscription. (See Subscription#pull)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   msgs = sub.pull
+  # sub = pubsub.subscription "my-topic-sub"
+  # msgs = sub.pull
+  # ```
   #
   # A maximum number of messages returned can also be specified:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub", max: 10
-  #   msgs = sub.pull
+  # sub = pubsub.subscription "my-topic-sub", max: 10
+  # msgs = sub.pull
+  # ```
   #
   # The request for messages can also block until messages are available.
   # (See Subscription#wait_for_messages)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   msgs = sub.wait_for_messages
+  # sub = pubsub.subscription "my-topic-sub"
+  # msgs = sub.wait_for_messages
+  # ```
   #
   # ## Acknowledging a Message
   #
@@ -236,25 +260,29 @@ module Gcloud
   # ReceivedMessages can be acknowledged one at a time:
   # (See ReceivedMessage#acknowledge!)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   sub.pull.each { |msg| msg.acknowledge! }
+  # sub = pubsub.subscription "my-topic-sub"
+  # sub.pull.each { |msg| msg.acknowledge! }
+  # ```
   #
   # Or, multiple messages can be acknowledged in a single API call:
   # (See Subscription#acknowledge)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   received_messages = sub.pull
-  #   sub.acknowledge received_messages
+  # sub = pubsub.subscription "my-topic-sub"
+  # received_messages = sub.pull
+  # sub.acknowledge received_messages
+  # ```
   #
   # ## Modifying a Deadline
   #
@@ -263,45 +291,51 @@ module Gcloud
   # more time is needed. This will allow more time to process the message before
   # the message is marked for redelivery. (See ReceivedMessage#delay!)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   received_message = sub.pull.first
-  #   if received_message
-  #     puts received_message.message.data
-  #     # Delay for 2 minutes
-  #     received_message.delay! 120
-  #   end
+  # sub = pubsub.subscription "my-topic-sub"
+  # received_message = sub.pull.first
+  # if received_message
+  #   puts received_message.message.data
+  #   # Delay for 2 minutes
+  #   received_message.delay! 120
+  # end
+  # ```
   #
   # The message can also be made available for immediate redelivery:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   received_message = sub.pull.first
-  #   if received_message
-  #     puts received_message.message.data
-  #     # Mark for redelivery by setting the deadline to now
-  #     received_message.delay! 0
-  #   end
+  # sub = pubsub.subscription "my-topic-sub"
+  # received_message = sub.pull.first
+  # if received_message
+  #   puts received_message.message.data
+  #   # Mark for redelivery by setting the deadline to now
+  #   received_message.delay! 0
+  # end
+  # ```
   #
   # Multiple messages can be delayed or made available for immediate redelivery:
   # (See Subscription#delay)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   received_messages = sub.pull
-  #   sub.delay 120, received_messages
+  # sub = pubsub.subscription "my-topic-sub"
+  # received_messages = sub.pull
+  # sub.delay 120, received_messages
+  # ```
   #
   # ## Listening for Messages
   #
@@ -309,42 +343,48 @@ module Gcloud
   # infinitely blocking loop to process messages as they are received. (See
   # Subscription#listen)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   sub.listen do |msg|
-  #     # process msg
-  #   end
+  # sub = pubsub.subscription "my-topic-sub"
+  # sub.listen do |msg|
+  #   # process msg
+  # end
+  # ```
   #
   # Messages are retrieved in batches for efficiency. The number of messages
   # pulled per batch can be limited with the `max` option:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   sub.listen max: 20 do |msg|
-  #     # process msg
-  #   end
+  # sub = pubsub.subscription "my-topic-sub"
+  # sub.listen max: 20 do |msg|
+  #   # process msg
+  # end
+  # ```
   #
   # When processing time and the acknowledgement deadline are a concern,
   # messages can be automatically acknowledged as they are pulled with the
   # `autoack` option:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new
+  # pubsub = gcloud.pubsub
   #
-  #   sub = pubsub.subscription "my-topic-sub"
-  #   sub.listen autoack: true do |msg|
-  #     # process msg
-  #   end
+  # sub = pubsub.subscription "my-topic-sub"
+  # sub.listen autoack: true do |msg|
+  #   # process msg
+  # end
+  # ```
   #
   # ## Working Across Projects
   #
@@ -354,33 +394,37 @@ module Gcloud
   # the `project` option. The main credentials must have permissions to the
   # topics and subscriptions in other projects.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new # my-project-id
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new # my-project-id
+  # pubsub = gcloud.pubsub
   #
-  #   # Get a topic in the current project
-  #   my_topic = pubsub.topic "my-topic"
-  #   my_topic.name #=> "projects/my-project-id/topics/my-topic"
-  #   # Get a topic in another project
-  #   other_topic = pubsub.topic "other-topic", project: "other-project-id"
-  #   other_topic.name #=> "projects/other-project-id/topics/other-topic"
+  # # Get a topic in the current project
+  # my_topic = pubsub.topic "my-topic"
+  # my_topic.name #=> "projects/my-project-id/topics/my-topic"
+  # # Get a topic in another project
+  # other_topic = pubsub.topic "other-topic", project: "other-project-id"
+  # other_topic.name #=> "projects/other-project-id/topics/other-topic"
+  # ```
   #
   # It is possible to create a subscription in the current project that pulls
   # from a topic in another project:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new # my-project-id
-  #   pubsub = gcloud.pubsub
+  # gcloud = Gcloud.new # my-project-id
+  # pubsub = gcloud.pubsub
   #
-  #   # Get a topic in another project
-  #   topic = pubsub.topic "other-topic", project: "other-project-id"
-  #   # Create a subscription in the current project that pulls from
-  #   # the topic in another project
-  #   sub = topic.subscribe "my-sub"
-  #   sub.name #=> "projects/my-project-id/subscriptions/my-sub"
-  #   sub.topic.name #=> "projects/other-project-id/topics/other-topic"
+  # # Get a topic in another project
+  # topic = pubsub.topic "other-topic", project: "other-project-id"
+  # # Create a subscription in the current project that pulls from
+  # # the topic in another project
+  # sub = topic.subscribe "my-sub"
+  # sub.name #=> "projects/my-project-id/subscriptions/my-sub"
+  # sub.topic.name #=> "projects/other-project-id/topics/other-topic"
+  # ```
   #
   module Pubsub
   end

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/version"
 require "google/api_client"

--- a/lib/gcloud/pubsub/connection.rb
+++ b/lib/gcloud/pubsub/connection.rb
@@ -19,13 +19,13 @@ require "google/api_client"
 module Gcloud
   module Pubsub
     ##
-    # Represents the connection to Pub/Sub,
+    # @private Represents the connection to Pub/Sub,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
@@ -271,7 +271,7 @@ module Gcloud
         "#{project_path(options)}/subscriptions/#{subscription_name}"
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
 

--- a/lib/gcloud/pubsub/credentials.rb
+++ b/lib/gcloud/pubsub/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/credentials"
 

--- a/lib/gcloud/pubsub/credentials.rb
+++ b/lib/gcloud/pubsub/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Pubsub
     ##
-    # Represents the OAuth 2.0 signing logic for Pub/Sub.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the OAuth 2.0 signing logic for Pub/Sub.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/pubsub"]
       PATH_ENV_VARS = %w(PUBSUB_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(PUBSUB_KEYFILE_JSON GCLOUD_KEYFILE_JSON

--- a/lib/gcloud/pubsub/errors.rb
+++ b/lib/gcloud/pubsub/errors.rb
@@ -81,14 +81,14 @@ module Gcloud
     ##
     # # AlreadyExistsError
     #
-    # Raised when Pub/Sub returns an +ALREADY_EXISTS+ error.
+    # Raised when Pub/Sub returns an `ALREADY_EXISTS` error.
     class AlreadyExistsError < ApiError
     end
 
     ##
     # # NotFoundError
     #
-    # Raised when Pub/Sub returns a +NOT_FOUND+ error.
+    # Raised when Pub/Sub returns a `NOT_FOUND` error.
     class NotFoundError < ApiError
     end
   end

--- a/lib/gcloud/pubsub/errors.rb
+++ b/lib/gcloud/pubsub/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/errors"
 

--- a/lib/gcloud/pubsub/errors.rb
+++ b/lib/gcloud/pubsub/errors.rb
@@ -26,7 +26,8 @@ module Gcloud
       # The response object of the failed HTTP request.
       attr_reader :response
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         new.tap do |e|
           e.response = resp
         end
@@ -59,7 +60,8 @@ module Gcloud
         @response = response
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         klass = klass_for resp.data["error"]["status"]
         klass.new resp.data["error"]["message"], resp
       rescue

--- a/lib/gcloud/pubsub/errors.rb
+++ b/lib/gcloud/pubsub/errors.rb
@@ -18,7 +18,7 @@ require "gcloud/errors"
 module Gcloud
   module Pubsub
     ##
-    # = Storage Error
+    # # Storage Error
     #
     # Base Pub/Sub exception class.
     class Error < Gcloud::Error
@@ -35,7 +35,7 @@ module Gcloud
     end
 
     ##
-    # = ApiError
+    # # ApiError
     #
     # Raised when an API call is not successful.
     class ApiError < Error
@@ -79,14 +79,14 @@ module Gcloud
     end
 
     ##
-    # = AlreadyExistsError
+    # # AlreadyExistsError
     #
     # Raised when Pub/Sub returns an +ALREADY_EXISTS+ error.
     class AlreadyExistsError < ApiError
     end
 
     ##
-    # = NotFoundError
+    # # NotFoundError
     #
     # Raised when Pub/Sub returns a +NOT_FOUND+ error.
     class NotFoundError < ApiError

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -18,7 +18,7 @@ require "gcloud/pubsub/errors"
 module Gcloud
   module Pubsub
     ##
-    # = Message
+    # # Message
     #
     # Represents a Pub/Sub Message.
     #

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/pubsub/errors"
 

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -22,11 +22,12 @@ module Gcloud
     #
     # Represents a Pub/Sub Message.
     #
-    # Message objects are created by Topic#publish.
-    # Subscription#pull returns an array of ReceivedMessage objects, each of
-    # which contains a Message object. Each ReceivedMessage object can be
+    # Message objects are created by {Topic#publish}.
+    # {Subscription#pull} returns an array of {ReceivedMessage} objects, each of
+    # which contains a Message object. Each {ReceivedMessage} object can be
     # acknowledged and/or delayed.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -44,8 +45,8 @@ module Gcloud
     #
     class Message
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
       # Create an empty Message object.
@@ -79,8 +80,8 @@ module Gcloud
       alias_method :msg_id, :message_id
 
       ##
-      # New Topic from a Google API Client object.
-      def self.from_gapi gapi #:nodoc:
+      # @private New {Topic} from a Google API Client object.
+      def self.from_gapi gapi
         new.tap do |f|
           f.gapi = gapi
         end

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -25,12 +25,15 @@ module Gcloud
     # = Project
     #
     # Represents the project that pubsub messages are pushed to and pulled from.
-    # Topic is a named resource to which messages are sent by publishers.
-    # Subscription is a named resource representing the stream of messages from
-    # a single, specific topic, to be delivered to the subscribing application.
-    # Message is a combination of data and attributes that a publisher sends to
-    # a topic and is eventually delivered to subscribers.
+    # {Topic} is a named resource to which messages are sent by publishers.
+    # {Subscription} is a named resource representing the stream of messages
+    # from a single, specific topic, to be delivered to the subscribing
+    # application. {Message} is a combination of data and attributes that a
+    # publisher sends to a topic and is eventually delivered to subscribers.
     #
+    # See {Gcloud#pubsub}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -39,15 +42,14 @@ module Gcloud
     #   topic = pubsub.topic "my-topic"
     #   topic.publish "task completed"
     #
-    # See Gcloud#pubsub
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Connection instance.
-      def initialize project, credentials #:nodoc:
+      # @private Creates a new Connection instance.
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -55,8 +57,7 @@ module Gcloud
 
       # The Pub/Sub project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -70,8 +71,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["PUBSUB_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -81,67 +82,54 @@ module Gcloud
       ##
       # Retrieves topic by name.
       #
-      # === Parameters
+      # The topic will be created if the topic does not exist and the
+      # +autocreate+ option is set to true.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
-      # +autocreate+::
-      #   Flag to control whether the requested topic will be created if it does
-      #   not exist. Ignored if +skip_lookup+ is +true+. The default value is
-      #   +false+. (+Boolean+)
-      # +project+::
-      #   If the topic belongs to a project other than the one currently
-      #   connected to, the alternate project ID can be specified here.
-      #   (+String+)
-      # +skip_lookup+::
-      #   Optionally create a Topic object without verifying the topic resource
-      #   exists on the Pub/Sub service. Calls made on this object will raise
-      #   errors if the topic resource does not exist. Default is +false+.
-      #   (+Boolean+)
+      # @param [String] topic_name Name of a topic.
+      # @param [Boolean] autocreate Flag to control whether the requested topic
+      #   will be created if it does not exist. Ignored if +skip_lookup+ is
+      #   +true+. The default value is +false+.
+      # @param [String] project If the topic belongs to a project other than the
+      #   one currently connected to, the alternate project ID can be specified
+      #   here.
+      # @param [Boolean] skip_lookup Optionally create a {Topic} object without
+      #   verifying the topic resource exists on the Pub/Sub service. Calls made
+      #   on this object will raise errors if the topic resource does not exist.
+      #   Default is +false+.
       #
-      # === Returns
+      # @return [Gcloud::Pubsub::Topic, nil] Returns +nil+ if topic does not
+      #   exist. Will return a newly created{ Gcloud::Pubsub::Topic} if the
+      #   topic does not exist and +autocreate+ is set to +true+.
       #
-      # Gcloud::Pubsub::Topic or nil if topic does not exist. Will return a
-      # newly created Gcloud::Pubsub::Topic if the topic does not exist and
-      # +autocreate+ is set to +true+.
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "existing-topic"
       #
-      # By default +nil+ will be returned if the topic does not exist.
-      # the topic will be created in Pub/Sub when needed.
-      #
+      # @example By default +nil+ will be returned if the topic does not exist.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic" #=> nil
       #
-      # The topic will be created if the topic does not exist and the
-      # +autocreate+ option is set to true.
-      #
+      # @example With the +autocreate+ option set to +true+.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic", autocreate: true
       #
-      # A topic in a different project can be created using the +project+ flag.
-      #
+      # @example Create a topic in a different project with the +project+ flag.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "another-topic", project: "another-project"
       #
-      # The lookup against the Pub/Sub service can be skipped using the
-      # +skip_lookup+ option:
-      #
+      # @example Skip the lookup against the service with +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -166,17 +154,11 @@ module Gcloud
       ##
       # Creates a new topic.
       #
-      # === Parameters
+      # @param [String] topic_name Name of a topic.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
+      # @return [Gcloud::Pubsub::Topic]
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Topic
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -197,21 +179,15 @@ module Gcloud
       ##
       # Retrieves a list of topics for the given project.
       #
-      # === Parameters
+      # @param [String] token The +token+ value returned by the last call to
+      #   +topics+; indicates that this is a continuation of a call, and that
+      #   the system should return the next page of data.
+      # @param [Integer] max Maximum number of topics to return.
       #
-      # +token+::
-      #   The +token+ value returned by the last call to +topics+; indicates
-      #   that this is a continuation of a call, and that the system should
-      #   return the next page of data. (+String+)
-      # +max+::
-      #   Maximum number of topics to return. (+Integer+)
+      # @return [Array<Gcloud::Pubsub::Topic>] (See
+      #   {Gcloud::Pubsub::Topic::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::Topic (See Gcloud::Pubsub::Topic::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -222,9 +198,7 @@ module Gcloud
       #     puts topic.name
       #   end
       #
-      # If you have a significant number of topics, you may need to paginate
-      # through them: (See Topic::List#token)
-      #
+      # @example With pagination: (See {Topic::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -256,27 +230,24 @@ module Gcloud
       alias_method :list_topics, :topics
 
       ##
-      # Publishes one or more messages to the given topic.
+      # Publishes one or more messages to the given topic. The topic will be
+      # created if the topic does previously not exist and the +autocreate+
+      # option is provided.
       #
-      # === Parameters
+      # A note about auto-creating the topic: Any message published to a topic
+      # without a subscription will be lost.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
-      # +data+::
-      #   The message data. (+String+)
-      # +attributes+::
-      #   Optional attributes for the message. (+Hash+)
-      # <code>attributes[:autocreate]</code>::
-      #   Flag to control whether the provided topic will be created if it does
-      #   not exist.
+      # @param [String] topic_name Name of a topic.
+      # @param [String] data The message data.
+      # @param [Hash] attributes Optional attributes for the message.
+      # @option attributes [Boolean] :autocreate Flag to control whether the
+      #   provided topic will be created if it does not exist.
       #
-      # === Returns
+      # @return [Message, Array<Message>] Returns the published message when
+      #   called without a block, or an array of messages when called with a
+      #   block.
       #
-      # Message object when called without a block,
-      # Array of Message objects when called with a block
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -284,8 +255,7 @@ module Gcloud
       #
       #   msg = pubsub.publish "my-topic", "new-message"
       #
-      # Additionally, a message can be published with attributes:
-      #
+      # @example Additionally, a message can be published with attributes:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -294,8 +264,7 @@ module Gcloud
       #   msg = pubsub.publish "my-topic", "new-message", foo: :bar,
       #                                                   this: :that
       #
-      # Multiple messages can be published at the same time by passing a block:
-      #
+      # @example Multiple messages can be sent at the same time using a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -307,18 +276,13 @@ module Gcloud
       #     batch.publish "new-message-3", foo: :bif
       #   end
       #
-      # Additionally, the topic will be created if the topic does previously not
-      # exist and the +autocreate+ option is provided.
-      #
+      # @example With +autocreate+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #
       #   msg = pubsub.publish "new-topic", "new-message", autocreate: true
-      #
-      # A note about auto-creating the topic: Any message published to a topic
-      # without a subscription will be lost.
       #
       def publish topic_name, data = nil, attributes = {}
         # Fix parameters
@@ -336,34 +300,27 @@ module Gcloud
       end
 
       ##
-      # Creates a new Subscription object for the provided topic.
+      # Creates a new {Subscription} object for the provided topic. The topic
+      # will be created if the topic does previously not exist and the
+      # +autocreate+ option is provided.
       #
-      # === Parameters
+      # @param [String] topic_name Name of a topic.
+      # @param [String] subscription_name Name of the new subscription. Must
+      #   start with a letter, and contain only letters ([A-Za-z]), numbers
+      #   ([0-9], dashes (-), underscores (_), periods (.), tildes (~), plus (+)
+      #   or percent signs (%). It must be between 3 and 255 characters in
+      #   length, and it must not start with "goog".
+      # @param [Integer] deadline The maximum number of seconds after a
+      #   subscriber receives a message before the subscriber should acknowledge
+      #   the message.
+      # @param [String] endpoint A URL locating the endpoint to which messages
+      #   should be pushed.
+      # @param [String] autocreate Flag to control whether the topic will be
+      #   created if it does not exist.
       #
-      # +topic_name+::
-      #   Name of a topic. (+String+)
-      # +subscription_name+::
-      #   Name of the new subscription. Must start with a letter, and contain
-      #   only letters ([A-Za-z]), numbers ([0-9], dashes (-), underscores (_),
-      #   periods (.), tildes (~), plus (+) or percent signs (%). It must be
-      #   between 3 and 255 characters in length, and it must not start with
-      #   "goog". (+String+)
-      # +deadline+::
-      #   The maximum number of seconds after a subscriber receives a message
-      #   before the subscriber should acknowledge the message. (+Integer+)
-      # +endpoint+::
-      #   A URL locating the endpoint to which messages should be pushed.
-      #   e.g. "https://example.com/push" (+String+)
-      # +autocreate+::
-      #   Flag to control whether the topic will be created if it does not
-      #   exist.
+      # @return [Gcloud::Pubsub::Subscription]
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -372,8 +329,7 @@ module Gcloud
       #   sub = pubsub.subscribe "my-topic", "my-topic-sub"
       #   puts sub.name # => "my-topic-sub"
       #
-      # The name is optional, and will be generated if not given.
-      #
+      # @example The name is optional, and will be generated if not given.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -382,9 +338,7 @@ module Gcloud
       #   sub = pubsub.subscribe "my-topic"
       #   puts sub.name # => "generated-sub-name"
       #
-      # The subscription can be created that waits two minutes for
-      # acknowledgement and pushed all messages to an endpoint
-      #
+      # @example Wait 2 minutes for acknowledgement and push all to an endpoint:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -394,9 +348,7 @@ module Gcloud
       #                          deadline: 120,
       #                          endpoint: "https://example.com/push"
       #
-      # Additionally, the topic will be created if the topic does previously not
-      # exist and the +autocreate+ option is provided.
-      #
+      # @example With +autocreate+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -425,26 +377,19 @@ module Gcloud
       ##
       # Retrieves subscription by name.
       #
-      # === Parameters
+      # @param [String] subscription_name Name of a subscription.
+      # @param [String] project If the subscription belongs to a project other
+      #   than the one currently connected to, the alternate project ID can be
+      #   specified here.
+      # @param [Boolean] skip_lookup Optionally create a {Subscription} object
+      #   without verifying the subscription resource exists on the Pub/Sub
+      #   service. Calls made on this object will raise errors if the service
+      #   resource does not exist. Default is +false+.
       #
-      # +subscription_name+::
-      #   Name of a subscription. (+String+)
-      # +project+::
-      #   If the subscription belongs to a project other than the one currently
-      #   connected to, the alternate project ID can be specified here.
-      #   (+String+)
-      # +skip_lookup+::
-      #   Optionally create a Subscription object without verifying the
-      #   subscription resource exists on the Pub/Sub service. Calls made on
-      #   this object will raise errors if the service resource does not exist.
-      #   Default is +false+. (+Boolean+)
+      # @return [Gcloud::Pubsub::Subscription, nil] Returns +nil+ if the
+      #   subscription does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription or +nil+ if the subscription does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -453,9 +398,7 @@ module Gcloud
       #   subscription = pubsub.subscription "my-sub"
       #   puts subscription.name
       #
-      # The lookup against the Pub/Sub service can be skipped using the
-      # +skip_lookup+ option:
-      #
+      # @example Skip the lookup against the service with +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -482,24 +425,16 @@ module Gcloud
       ##
       # Retrieves a list of subscriptions for the given project.
       #
-      # === Parameters
+      # @param [String] prefix Filter results to subscriptions whose names begin
+      #   with this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of subscriptions to return.
       #
-      # +prefix+::
-      #   Filter results to subscriptions whose names begin with this prefix.
-      #   (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of subscriptions to return. (+Integer+)
+      # @return [Array<Gcloud::Pubsub::Subscription>] (See
+      #   {Gcloud::Pubsub::Subscription::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::Subscription
-      # (See Gcloud::Pubsub::Subscription::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -510,8 +445,7 @@ module Gcloud
       #     puts subscription.name
       #   end
       #
-      # If you have a significant number of subscriptions, you may need to
-      # paginate through them: (See Subscription::List#token)
+      # @example With pagination: (See {Subscription::List#token})
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -22,7 +22,7 @@ require "gcloud/pubsub/topic"
 module Gcloud
   module Pubsub
     ##
-    # = Project
+    # # Project
     #
     # Represents the project that pubsub messages are pushed to and pulled from.
     # {Topic} is a named resource to which messages are sent by publishers.

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -83,23 +83,23 @@ module Gcloud
       # Retrieves topic by name.
       #
       # The topic will be created if the topic does not exist and the
-      # +autocreate+ option is set to true.
+      # `autocreate` option is set to true.
       #
       # @param [String] topic_name Name of a topic.
       # @param [Boolean] autocreate Flag to control whether the requested topic
-      #   will be created if it does not exist. Ignored if +skip_lookup+ is
-      #   +true+. The default value is +false+.
+      #   will be created if it does not exist. Ignored if `skip_lookup` is
+      #   `true`. The default value is `false`.
       # @param [String] project If the topic belongs to a project other than the
       #   one currently connected to, the alternate project ID can be specified
       #   here.
       # @param [Boolean] skip_lookup Optionally create a {Topic} object without
       #   verifying the topic resource exists on the Pub/Sub service. Calls made
       #   on this object will raise errors if the topic resource does not exist.
-      #   Default is +false+.
+      #   Default is `false`.
       #
-      # @return [Gcloud::Pubsub::Topic, nil] Returns +nil+ if topic does not
+      # @return [Gcloud::Pubsub::Topic, nil] Returns `nil` if topic does not
       #   exist. Will return a newly created{ Gcloud::Pubsub::Topic} if the
-      #   topic does not exist and +autocreate+ is set to +true+.
+      #   topic does not exist and `autocreate` is set to `true`.
       #
       # @example
       #   require "gcloud"
@@ -108,28 +108,28 @@ module Gcloud
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "existing-topic"
       #
-      # @example By default +nil+ will be returned if the topic does not exist.
+      # @example By default `nil` will be returned if the topic does not exist.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic" #=> nil
       #
-      # @example With the +autocreate+ option set to +true+.
+      # @example With the `autocreate` option set to `true`.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "non-existing-topic", autocreate: true
       #
-      # @example Create a topic in a different project with the +project+ flag.
+      # @example Create a topic in a different project with the `project` flag.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "another-topic", project: "another-project"
       #
-      # @example Skip the lookup against the service with +skip_lookup+:
+      # @example Skip the lookup against the service with `skip_lookup`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -179,8 +179,8 @@ module Gcloud
       ##
       # Retrieves a list of topics for the given project.
       #
-      # @param [String] token The +token+ value returned by the last call to
-      #   +topics+; indicates that this is a continuation of a call, and that
+      # @param [String] token The `token` value returned by the last call to
+      #   `topics`; indicates that this is a continuation of a call, and that
       #   the system should return the next page of data.
       # @param [Integer] max Maximum number of topics to return.
       #
@@ -231,7 +231,7 @@ module Gcloud
 
       ##
       # Publishes one or more messages to the given topic. The topic will be
-      # created if the topic does previously not exist and the +autocreate+
+      # created if the topic does previously not exist and the `autocreate`
       # option is provided.
       #
       # A note about auto-creating the topic: Any message published to a topic
@@ -276,7 +276,7 @@ module Gcloud
       #     batch.publish "new-message-3", foo: :bif
       #   end
       #
-      # @example With +autocreate+:
+      # @example With `autocreate`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -302,7 +302,7 @@ module Gcloud
       ##
       # Creates a new {Subscription} object for the provided topic. The topic
       # will be created if the topic does previously not exist and the
-      # +autocreate+ option is provided.
+      # `autocreate` option is provided.
       #
       # @param [String] topic_name Name of a topic.
       # @param [String] subscription_name Name of the new subscription. Must
@@ -348,7 +348,7 @@ module Gcloud
       #                          deadline: 120,
       #                          endpoint: "https://example.com/push"
       #
-      # @example With +autocreate+:
+      # @example With `autocreate`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -384,9 +384,9 @@ module Gcloud
       # @param [Boolean] skip_lookup Optionally create a {Subscription} object
       #   without verifying the subscription resource exists on the Pub/Sub
       #   service. Calls made on this object will raise errors if the service
-      #   resource does not exist. Default is +false+.
+      #   resource does not exist. Default is `false`.
       #
-      # @return [Gcloud::Pubsub::Subscription, nil] Returns +nil+ if the
+      # @return [Gcloud::Pubsub::Subscription, nil] Returns `nil` if the
       #   subscription does not exist
       #
       # @example
@@ -398,7 +398,7 @@ module Gcloud
       #   subscription = pubsub.subscription "my-sub"
       #   puts subscription.name
       #
-      # @example Skip the lookup against the service with +skip_lookup+:
+      # @example Skip the lookup against the service with `skip_lookup`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/gce"
 require "gcloud/pubsub/connection"

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -115,8 +115,8 @@ module Gcloud
       #
       # @param [Integer] new_deadline The new ack deadline in seconds from the
       #   time this request is sent to the Pub/Sub system. Must be >= 0. For
-      #   example, if the value is +10+, the new ack deadline will expire 10
-      #   seconds after the call is made. Specifying +0+ may immediately make
+      #   example, if the value is `10`, the new ack deadline will expire 10
+      #   seconds after the call is made. Specifying `0` may immediately make
       #   the message available for another pull request.
       #
       # @example

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -113,11 +113,11 @@ module Gcloud
       # This indicates that more time is needed to process the message, or to
       # make the message available for redelivery.
       #
-      # @param [Integer] deadline The new ack deadline in seconds from the time
-      #   this request is sent to the Pub/Sub system. Must be >= 0. For example,
-      #   if the value is +10+, the new ack deadline will expire 10 seconds
-      #   after the call is made. Specifying +0+ may immediately make the
-      #   message available for another pull request.
+      # @param [Integer] new_deadline The new ack deadline in seconds from the
+      #   time this request is sent to the Pub/Sub system. Must be >= 0. For
+      #   example, if the value is +10+, the new ack deadline will expire 10
+      #   seconds after the call is made. Specifying +0+ may immediately make
+      #   the message available for another pull request.
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -19,7 +19,7 @@ require "gcloud/pubsub/message"
 module Gcloud
   module Pubsub
     ##
-    # = ReceivedMessage
+    # # ReceivedMessage
     #
     # Represents a Pub/Sub {Message} that can be acknowledged or delayed.
     #

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/pubsub/errors"
 require "gcloud/pubsub/message"

--- a/lib/gcloud/pubsub/received_message.rb
+++ b/lib/gcloud/pubsub/received_message.rb
@@ -21,8 +21,9 @@ module Gcloud
     ##
     # = ReceivedMessage
     #
-    # Represents a Pub/Sub Message that can be acknowledged or delayed.
+    # Represents a Pub/Sub {Message} that can be acknowledged or delayed.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -37,16 +38,16 @@ module Gcloud
     #
     class ReceivedMessage
       ##
-      # The Subscription object.
-      attr_accessor :subscription #:nodoc:
+      # @private The {Subscription} object.
+      attr_accessor :subscription
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Subscription object.
-      def initialize #:nodoc:
+      # @private Create an empty {Subscription} object.
+      def initialize
         @subscription = nil
         @gapi = {}
       end
@@ -87,8 +88,7 @@ module Gcloud
       ##
       # Acknowledges receipt of the message.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -113,17 +113,13 @@ module Gcloud
       # This indicates that more time is needed to process the message, or to
       # make the message available for redelivery.
       #
-      # === Parameters
+      # @param [Integer] deadline The new ack deadline in seconds from the time
+      #   this request is sent to the Pub/Sub system. Must be >= 0. For example,
+      #   if the value is +10+, the new ack deadline will expire 10 seconds
+      #   after the call is made. Specifying +0+ may immediately make the
+      #   message available for another pull request.
       #
-      # +deadline+::
-      #   The new ack deadline in seconds from the time this request is sent
-      #   to the Pub/Sub system. Must be >= 0. For example, if the value is
-      #   +10+, the new ack deadline will expire 10 seconds after the call is
-      #   made. Specifying +0+ may immediately make the message available for
-      #   another pull request. (+Integer+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -150,8 +146,8 @@ module Gcloud
       end
 
       ##
-      # New ReceivedMessage from a Google API Client object.
-      def self.from_gapi gapi, subscription #:nodoc:
+      # @private New ReceivedMessage from a Google API Client object.
+      def self.from_gapi gapi, subscription
         new.tap do |f|
           f.gapi         = gapi
           f.subscription = subscription

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -410,7 +410,7 @@ module Gcloud
       # calls to the Pub/Sub service.
       #
       # @param [Boolean] force Force the latest policy to be retrieved from the
-      #   Pub/Sub service when +true. Otherwise the policy will be memoized to
+      #   Pub/Sub service when `true`. Otherwise the policy will be memoized to
       #   reduce the number of API calls made to the Pub/Sub service. The
       #   default is `false`.
       #

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -494,8 +494,8 @@ module Gcloud
       end
 
       ##
-      # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy.
+      # Tests the specified permissions against the [Cloud
+      # IAM](https://cloud.google.com/iam/) access control policy.
       #
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/pubsub/errors"
 require "gcloud/pubsub/subscription/list"

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -23,8 +23,9 @@ module Gcloud
     # = Subscription
     #
     # A named resource representing the stream of messages from a single,
-    # specific topic, to be delivered to the subscribing application.
+    # specific {Topic}, to be delivered to the subscribing application.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -36,16 +37,16 @@ module Gcloud
     #
     class Subscription
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Subscription object.
-      def initialize #:nodoc:
+      # @private Create an empty {Subscription} object.
+      def initialize
         @connection = nil
         @gapi = {}
         @name = nil
@@ -53,8 +54,8 @@ module Gcloud
       end
 
       ##
-      # New lazy Topic object without making an HTTP request.
-      def self.new_lazy name, conn, options = {} #:nodoc:
+      # @private New lazy {Topic} object without making an HTTP request.
+      def self.new_lazy name, conn, options = {}
         sub = new.tap do |f|
           f.gapi = nil
           f.connection = conn
@@ -72,14 +73,11 @@ module Gcloud
       end
 
       ##
-      # The Topic from which this subscription receives messages.
+      # The {Topic} from which this subscription receives messages.
       #
-      # === Returns
+      # @return [Topic]
       #
-      # Topic
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -124,8 +122,7 @@ module Gcloud
       ##
       # Determines whether the subscription exists in the Pub/Sub service.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -146,11 +143,11 @@ module Gcloud
       end
 
       ##
+      # @private
       # Determines whether the subscription object was created with an
       # HTTP call.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -159,7 +156,7 @@ module Gcloud
       #   sub = pubsub.get_subscription "my-topic-sub"
       #   sub.lazy? #=> false
       #
-      def lazy? #:nodoc:
+      def lazy?
         @gapi.nil?
       end
 
@@ -167,12 +164,9 @@ module Gcloud
       # Deletes an existing subscription.
       # All pending messages in the subscription are immediately dropped.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the subscription was deleted.
       #
-      # +true+ if the subscription was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -197,27 +191,20 @@ module Gcloud
       # +UNAVAILABLE+ if there are too many concurrent pull requests pending
       # for the given subscription.
       #
-      # === Parameters
+      # @param [Boolean] immediate When +true+ the system will respond
+      #   immediately even if it is not able to return messages. When +false+
+      #   the system is allowed to wait until it can return least one message.
+      #   No messages are returned when a request times out. The default value
+      #   is +true+.
+      # @param [Integer] max The maximum number of messages to return for this
+      #   request. The Pub/Sub system may return fewer than the number
+      #   specified. The default value is +100+, the maximum value is +1000+.
+      # @param [Boolean] autoack Automatically acknowledge the message as it is
+      #   pulled. The default value is +false+.
       #
-      # +immediate+::
-      #   When +true+ the system will respond immediately even if it is not able
-      #   to return messages. When +false+ the system is allowed to wait until
-      #   it can return least one message. No messages are returned when a
-      #   request times out. The default value is +true+. (+Boolean+)
-      # +max+::
-      #   The maximum number of messages to return for this request. The Pub/Sub
-      #   system may return fewer than the number specified. The default value
-      #   is +100+, the maximum value is +1000+. (+Integer+)
-      # +autoack+::
-      #   Automatically acknowledge the message as it is pulled. The default
-      #   value is +false+. (+Boolean+)
+      # @return [Array<Gcloud::Pubsub::ReceivedMessage>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::ReceivedMessage
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -226,8 +213,7 @@ module Gcloud
       #   sub = pubsub.subscription "my-topic-sub"
       #   sub.pull.each { |msg| msg.acknowledge! }
       #
-      # A maximum number of messages returned can also be specified:
-      #
+      # @example A maximum number of messages returned can also be specified:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -236,9 +222,7 @@ module Gcloud
       #   sub = pubsub.subscription "my-topic-sub", max: 10
       #   sub.pull.each { |msg| msg.acknowledge! }
       #
-      # The call can block until messages are available by setting the
-      # +:immediate+ option to +false+:
-      #
+      # @example The call can block until messages are available:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -271,22 +255,15 @@ module Gcloud
       #
       #   subscription.pull immediate: false
       #
-      # === Parameters
+      # @param [Integer] max The maximum number of messages to return for this
+      #   request. The Pub/Sub system may return fewer than the number
+      #   specified. The default value is +100+, the maximum value is +1000+.
+      # @param [Boolean] autoack Automatically acknowledge the message as it is
+      #   pulled. The default value is +false+.
       #
-      # +max+::
-      #   The maximum number of messages to return for this request. The Pub/Sub
-      #   system may return fewer than the number specified. The default value
-      #   is +100+, the maximum value is +1000+. (+Integer+)
-      # +autoack+::
-      #   Automatically acknowledge the message as it is pulled. The default
-      #   value is +false+. (+Boolean+)
+      # @return [Array<Gcloud::Pubsub::ReceivedMessage>]
       #
-      # === Returns
-      #
-      # Array of Gcloud::Pubsub::ReceivedMessage
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -304,22 +281,16 @@ module Gcloud
       # Poll the backend for new messages. This runs a loop to ping the API,
       # blocking indefinitely, yielding retrieved messages as they are received.
       #
-      # === Parameters
+      # @param [Integer] max The maximum number of messages to return for this
+      #   request. The Pub/Sub system may return fewer than the number
+      #   specified. The default value is +100+, the maximum value is +1000+.
+      # @param [Boolean] autoack Automatically acknowledge the message as it is
+      #   pulled. The default value is +false+.
+      # @param [Number] delay The number of seconds to pause between requests
+      #   when the Google Cloud service has no messages to return. The default
+      #   value is +1+.
       #
-      # +max+::
-      #   The maximum number of messages to return for this request. The Pub/Sub
-      #   system may return fewer than the number specified. The default value
-      #   is +100+, the maximum value is +1000+. (+Integer+)
-      # +autoack+::
-      #   Automatically acknowledge the message as it is pulled. The default
-      #   value is +false+. (+Boolean+)
-      # +delay+::
-      #   The number of seconds to pause between requests when the Google Cloud
-      #   service has no messages to return. The default value is +1+.
-      #   (+Number+)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -330,9 +301,7 @@ module Gcloud
       #     # process msg
       #   end
       #
-      # The number of messages pulled per batch can be set with the +max+
-      # option:
-      #
+      # @example Limit the number of messages pulled per batch with +max+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -343,9 +312,7 @@ module Gcloud
       #     # process msg
       #   end
       #
-      # Messages can be automatically acknowledged as they are pulled with the
-      # +autoack+ option:
-      #
+      # @example Automatically acknowledge messages with +autoack+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -375,14 +342,10 @@ module Gcloud
       # Acknowledging a message more than once will not result in an error.
       # This is only used for messages received via pull.
       #
-      # === Parameters
+      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      #   objects or ack_id values.
       #
-      # +messages+::
-      #   One or more ReceivedMessage objects or ack_id values.
-      #   (+ReceivedMessage+ or +ack_id+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -411,20 +374,15 @@ module Gcloud
       # make the messages available for redelivery if the processing was
       # interrupted.
       #
-      # === Parameters
+      # @param [Integer] new_deadline The new ack deadline in seconds from the
+      #   time this request is sent to the Pub/Sub system. Must be >= 0. For
+      #   example, if the value is +10+, the new ack deadline will expire 10
+      #   seconds after the call is made. Specifying +0+ may immediately make
+      #   the message available for another pull request.
+      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      #   objects or ack_id values.
       #
-      # +new_deadline+::
-      #   The new ack deadline in seconds from the time this request is sent
-      #   to the Pub/Sub system. Must be >= 0. For example, if the value is
-      #   +10+, the new ack deadline will expire 10 seconds after the call is
-      #   made. Specifying +0+ may immediately make the messages available for
-      #   another pull request. (+Integer+)
-      # +messages+::
-      #   One or more ReceivedMessage objects or ack_id values.
-      #   (+ReceivedMessage+ or +ack_id+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -448,17 +406,15 @@ module Gcloud
       ##
       # Gets the access control policy.
       #
-      # === Parameters
+      # By default, the policy values are memoized to reduce the number of API
+      # calls to the Pub/Sub service.
       #
-      # +force+::
-      #   Force the latest policy to be retrieved from the Pub/Sub service when
-      #   +true. Otherwise the policy will be memoized to reduce the number of
-      #   API calls made to the Pub/Sub service. The default is +false+.
-      #   (+Boolean+)
+      # @param [Boolean] force Force the latest policy to be retrieved from the
+      #   Pub/Sub service when +true. Otherwise the policy will be memoized to
+      #   reduce the number of API calls made to the Pub/Sub service. The
+      #   default is +false+.
       #
-      # === Returns
-      #
-      # A hash that conforms to the following structure:
+      # @return [Hash] Returns a hash that conforms to the following structure:
       #
       #   {
       #     "etag"=>"CAE=",
@@ -468,11 +424,7 @@ module Gcloud
       #     }]
       #   }
       #
-      # === Examples
-      #
-      # By default, the policy values are memoized to reduce the number of API
-      # calls to the Pub/Sub service.
-      #
+      # @example Policy values are memoized to reduce the number of API calls:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -482,9 +434,7 @@ module Gcloud
       #   puts subscription.policy["bindings"]
       #   puts subscription.policy["rules"]
       #
-      # To retrieve the latest policy from the Pub/Sub service, use the +force+
-      # flag.
-      #
+      # @example Use +force+ to retrieve the latest policy from the service:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -507,10 +457,8 @@ module Gcloud
       ##
       # Sets the access control policy.
       #
-      # === Parameters
-      #
-      # +new_policy+::
-      #   A hash that conforms to the following structure:
+      # @param [String] new_policy A hash that conforms to the following
+      #   structure:
       #
       #     {
       #       "bindings" => [{
@@ -519,8 +467,7 @@ module Gcloud
       #       }]
       #     }
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -548,23 +495,18 @@ module Gcloud
 
       ##
       # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy. See
-      # {Managing Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # IAM}[https://cloud.google.com/iam/] access control policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +permissions+::
-      #   The set of permissions to check access for. Permissions with wildcards
-      #   (such as +*+ or +storage.*+) are not allowed.
-      #   (String or Array of Strings)
+      # @param [String, Array<String>] permissions The set of permissions to
+      #   check access for. Permissions with wildcards (such as +*+ or
+      #   +storage.*+) are not allowed.
       #
-      # === Returns
+      # @return [Array<String>] The permissions that have access.
       #
-      # The permissions that have access. (Array of Strings)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -587,8 +529,8 @@ module Gcloud
       end
 
       ##
-      # New Subscription from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New {Subscription} from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -618,7 +560,7 @@ module Gcloud
 
       ##
       # Makes sure the values are the +ack_id+.
-      # If given several ReceivedMessage objects extract the +ack_id+ values.
+      # If given several {ReceivedMessage} objects extract the +ack_id+ values.
       def coerce_ack_ids messages
         Array(messages).flatten.map do |msg|
           msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -164,7 +164,7 @@ module Gcloud
       # Deletes an existing subscription.
       # All pending messages in the subscription are immediately dropped.
       #
-      # @return [Boolean] Returns +true+ if the subscription was deleted.
+      # @return [Boolean] Returns `true` if the subscription was deleted.
       #
       # @example
       #   require "gcloud"
@@ -188,19 +188,19 @@ module Gcloud
       ##
       # Pulls messages from the server. Returns an empty list if there are no
       # messages available in the backlog. Raises an ApiError with status
-      # +UNAVAILABLE+ if there are too many concurrent pull requests pending
+      # `UNAVAILABLE` if there are too many concurrent pull requests pending
       # for the given subscription.
       #
-      # @param [Boolean] immediate When +true+ the system will respond
-      #   immediately even if it is not able to return messages. When +false+
+      # @param [Boolean] immediate When `true` the system will respond
+      #   immediately even if it is not able to return messages. When `false`
       #   the system is allowed to wait until it can return least one message.
       #   No messages are returned when a request times out. The default value
-      #   is +true+.
+      #   is `true`.
       # @param [Integer] max The maximum number of messages to return for this
       #   request. The Pub/Sub system may return fewer than the number
-      #   specified. The default value is +100+, the maximum value is +1000+.
+      #   specified. The default value is `100`, the maximum value is `1000`.
       # @param [Boolean] autoack Automatically acknowledge the message as it is
-      #   pulled. The default value is +false+.
+      #   pulled. The default value is `false`.
       #
       # @return [Array<Gcloud::Pubsub::ReceivedMessage>]
       #
@@ -257,9 +257,9 @@ module Gcloud
       #
       # @param [Integer] max The maximum number of messages to return for this
       #   request. The Pub/Sub system may return fewer than the number
-      #   specified. The default value is +100+, the maximum value is +1000+.
+      #   specified. The default value is `100`, the maximum value is `1000`.
       # @param [Boolean] autoack Automatically acknowledge the message as it is
-      #   pulled. The default value is +false+.
+      #   pulled. The default value is `false`.
       #
       # @return [Array<Gcloud::Pubsub::ReceivedMessage>]
       #
@@ -283,12 +283,12 @@ module Gcloud
       #
       # @param [Integer] max The maximum number of messages to return for this
       #   request. The Pub/Sub system may return fewer than the number
-      #   specified. The default value is +100+, the maximum value is +1000+.
+      #   specified. The default value is `100`, the maximum value is `1000`.
       # @param [Boolean] autoack Automatically acknowledge the message as it is
-      #   pulled. The default value is +false+.
+      #   pulled. The default value is `false`.
       # @param [Number] delay The number of seconds to pause between requests
       #   when the Google Cloud service has no messages to return. The default
-      #   value is +1+.
+      #   value is `1`.
       #
       # @example
       #   require "gcloud"
@@ -301,7 +301,7 @@ module Gcloud
       #     # process msg
       #   end
       #
-      # @example Limit the number of messages pulled per batch with +max+:
+      # @example Limit the number of messages pulled per batch with `max`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -312,7 +312,7 @@ module Gcloud
       #     # process msg
       #   end
       #
-      # @example Automatically acknowledge messages with +autoack+:
+      # @example Automatically acknowledge messages with `autoack`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -376,8 +376,8 @@ module Gcloud
       #
       # @param [Integer] new_deadline The new ack deadline in seconds from the
       #   time this request is sent to the Pub/Sub system. Must be >= 0. For
-      #   example, if the value is +10+, the new ack deadline will expire 10
-      #   seconds after the call is made. Specifying +0+ may immediately make
+      #   example, if the value is `10`, the new ack deadline will expire 10
+      #   seconds after the call is made. Specifying `0` may immediately make
       #   the message available for another pull request.
       # @param [ReceivedMessage, String] *messages One or more {ReceivedMessage}
       #   objects or ack_id values.
@@ -412,7 +412,7 @@ module Gcloud
       # @param [Boolean] force Force the latest policy to be retrieved from the
       #   Pub/Sub service when +true. Otherwise the policy will be memoized to
       #   reduce the number of API calls made to the Pub/Sub service. The
-      #   default is +false+.
+      #   default is `false`.
       #
       # @return [Hash] Returns a hash that conforms to the following structure:
       #
@@ -434,7 +434,7 @@ module Gcloud
       #   puts subscription.policy["bindings"]
       #   puts subscription.policy["rules"]
       #
-      # @example Use +force+ to retrieve the latest policy from the service:
+      # @example Use `force` to retrieve the latest policy from the service:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -501,8 +501,8 @@ module Gcloud
       #   Policies
       #
       # @param [String, Array<String>] *permissions The set of permissions to
-      #   check access for. Permissions with wildcards (such as +*+ or
-      #   +storage.*+) are not allowed.
+      #   check access for. Permissions with wildcards (such as `*` or
+      #   `storage.*`) are not allowed.
       #
       # @return [Array<String>] The permissions that have access.
       #
@@ -559,8 +559,8 @@ module Gcloud
       end
 
       ##
-      # Makes sure the values are the +ack_id+.
-      # If given several {ReceivedMessage} objects extract the +ack_id+ values.
+      # Makes sure the values are the `ack_id`.
+      # If given several {ReceivedMessage} objects extract the `ack_id` values.
       def coerce_ack_ids messages
         Array(messages).flatten.map do |msg|
           msg.respond_to?(:ack_id) ? msg.ack_id : msg.to_s

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -20,7 +20,7 @@ require "gcloud/pubsub/received_message"
 module Gcloud
   module Pubsub
     ##
-    # = Subscription
+    # # Subscription
     #
     # A named resource representing the stream of messages from a single,
     # specific {Topic}, to be delivered to the subscribing application.

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -342,7 +342,7 @@ module Gcloud
       # Acknowledging a message more than once will not result in an error.
       # This is only used for messages received via pull.
       #
-      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      # @param [ReceivedMessage, String] *messages One or more {ReceivedMessage}
       #   objects or ack_id values.
       #
       # @example
@@ -379,7 +379,7 @@ module Gcloud
       #   example, if the value is +10+, the new ack deadline will expire 10
       #   seconds after the call is made. Specifying +0+ may immediately make
       #   the message available for another pull request.
-      # @param [ReceivedMessage, String] messages One or more {ReceivedMessage}
+      # @param [ReceivedMessage, String] *messages One or more {ReceivedMessage}
       #   objects or ack_id values.
       #
       # @example
@@ -500,7 +500,7 @@ module Gcloud
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies
       #
-      # @param [String, Array<String>] permissions The set of permissions to
+      # @param [String, Array<String>] *permissions The set of permissions to
       #   check access for. Permissions with wildcards (such as +*+ or
       #   +storage.*+) are not allowed.
       #

--- a/lib/gcloud/pubsub/subscription/list.rb
+++ b/lib/gcloud/pubsub/subscription/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/pubsub/subscription/list.rb
+++ b/lib/gcloud/pubsub/subscription/list.rb
@@ -24,7 +24,7 @@ module Gcloud
         ##
         # If not empty, indicates that there are more subscriptions
         # that match the request and this value should be passed to
-        # the next Gcloud::PubSub::Topic#subscriptions to continue.
+        # the next {Gcloud::PubSub::Topic#subscriptions} to continue.
         attr_accessor :token
 
         ##
@@ -35,8 +35,8 @@ module Gcloud
         end
 
         ##
-        # New Subscription::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Subscription::List from a response object.
+        def self.from_response resp, conn
           subs = Array(resp.data["subscriptions"]).map do |gapi_object|
             if gapi_object.is_a? String
               Subscription.new_lazy gapi_object, conn

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -403,7 +403,7 @@ module Gcloud
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies
       #
-      # @param [String, Array<String>] permissions The set of permissions to
+      # @param [String, Array<String>] *permissions The set of permissions to
       #   check access for. Permissions with wildcards (such as +*+ or
       #   +storage.*+) are not allowed.
       #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -313,7 +313,7 @@ module Gcloud
       # Gets the access control policy.
       #
       # @param [Boolean] force Force the latest policy to be retrieved from the
-      #   Pub/Sub service when +true. Otherwise the policy will be memoized to
+      #   Pub/Sub service when `true`. Otherwise the policy will be memoized to
       #   reduce the number of API calls made to the Pub/Sub service. The
       #   default is `false`.
       #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -25,6 +25,7 @@ module Gcloud
     #
     # A named resource to which messages are published.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -35,16 +36,16 @@ module Gcloud
     #
     class Topic
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Topic object.
-      def initialize #:nodoc:
+      # @private Create an empty {Topic} object.
+      def initialize
         @connection = nil
         @gapi = {}
         @name = nil
@@ -52,8 +53,8 @@ module Gcloud
       end
 
       ##
-      # New lazy Topic object without making an HTTP request.
-      def self.new_lazy name, conn, options = {} #:nodoc:
+      # @private New lazy {Topic} object without making an HTTP request.
+      def self.new_lazy name, conn, options = {}
         new.tap do |t|
           t.gapi = nil
           t.connection = conn
@@ -73,12 +74,9 @@ module Gcloud
       ##
       # Permanently deletes the topic.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the topic was deleted.
       #
-      # +true+ if the topic was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -98,29 +96,22 @@ module Gcloud
       end
 
       ##
-      # Creates a new Subscription object on the current Topic.
+      # Creates a new {Subscription} object on the current Topic.
       #
-      # === Parameters
+      # @param [String] subscription_name Name of the new subscription. Must
+      #   start with a letter, and contain only letters ([A-Za-z]), numbers
+      #   ([0-9], dashes (-), underscores (_), periods (.), tildes (~), plus (+)
+      #   or percent signs (%). It must be between 3 and 255 characters in
+      #   length, and it must not start with "goog".
+      # @param [Integer] deadline The maximum number of seconds after a
+      #   subscriber receives a message before the subscriber should acknowledge
+      #   the message.
+      # @param [String] endpoint A URL locating the endpoint to which messages
+      #   should be pushed.
       #
-      # +subscription_name+::
-      #   Name of the new subscription. Must start with a letter, and contain
-      #   only letters ([A-Za-z]), numbers ([0-9], dashes (-), underscores (_),
-      #   periods (.), tildes (~), plus (+) or percent signs (%). It must be
-      #   between 3 and 255 characters in length, and it must not start with
-      #   "goog". (+String+)
-      # +deadline+::
-      #   The maximum number of seconds after a subscriber receives a message
-      #   before the subscriber should acknowledge the message. (+Integer+)
-      # +endpoint+::
-      #   A URL locating the endpoint to which messages should be pushed.
-      #   e.g. "https://example.com/push" (+String+)
+      # @return [Gcloud::Pubsub::Subscription]
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -130,7 +121,7 @@ module Gcloud
       #   sub = topic.subscribe "my-topic-sub"
       #   puts sub.name # => "my-topic-sub"
       #
-      # The name is optional, and will be generated if not given.
+      # @example The name is optional, and will be generated if not given:
       #
       #   require "gcloud"
       #
@@ -141,8 +132,7 @@ module Gcloud
       #   sub = topic.subscribe "my-topic-sub"
       #   puts sub.name # => "generated-sub-name"
       #
-      # The subscription can be created that waits two minutes for
-      # acknowledgement and pushed all messages to an endpoint
+      # @example Wait 2 minutes for acknowledgement and push all to an endpoint:
       #
       #   require "gcloud"
       #
@@ -170,22 +160,16 @@ module Gcloud
       ##
       # Retrieves subscription by name.
       #
-      # === Parameters
+      # @param [String] subscription_name Name of a subscription.
+      # @param [Boolean] skip_lookup Optionally create a {Subscription} object
+      #   without verifying the subscription resource exists on the Pub/Sub
+      #   service. Calls made on this object will raise errors if the service
+      #   resource does not exist. Default is +false+.
       #
-      # +subscription_name+::
-      #   Name of a subscription. (+String+)
-      # +skip_lookup+::
-      #   Optionally create a Subscription object without verifying the
-      #   subscription resource exists on the Pub/Sub service. Calls made on
-      #   this object will raise errors if the service resource does not exist.
-      #   Default is +false+. (+Boolean+)
+      # @return [Gcloud::Pubsub::Subscription, nil] Returns +nil+ if
+      #   the subscription does not exist.
       #
-      # === Returns
-      #
-      # Gcloud::Pubsub::Subscription or nil if subscription does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -195,9 +179,7 @@ module Gcloud
       #   subscription = topic.subscription "my-topic-subscription"
       #   puts subscription.name
       #
-      # The lookup against the Pub/Sub service can be skipped using the
-      # +skip_lookup+ option:
-      #
+      # @example Skip the lookup against the service with +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -223,21 +205,14 @@ module Gcloud
       ##
       # Retrieves a list of subscription names for the given project.
       #
-      # === Parameters
+      # @param [String] token The +token+ value returned by the last call to
+      #   +subscriptions+; indicates that this is a continuation of a call, and
+      #   that the system should return the next page of data.
+      # @param [Integer] max Maximum number of subscriptions to return.
       #
-      # +token+::
-      #   The +token+ value returned by the last call to +subscriptions+;
-      #   indicates that this is a continuation of a call, and that the system
-      #   should return the next page of data. (+String+)
-      # +max+::
-      #   Maximum number of subscriptions to return. (+Integer+)
+      # @return [Array<Subscription>] (See {Subscription::List})
       #
-      # === Returns
-      #
-      # Array of Subscription objects (See Subscription::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -249,8 +224,7 @@ module Gcloud
       #     puts subscription.name
       #   end
       #
-      # If you have a significant number of subscriptions, you may need to
-      # paginate through them: (See Subscription::List#token)
+      # @example With pagination: (See {Subscription::List#token})
       #
       #   require "gcloud"
       #
@@ -286,20 +260,14 @@ module Gcloud
       ##
       # Publishes one or more messages to the topic.
       #
-      # === Parameters
+      # @param [String] data The message data.
+      # @param [Hash] attributes Optional attributes for the message.
       #
-      # +data+::
-      #   The message data. (+String+)
-      # +attributes+::
-      #   Optional attributes for the message. (+Hash+)
+      # @return [Message, Array<Message>] Returns the published message when
+      #   called without a block, or an array of messages when called with a
+      #   block.
       #
-      # === Returns
-      #
-      # Message object when called without a block,
-      # Array of Message objects when called with a block
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -308,7 +276,7 @@ module Gcloud
       #   topic = pubsub.topic "my-topic"
       #   msg = topic.publish "new-message"
       #
-      # Additionally, a message can be published with attributes:
+      # @example Additionally, a message can be published with attributes:
       #
       #   require "gcloud"
       #
@@ -320,8 +288,7 @@ module Gcloud
       #                       foo: :bar,
       #                       this: :that
       #
-      # Multiple messages can be published at the same time by passing a block:
-      #
+      # @example Multiple messages can be sent at the same time using a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -345,17 +312,12 @@ module Gcloud
       ##
       # Gets the access control policy.
       #
-      # === Parameters
+      # @param [Boolean] force Force the latest policy to be retrieved from the
+      #   Pub/Sub service when +true. Otherwise the policy will be memoized to
+      #   reduce the number of API calls made to the Pub/Sub service. The
+      #   default is +false+.
       #
-      # +force+::
-      #   Force the latest policy to be retrieved from the Pub/Sub service when
-      #   +true. Otherwise the policy will be memoized to reduce the number of
-      #   API calls made to the Pub/Sub service. The default is +false+.
-      #   (+Boolean+)
-      #
-      # === Returns
-      #
-      # A hash that conforms to the following structure:
+      # @return [Hash] Returns a hash that conforms to the following structure:
       #
       #   {
       #     "etag"=>"CAE=",
@@ -365,11 +327,7 @@ module Gcloud
       #     }]
       #   }
       #
-      # === Examples
-      #
-      # By default, the policy values are memoized to reduce the number of API
-      # calls to the Pub/Sub service.
-      #
+      # @example Policy values are memoized to reduce the number of API calls:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -379,9 +337,7 @@ module Gcloud
       #   puts topic.policy["bindings"]
       #   puts topic.policy["rules"]
       #
-      # To retrieve the latest policy from the Pub/Sub service, use the +force+
-      # flag.
-      #
+      # @example Use +force+ to retrieve the latest policy from the service:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -404,10 +360,8 @@ module Gcloud
       ##
       # Sets the access control policy.
       #
-      # === Parameters
-      #
-      # +new_policy+::
-      #   A hash that conforms to the following structure:
+      # @param [String] new_policy A hash that conforms to the following
+      #   structure:
       #
       #     {
       #       "bindings" => [{
@@ -416,8 +370,7 @@ module Gcloud
       #       }]
       #     }
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -445,23 +398,18 @@ module Gcloud
 
       ##
       # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy. See
-      # {Managing Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # IAM}[https://cloud.google.com/iam/] access control policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +permissions+::
-      #   The set of permissions to check access for. Permissions with wildcards
-      #   (such as +*+ or +storage.*+) are not allowed.
-      #   (String or Array of Strings)
+      # @param [String, Array<String>] permissions The set of permissions to
+      #   check access for. Permissions with wildcards (such as +*+ or
+      #   +storage.*+) are not allowed.
       #
-      # === Returns
+      # @return [Array<Strings>] The permissions that have access.
       #
-      # The permissions that have access. (Array of Strings)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -486,8 +434,7 @@ module Gcloud
       ##
       # Determines whether the topic exists in the Pub/Sub service.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -506,10 +453,10 @@ module Gcloud
       end
 
       ##
+      # @private
       # Determines whether the topic object was created with an HTTP call.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -518,13 +465,13 @@ module Gcloud
       #   topic = pubsub.topic "my-topic"
       #   topic.lazy? #=> false
       #
-      def lazy? #:nodoc:
+      def lazy?
         @gapi.nil?
       end
 
       ##
-      # New Topic from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New {Topic} from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -563,12 +510,12 @@ module Gcloud
       # Batch object used to publish multiple messages at once.
       class Batch
         ##
-        # The messages to publish
-        attr_reader :messages #:nodoc:
+        # @private The messages to publish
+        attr_reader :messages
 
         ##
-        # Create a new instance of the object.
-        def initialize data = nil, attributes = {} #:nodoc:
+        # @private Create a new instance of the object.
+        def initialize data = nil, attributes = {}
           @messages = []
           @mode = :batch
           return if data.nil?
@@ -579,14 +526,14 @@ module Gcloud
         ##
         # Add multiple messages to the topic.
         # All messages added will be published at once.
-        # See Gcloud::Pubsub::Topic#publish
+        # See {Gcloud::Pubsub::Topic#publish}
         def publish data, attributes = {}
           @messages << [data, attributes]
         end
 
         ##
-        # Create Message objects with message ids.
-        def to_gcloud_messages message_ids #:nodoc:
+        # @private Create Message objects with message ids.
+        def to_gcloud_messages message_ids
           msgs = @messages.zip(Array(message_ids)).map do |arr, id|
             Message.from_gapi "data"       => arr[0],
                               "attributes" => jsonify_hash(arr[1]),

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "json"
 require "gcloud/pubsub/errors"

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -397,8 +397,8 @@ module Gcloud
       end
 
       ##
-      # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy.
+      # Tests the specified permissions against the [Cloud
+      # IAM](https://cloud.google.com/iam/) access control policy.
       #
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -21,7 +21,7 @@ require "gcloud/pubsub/subscription"
 module Gcloud
   module Pubsub
     ##
-    # = Topic
+    # # Topic
     #
     # A named resource to which messages are published.
     #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -74,7 +74,7 @@ module Gcloud
       ##
       # Permanently deletes the topic.
       #
-      # @return [Boolean] Returns +true+ if the topic was deleted.
+      # @return [Boolean] Returns `true` if the topic was deleted.
       #
       # @example
       #   require "gcloud"
@@ -164,9 +164,9 @@ module Gcloud
       # @param [Boolean] skip_lookup Optionally create a {Subscription} object
       #   without verifying the subscription resource exists on the Pub/Sub
       #   service. Calls made on this object will raise errors if the service
-      #   resource does not exist. Default is +false+.
+      #   resource does not exist. Default is `false`.
       #
-      # @return [Gcloud::Pubsub::Subscription, nil] Returns +nil+ if
+      # @return [Gcloud::Pubsub::Subscription, nil] Returns `nil` if
       #   the subscription does not exist.
       #
       # @example
@@ -179,7 +179,7 @@ module Gcloud
       #   subscription = topic.subscription "my-topic-subscription"
       #   puts subscription.name
       #
-      # @example Skip the lookup against the service with +skip_lookup+:
+      # @example Skip the lookup against the service with `skip_lookup`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -205,8 +205,8 @@ module Gcloud
       ##
       # Retrieves a list of subscription names for the given project.
       #
-      # @param [String] token The +token+ value returned by the last call to
-      #   +subscriptions+; indicates that this is a continuation of a call, and
+      # @param [String] token The `token` value returned by the last call to
+      #   `subscriptions`; indicates that this is a continuation of a call, and
       #   that the system should return the next page of data.
       # @param [Integer] max Maximum number of subscriptions to return.
       #
@@ -315,7 +315,7 @@ module Gcloud
       # @param [Boolean] force Force the latest policy to be retrieved from the
       #   Pub/Sub service when +true. Otherwise the policy will be memoized to
       #   reduce the number of API calls made to the Pub/Sub service. The
-      #   default is +false+.
+      #   default is `false`.
       #
       # @return [Hash] Returns a hash that conforms to the following structure:
       #
@@ -337,7 +337,7 @@ module Gcloud
       #   puts topic.policy["bindings"]
       #   puts topic.policy["rules"]
       #
-      # @example Use +force+ to retrieve the latest policy from the service:
+      # @example Use `force` to retrieve the latest policy from the service:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -404,8 +404,8 @@ module Gcloud
       #   Policies
       #
       # @param [String, Array<String>] *permissions The set of permissions to
-      #   check access for. Permissions with wildcards (such as +*+ or
-      #   +storage.*+) are not allowed.
+      #   check access for. Permissions with wildcards (such as `*` or
+      #   `storage.*`) are not allowed.
       #
       # @return [Array<Strings>] The permissions that have access.
       #

--- a/lib/gcloud/pubsub/topic/list.rb
+++ b/lib/gcloud/pubsub/topic/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/pubsub/topic/list.rb
+++ b/lib/gcloud/pubsub/topic/list.rb
@@ -24,7 +24,7 @@ module Gcloud
         ##
         # If not empty, indicates that there are more topics
         # that match the request and this value should be passed to
-        # the next Gcloud::PubSub::Project#topics to continue.
+        # the next {Gcloud::PubSub::Project#topics} to continue.
         attr_accessor :token
 
         ##
@@ -35,8 +35,8 @@ module Gcloud
         end
 
         ##
-        # New Topic::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Topic::List from a response object.
+        def self.from_response resp, conn
           topics = Array(resp.data["topics"]).map do |gapi_object|
             Topic.from_gapi gapi_object, conn
           end

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -22,7 +22,7 @@ module Gcloud
   # Creates a new +Project+ instance connected to the Resource Manager service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +keyfile+::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
@@ -37,11 +37,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/cloud-platform+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::ResourceManager::Manager
   #
-  # === Example
+  # ### Example
   #
   #   require "gcloud/resource_manager"
   #
@@ -64,7 +64,7 @@ module Gcloud
   # Disabled because there are links in the docs that are long.
 
   ##
-  # = Google Cloud Resource Manager
+  # # Google Cloud Resource Manager
   #
   # The Resource Manager API provides methods that you can use to
   # programmatically manage your projects in the Google Cloud Platform. You may
@@ -81,7 +81,7 @@ module Gcloud
   # The Resource Manager API is a Beta release and is not covered by any SLA or
   # deprecation policy and may be subject to backward-incompatible changes.
   #
-  # == Accessing the Service
+  # ## Accessing the Service
   #
   # Currently, the full functionality of the Resource Manager API is available
   # only to whitelisted users. (Contact your account manager or a member of the
@@ -91,7 +91,7 @@ module Gcloud
   # Resource Manager API in the {Developers
   # Console}[https://console.developers.google.com].
   #
-  # == Authentication
+  # ## Authentication
   #
   # The Resource Manager API currently requires authentication of a {User
   # Account}[https://developers.google.com/identity/protocols/OAuth2], and
@@ -111,7 +111,7 @@ module Gcloud
   #   gcloud = Gcloud.new
   #   resource_manager = gcloud.resource_manager
   #
-  # == Listing Projects
+  # ## Listing Projects
   #
   # Project is a collection of settings, credentials, and metadata about the
   # application or applications you're working on. You can retrieve and inspect
@@ -125,7 +125,7 @@ module Gcloud
   #     puts projects.project_id
   #   end
   #
-  # == Managing Projects with Labels
+  # ## Managing Projects with Labels
   #
   # Labels can be added to or removed from projects. (See Project#labels)
   #
@@ -151,7 +151,7 @@ module Gcloud
   #     puts project.project_id
   #   end
   #
-  # == Creating a Project
+  # ## Creating a Project
   #
   # You can also use the API to create new projects. (See
   # Manager#create_project)
@@ -164,7 +164,7 @@ module Gcloud
   #                                             name: "Todos Development",
   #                                             labels: {env: :development}
   #
-  # == Deleting a Project
+  # ## Deleting a Project
   #
   # You can delete projects when they are no longer needed. (See
   # Manager#delete and Project#delete)
@@ -175,7 +175,7 @@ module Gcloud
   #   resource_manager = gcloud.resource_manager
   #   resource_manager.delete "tokyo-rain-123"
   #
-  # == Undeleting a Project
+  # ## Undeleting a Project
   #
   # You can also restore a deleted project within the waiting period that
   # starts when the project was deleted. Restoring a project returns it to the
@@ -188,7 +188,7 @@ module Gcloud
   #   resource_manager = gcloud.resource_manager
   #   resource_manager.undelete "tokyo-rain-123"
   #
-  # == Managing IAM Policies
+  # ## Managing IAM Policies
   #
   # Google Cloud Identity and Access Management ({Cloud
   # IAM}[https://cloud.google.com/iam/]) access control policies can be managed

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -19,23 +19,23 @@ require "gcloud/resource_manager/manager"
 # Google Cloud Resource Manager
 module Gcloud
   ##
-  # Creates a new +Project+ instance connected to the Resource Manager service.
+  # Creates a new `Project` instance connected to the Resource Manager service.
   # Each call creates a new connection.
   #
   # ### Parameters
   #
-  # +keyfile+::
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
-  # +scope+::
+  #   readable. (`String` or `Hash`)
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/cloud-platform+
+  #   * `https://www.googleapis.com/auth/cloud-platform`
   #
   # ### Returns
   #
@@ -102,7 +102,7 @@ module Gcloud
   #
   #   $ gcloud auth login
   #
-  # Also make sure all +GCLOUD+ environment variables are cleared of any service
+  # Also make sure all `GCLOUD` environment variables are cleared of any service
   # accounts. Then gcloud will be able to detect the user authentication and
   # connect with those credentials.
   #

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 require "gcloud/resource_manager/manager"
 
-#--
-# Google Cloud Resource Manager
 module Gcloud
   ##
   # Creates a new `Project` instance connected to the Resource Manager service.

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -60,9 +60,6 @@ module Gcloud
     Gcloud::ResourceManager::Manager.new credentials
   end
 
-  # rubocop:disable Metrics/LineLength
-  # Disabled because there are links in the docs that are long.
-
   ##
   # # Google Cloud Resource Manager
   #
@@ -100,16 +97,20 @@ module Gcloud
   # To use a User Account install the [Google Cloud
   # SDK](http://cloud.google.com/sdk) and authenticate with the following:
   #
-  #   $ gcloud auth login
+  # ```
+  # $ gcloud auth login
+  # ```
   #
   # Also make sure all `GCLOUD` environment variables are cleared of any service
   # accounts. Then gcloud will be able to detect the user authentication and
   # connect with those credentials.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # ```
   #
   # ## Listing Projects
   #
@@ -117,63 +118,73 @@ module Gcloud
   # application or applications you're working on. You can retrieve and inspect
   # all projects that you have permissions to. (See Manager#projects)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   resource_manager.projects.each do |project|
-  #     puts projects.project_id
-  #   end
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # resource_manager.projects.each do |project|
+  #   puts projects.project_id
+  # end
+  # ```
   #
   # ## Managing Projects with Labels
   #
   # Labels can be added to or removed from projects. (See Project#labels)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   project = resource_manager.project "tokyo-rain-123"
-  #   # Label the project as production
-  #   project.update do |p|
-  #     p.labels["env"] = "production"
-  #   end
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # project = resource_manager.project "tokyo-rain-123"
+  # # Label the project as production
+  # project.update do |p|
+  #   p.labels["env"] = "production"
+  # end
+  # ```
   #
   # Projects can then be filtered by labels. (See Manager#projects)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   # Find only the productions projects
-  #   projects = resource_manager.projects filter: "labels.env:production"
-  #   projects.each do |project|
-  #     puts project.project_id
-  #   end
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # # Find only the productions projects
+  # projects = resource_manager.projects filter: "labels.env:production"
+  # projects.each do |project|
+  #   puts project.project_id
+  # end
+  # ```
   #
   # ## Creating a Project
   #
   # You can also use the API to create new projects. (See
   # Manager#create_project)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   project = resource_manager.create_project "tokyo-rain-123",
-  #                                             name: "Todos Development",
-  #                                             labels: {env: :development}
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # project = resource_manager.create_project "tokyo-rain-123",
+  #                                           name: "Todos Development",
+  #                                           labels: {env: :development}
+  # ```
   #
   # ## Deleting a Project
   #
   # You can delete projects when they are no longer needed. (See
   # Manager#delete and Project#delete)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   resource_manager.delete "tokyo-rain-123"
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # resource_manager.delete "tokyo-rain-123"
+  # ```
   #
   # ## Undeleting a Project
   #
@@ -182,11 +193,13 @@ module Gcloud
   # state it was in prior to being deleted. (See Manager#undelete and
   # Project#undelete)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   resource_manager.undelete "tokyo-rain-123"
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # resource_manager.undelete "tokyo-rain-123"
+  # ```
   #
   # ## Managing IAM Policies
   #
@@ -198,46 +211,50 @@ module Gcloud
   #
   # A project's access control policy can be retrieved. (See Project#policy)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   project = resource_manager.project "tokyo-rain-123"
-  #   policy = project.policy
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # project = resource_manager.project "tokyo-rain-123"
+  # policy = project.policy
+  # ```
   #
   # A project's access control policy can also be set. (See Project#policy=)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   project = resource_manager.project "tokyo-rain-123"
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # project = resource_manager.project "tokyo-rain-123"
   #
-  #   viewer_policy = {
-  #     "bindings" => [{
-  #       "role" => "roles/viewer",
-  #       "members" => ["serviceAccount:your-service-account"]
-  #     }]
-  #   }
-  #   project.policy = viewer_policy
+  # viewer_policy = {
+  #   "bindings" => [{
+  #     "role" => "roles/viewer",
+  #     "members" => ["serviceAccount:your-service-account"]
+  #   }]
+  # }
+  # project.policy = viewer_policy
+  # ```
   #
   # And permissions can be tested on a project. (See Project#test_permissions)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   resource_manager = gcloud.resource_manager
-  #   project = resource_manager.project "tokyo-rain-123"
-  #   perms = project.test_permissions "resourcemanager.projects.get",
-  #                                    "resourcemanager.projects.delete"
-  #   perms.include? "resourcemanager.projects.get"    #=> true
-  #   perms.include? "resourcemanager.projects.delete" #=> false
+  # gcloud = Gcloud.new
+  # resource_manager = gcloud.resource_manager
+  # project = resource_manager.project "tokyo-rain-123"
+  # perms = project.test_permissions "resourcemanager.projects.get",
+  #                                  "resourcemanager.projects.delete"
+  # perms.include? "resourcemanager.projects.get"    #=> true
+  # perms.include? "resourcemanager.projects.delete" #=> false
+  # ```
   #
   # For more information about using access control policies see [Managing
   # Policies](https://cloud.google.com/iam/docs/managing-policies).
   #
   module ResourceManager
   end
-
-  # rubocop:enable Metrics/LineLength
 end

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -21,27 +21,20 @@ module Gcloud
   # Creates a new `Project` instance connected to the Resource Manager service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
   #
-  # ### Returns
+  # @return [Gcloud::ResourceManager::Manager]
   #
-  # Gcloud::ResourceManager::Manager
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/resource_manager"
   #
   #   resource_manager = Gcloud.resource_manager

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -29,8 +29,8 @@ module Gcloud
   #   readable. (+String+ or +Hash+)
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -68,8 +68,8 @@ module Gcloud
   #
   # The Resource Manager API provides methods that you can use to
   # programmatically manage your projects in the Google Cloud Platform. You may
-  # be familiar with managing projects in the {Developers
-  # Console}[https://developers.google.com/console/help/new/]. With this API you
+  # be familiar with managing projects in the [Developers
+  # Console](https://developers.google.com/console/help/new/). With this API you
   # can do the following:
   #
   # * Get a list of all projects associated with an account
@@ -88,17 +88,17 @@ module Gcloud
   # Google Cloud sales team if you are interested in access.) Read-only methods
   # such as ResourceManager::Manager#projects and
   # ResourceManager::Manager#project are accessible to any user who enables the
-  # Resource Manager API in the {Developers
-  # Console}[https://console.developers.google.com].
+  # Resource Manager API in the [Developers
+  # Console](https://console.developers.google.com).
   #
   # ## Authentication
   #
-  # The Resource Manager API currently requires authentication of a {User
-  # Account}[https://developers.google.com/identity/protocols/OAuth2], and
-  # cannot currently be accessed with a {Service
-  # Account}[https://developers.google.com/identity/protocols/OAuth2ServiceAccount].
-  # To use a User Account install the {Google Cloud
-  # SDK}[http://cloud.google.com/sdk] and authenticate with the following:
+  # The Resource Manager API currently requires authentication of a [User
+  # Account](https://developers.google.com/identity/protocols/OAuth2), and
+  # cannot currently be accessed with a [Service
+  # Account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount).
+  # To use a User Account install the [Google Cloud
+  # SDK](http://cloud.google.com/sdk) and authenticate with the following:
   #
   #   $ gcloud auth login
   #
@@ -190,11 +190,11 @@ module Gcloud
   #
   # ## Managing IAM Policies
   #
-  # Google Cloud Identity and Access Management ({Cloud
-  # IAM}[https://cloud.google.com/iam/]) access control policies can be managed
+  # Google Cloud Identity and Access Management ([Cloud
+  # IAM](https://cloud.google.com/iam/)) access control policies can be managed
   # on projects. These policies allow project owners to manage _who_ (identity)
-  # has access to _what_ (role). See {Cloud IAM
-  # Overview}[https://cloud.google.com/iam/docs/overview] for more information.
+  # has access to _what_ (role). See [Cloud IAM
+  # Overview](https://cloud.google.com/iam/docs/overview) for more information.
   #
   # A project's access control policy can be retrieved. (See Project#policy)
   #
@@ -233,8 +233,8 @@ module Gcloud
   #   perms.include? "resourcemanager.projects.get"    #=> true
   #   perms.include? "resourcemanager.projects.delete" #=> false
   #
-  # For more information about using access control policies see {Managing
-  # Policies}[https://cloud.google.com/iam/docs/managing-policies].
+  # For more information about using access control policies see [Managing
+  # Policies](https://cloud.google.com/iam/docs/managing-policies).
   #
   module ResourceManager
   end

--- a/lib/gcloud/resource_manager/connection.rb
+++ b/lib/gcloud/resource_manager/connection.rb
@@ -19,16 +19,17 @@ require "google/api_client"
 module Gcloud
   module ResourceManager
     ##
+    # @private
     # Represents the connection to Resource Manager, as well as expose the API
     # calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1beta1"
 
-      attr_accessor :credentials #:nodoc:
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
-      def initialize credentials #:nodoc:
+      def initialize credentials
         @credentials = credentials
         @client = Google::APIClient.new application_name:    "gcloud-ruby",
                                         application_version: Gcloud::VERSION
@@ -116,7 +117,7 @@ module Gcloud
         )
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
     end

--- a/lib/gcloud/resource_manager/connection.rb
+++ b/lib/gcloud/resource_manager/connection.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/version"
 require "google/api_client"

--- a/lib/gcloud/resource_manager/credentials.rb
+++ b/lib/gcloud/resource_manager/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module ResourceManager
     ##
-    # Represents the Oauth2 signing logic for Resource Manager.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the Oauth2 signing logic for Resource Manager.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/cloud-platform"]
       PATH_ENV_VARS = %w(RESOURCE_MANAGER_KEYFILE
                          GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)

--- a/lib/gcloud/resource_manager/credentials.rb
+++ b/lib/gcloud/resource_manager/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/credentials"
 

--- a/lib/gcloud/resource_manager/errors.rb
+++ b/lib/gcloud/resource_manager/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/errors"
 

--- a/lib/gcloud/resource_manager/errors.rb
+++ b/lib/gcloud/resource_manager/errors.rb
@@ -33,13 +33,15 @@ module Gcloud
       # The errors encountered.
       attr_reader :errors
 
-      def initialize message, code, errors = [] #:nodoc:
+      # @private
+      def initialize message, code, errors = []
         super message
         @code   = code
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         if resp.data? && resp.data["error"]
           from_response_data resp.data["error"]
         else
@@ -47,11 +49,13 @@ module Gcloud
         end
       end
 
-      def self.from_response_data error #:nodoc:
+      # @private
+      def self.from_response_data error
         new error["message"], error["code"], error["errors"]
       end
 
-      def self.from_response_status resp #:nodoc:
+      # @private
+      def self.from_response_status resp
         if resp.status == 404
           new "#{resp.error_message}: #{resp.request.uri.request_uri}",
               resp.status

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -33,17 +33,17 @@ module Gcloud
     #     puts projects.project_id
     #   end
     #
-    # See Gcloud#resource_manager
+    # See {Gcloud#resource_manager}
     class Manager
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Connection instance.
+      # @private Creates a new Connection instance.
       #
-      # See Gcloud.resource_manager
-      def initialize credentials #:nodoc:
+      # See {Gcloud.resource_manager}
+      def initialize credentials
         @connection = Connection.new credentials
       end
 
@@ -52,11 +52,8 @@ module Gcloud
       # specified filter. This method returns projects in an unspecified order.
       # New projects do not necessarily appear at the end of the list.
       #
-      # === Parameters
-      #
-      # +filter+::
-      #   An expression for filtering the results of the request. Filter rules
-      #   are case insensitive. (+String+)
+      # @param [String] filter An expression for filtering the results of the
+      #   request. Filter rules are case insensitive.
       #
       #   The fields eligible for filtering are:
       #   * +name+
@@ -72,19 +69,14 @@ module Gcloud
       #   * +labels.color:red+ - The project's label color has the value red.
       #   * <code>labels.color:red labels.size:big</code> - The project's label
       #     color has the value red and its label size has the value big.
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of projects to return. (+Integer+)
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of projects to return.
       #
-      # === Returns
+      # @return [Array<Gcloud::ResourceManager::Project>] (See
+      #   {Gcloud::ResourceManager::Project::List})
       #
-      # Array of Gcloud::ResourceManager::Project
-      # (See Gcloud::ResourceManager::Project::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -94,8 +86,7 @@ module Gcloud
       #     puts project.project_id
       #   end
       #
-      # Projects can be filtered using the +filter+ option:
-      #
+      # @example Projects can be filtered using the +filter+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -105,9 +96,7 @@ module Gcloud
       #     puts project.project_id
       #   end
       #
-      # If you have a significant number of projects, you may need to paginate
-      # through them: (See Gcloud::ResourceManager::Project::List)
-      #
+      # @example With pagination: (See {Gcloud::ResourceManager::Project::List})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -129,17 +118,12 @@ module Gcloud
       ##
       # Retrieves the project identified by the specified +project_id+.
       #
-      # === Parameters
+      # @param [String] project_id The ID of the project.
       #
-      # +project_id+::
-      #   The ID of the project. (+String+)
+      # @return [Gcloud::ResourceManager::Project, nil] Returns +nil+ if the
+      #   project does not exist
       #
-      # === Returns
-      #
-      # Gcloud::ResourceManager::Project, or +nil+ if the project does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -166,21 +150,15 @@ module Gcloud
       # Several APIs are activated automatically for the project, including
       # Google Cloud Storage.
       #
-      # === Parameters
-      #
-      # +project_id+::
-      #   The unique, user-assigned ID of the project. It must be 6 to 30
-      #   lowercase letters, digits, or hyphens. It must start with a letter.
-      #   Trailing hyphens are prohibited. (+String+)
-      # +name+::
-      #   The user-assigned name of the project. This field is optional and can
-      #   remain unset.
+      # @param [String] project_id The unique, user-assigned ID of the project.
+      #   It must be 6 to 30 lowercase letters, digits, or hyphens. It must
+      #   start with a letter. Trailing hyphens are prohibited.
+      # @param [String] name The user-assigned name of the project. This field
+      #   is optional and can remain unset.
       #
       #   Allowed characters are: lowercase and uppercase letters, numbers,
       #   hyphen, single-quote, double-quote, space, and exclamation point.
-      #   (+String+)
-      # +labels+::
-      #   The labels associated with this project.
+      # @param [Hash] labels The labels associated with this project.
       #
       #   Label keys must be between 1 and 63 characters long and must conform
       #   to the following regular expression:
@@ -190,22 +168,17 @@ module Gcloud
       #   to the regular expression <code>([a-z]([-a-z0-9]*[a-z0-9])?)?</code>.
       #
       #   No more than 256 labels can be associated with a given resource.
-      #   (+Hash+)
       #
-      # === Returns
+      # @return [Gcloud::ResourceManager::Project]
       #
-      # Gcloud::ResourceManager::Project
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   resource_manager = gcloud.resource_manager
       #   project = resource_manager.create_project "tokyo-rain-123"
       #
-      # A project can also be created with a +name+ and +labels+.
-      #
+      # @example A project can also be created with a +name+ and +labels+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -244,13 +217,9 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Parameters
+      # @param [String] project_id The ID of the project.
       #
-      # +project_id+::
-      #   The ID of the project. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -274,13 +243,9 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Parameters
+      # @param [String] project_id The ID of the project.
       #
-      # +project_id+::
-      #   The ID of the project. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/resource_manager/credentials"
 require "gcloud/resource_manager/connection"

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -56,17 +56,17 @@ module Gcloud
       #   request. Filter rules are case insensitive.
       #
       #   The fields eligible for filtering are:
-      #   * +name+
-      #   * +id+
-      #   * +labels.key+ - where +key+ is the name of a label
+      #   * `name`
+      #   * `id`
+      #   * `labels.key` - where `key` is the name of a label
       #
       #   Some examples of using labels as filters:
-      #   * +name:*+ - The project has a name.
-      #   * +name:Howl+ - The project's name is Howl or howl.
-      #   * +name:HOWL+ - Equivalent to above.
-      #   * +NAME:howl+ - Equivalent to above.
-      #   * +labels.color:*+ - The project has the label color.
-      #   * +labels.color:red+ - The project's label color has the value red.
+      #   * `name:*` - The project has a name.
+      #   * `name:Howl` - The project's name is Howl or howl.
+      #   * `name:HOWL` - Equivalent to above.
+      #   * `NAME:howl` - Equivalent to above.
+      #   * `labels.color:*` - The project has the label color.
+      #   * `labels.color:red` - The project's label color has the value red.
       #   * <code>labels.color:red labels.size:big</code> - The project's label
       #     color has the value red and its label size has the value big.
       # @param [String] token A previously-returned page token representing part
@@ -86,7 +86,7 @@ module Gcloud
       #     puts project.project_id
       #   end
       #
-      # @example Projects can be filtered using the +filter+ option:
+      # @example Projects can be filtered using the `filter` option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -116,11 +116,11 @@ module Gcloud
       end
 
       ##
-      # Retrieves the project identified by the specified +project_id+.
+      # Retrieves the project identified by the specified `project_id`.
       #
       # @param [String] project_id The ID of the project.
       #
-      # @return [Gcloud::ResourceManager::Project, nil] Returns +nil+ if the
+      # @return [Gcloud::ResourceManager::Project, nil] Returns `nil` if the
       #   project does not exist
       #
       # @example
@@ -178,7 +178,7 @@ module Gcloud
       #   resource_manager = gcloud.resource_manager
       #   project = resource_manager.create_project "tokyo-rain-123"
       #
-      # @example A project can also be created with a +name+ and +labels+:
+      # @example A project can also be created with a `name` and `labels`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -203,10 +203,10 @@ module Gcloud
       # if the following criteria are met:
       #
       # * The project does not have a billing account associated with it.
-      # * The project has a lifecycle state of +ACTIVE+.
-      # * This method changes the project's lifecycle state from +ACTIVE+ to
-      #   +DELETE_REQUESTED+. The deletion starts at an unspecified time, at
-      #   which point the lifecycle state changes to +DELETE_IN_PROGRESS+.
+      # * The project has a lifecycle state of `ACTIVE`.
+      # * This method changes the project's lifecycle state from `ACTIVE` to
+      #   `DELETE_REQUESTED`. The deletion starts at an unspecified time, at
+      #   which point the lifecycle state changes to `DELETE_IN_PROGRESS`.
       #
       # Until the deletion completes, you can check the lifecycle state by
       # retrieving the project with Manager#project. The project remains visible
@@ -237,8 +237,8 @@ module Gcloud
 
       ##
       # Restores the project. You can only use this method for a project that
-      # has a lifecycle state of +DELETE_REQUESTED+. After deletion starts, as
-      # indicated by a lifecycle state of +DELETE_IN_PROGRESS+, the project
+      # has a lifecycle state of `DELETE_REQUESTED`. After deletion starts, as
+      # indicated by a lifecycle state of `DELETE_IN_PROGRESS`, the project
       # cannot be restored.
       #
       # The caller must have modify permissions for this project.

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -21,7 +21,7 @@ require "gcloud/resource_manager/project"
 module Gcloud
   module ResourceManager
     ##
-    # = Manager
+    # # Manager
     #
     # Provides methods for creating, retrieving, and updating projects.
     #

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -349,7 +349,7 @@ module Gcloud
       end
 
       ##
-      # Gets the {Cloud IAM}[https://cloud.google.com/iam/] access control
+      # Gets the [Cloud IAM](https://cloud.google.com/iam/) access control
       # policy. Returns a hash that conforms to the following structure:
       #
       #   {
@@ -403,7 +403,7 @@ module Gcloud
       end
 
       ##
-      # Sets the {Cloud IAM}[https://cloud.google.com/iam/] access control
+      # Sets the [Cloud IAM](https://cloud.google.com/iam/) access control
       # policy.
       #
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
@@ -446,8 +446,8 @@ module Gcloud
       end
 
       ##
-      # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy.
+      # Tests the specified permissions against the [Cloud
+      # IAM](https://cloud.google.com/iam/) access control policy.
       #
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -21,7 +21,7 @@ require "gcloud/resource_manager/project/updater"
 module Gcloud
   module ResourceManager
     ##
-    # = Project
+    # # Project
     #
     # Project is a high-level Google Cloud Platform entity. It is a container
     # for ACLs, APIs, AppEngine Apps, VMs, and other Google Cloud Platform

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -452,7 +452,7 @@ module Gcloud
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies
       #
-      # @param [String, Array<String>] permissions The set of permissions to
+      # @param [String, Array<String>] *permissions The set of permissions to
       #   check access for. Permissions with wildcards (such as `*` or
       #   `storage.*`) are not allowed.
       #

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "time"
 require "gcloud/resource_manager/errors"

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -113,7 +113,7 @@ module Gcloud
       # to the regular expression <code>([a-z]([-a-z0-9]*[a-z0-9])?)?</code>.
       #
       # No more than 256 labels can be associated with a given resource.
-      # (+Hash+)
+      # (`Hash`)
       #
       # @example Labels are read-only and cannot be changed:
       #   require "gcloud"
@@ -156,7 +156,7 @@ module Gcloud
       # to the regular expression <code>([a-z]([-a-z0-9]*[a-z0-9])?)?</code>.
       #
       # No more than 256 labels can be associated with a given resource.
-      # (+Hash+)
+      # (`Hash`)
       #
       # @example
       #   require "gcloud"
@@ -190,13 +190,13 @@ module Gcloud
       # The project lifecycle state.
       #
       # Possible values are:
-      # * +ACTIVE+ - The normal and active state.
-      # * +LIFECYCLE_STATE_UNSPECIFIED+ - Unspecified state. This is only
+      # * `ACTIVE` - The normal and active state.
+      # * `LIFECYCLE_STATE_UNSPECIFIED` - Unspecified state. This is only
       #   used/useful for distinguishing unset values.
-      # * +DELETE_REQUESTED+ - The project has been marked for deletion by the
+      # * `DELETE_REQUESTED` - The project has been marked for deletion by the
       #   user (by invoking DeleteProject) or by the system (Google Cloud
       #   Platform). This can generally be reversed by invoking UndeleteProject.
-      # * +DELETE_IN_PROGRESS+ - The process of deleting the project has begun.
+      # * `DELETE_IN_PROGRESS` - The process of deleting the project has begun.
       #   Reversing the deletion is no longer possible.
       #
       def state
@@ -204,28 +204,28 @@ module Gcloud
       end
 
       ##
-      # Checks if the state is +ACTIVE+.
+      # Checks if the state is `ACTIVE`.
       def active?
         return false if state.nil?
         "ACTIVE".casecmp(state).zero?
       end
 
       ##
-      # Checks if the state is +LIFECYCLE_STATE_UNSPECIFIED+.
+      # Checks if the state is `LIFECYCLE_STATE_UNSPECIFIED`.
       def unspecified?
         return false if state.nil?
         "LIFECYCLE_STATE_UNSPECIFIED".casecmp(state).zero?
       end
 
       ##
-      # Checks if the state is +DELETE_REQUESTED+.
+      # Checks if the state is `DELETE_REQUESTED`.
       def delete_requested?
         return false if state.nil?
         "DELETE_REQUESTED".casecmp(state).zero?
       end
 
       ##
-      # Checks if the state is +DELETE_IN_PROGRESS+.
+      # Checks if the state is `DELETE_IN_PROGRESS`.
       def delete_in_progress?
         return false if state.nil?
         "DELETE_IN_PROGRESS".casecmp(state).zero?
@@ -283,10 +283,10 @@ module Gcloud
       # if the following criteria are met:
       #
       # * The project does not have a billing account associated with it.
-      # * The project has a lifecycle state of +ACTIVE+.
-      # * This method changes the project's lifecycle state from +ACTIVE+ to
-      #   +DELETE_REQUESTED+. The deletion starts at an unspecified time, at
-      #   which point the lifecycle state changes to +DELETE_IN_PROGRESS+.
+      # * The project has a lifecycle state of `ACTIVE`.
+      # * This method changes the project's lifecycle state from `ACTIVE` to
+      #   `DELETE_REQUESTED`. The deletion starts at an unspecified time, at
+      #   which point the lifecycle state changes to `DELETE_IN_PROGRESS`.
       #
       # Until the deletion completes, you can check the lifecycle state by
       # calling #reload!, or by retrieving the project with Manager#project. The
@@ -321,8 +321,8 @@ module Gcloud
 
       ##
       # Restores the project. You can only use this method for a project that
-      # has a lifecycle state of +DELETE_REQUESTED+. After deletion starts, as
-      # indicated by a lifecycle state of +DELETE_IN_PROGRESS+, the project
+      # has a lifecycle state of `DELETE_REQUESTED`. After deletion starts, as
+      # indicated by a lifecycle state of `DELETE_IN_PROGRESS`, the project
       # cannot be restored.
       #
       # The caller must have modify permissions for this project.
@@ -364,9 +364,9 @@ module Gcloud
       # @see https://cloud.google.com/iam/docs/managing-policies Managing
       #   Policies
       #
-      # @param [Boolean] force Force load the latest policy when +true+.
+      # @param [Boolean] force Force load the latest policy when `true`.
       #   Otherwise the policy will be memoized to reduce the number of API
-      #   calls made. The default is +false+.
+      #   calls made. The default is `false`.
       #
       # @return [Hash] See description
       #
@@ -382,7 +382,7 @@ module Gcloud
       #   puts policy["version"]
       #   puts policy["etag"]
       #
-      # @example Use the +force+ option to retrieve the latest policy:
+      # @example Use the `force` option to retrieve the latest policy:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -453,8 +453,8 @@ module Gcloud
       #   Policies
       #
       # @param [String, Array<String>] permissions The set of permissions to
-      #   check access for. Permissions with wildcards (such as +*+ or
-      #   +storage.*+) are not allowed.
+      #   check access for. Permissions with wildcards (such as `*` or
+      #   `storage.*`) are not allowed.
       #
       # @return [Array<String>] The permissions that have access
       #

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -27,6 +27,7 @@ module Gcloud
     # for ACLs, APIs, AppEngine Apps, VMs, and other Google Cloud Platform
     # resources.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -39,16 +40,16 @@ module Gcloud
     #
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Project object.
-      def initialize #:nodoc:
+      # @private Create an empty Project object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -83,8 +84,7 @@ module Gcloud
       # Allowed characters are: lowercase and uppercase letters, numbers,
       # hyphen, single-quote, double-quote, space, and exclamation point.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -115,10 +115,7 @@ module Gcloud
       # No more than 256 labels can be associated with a given resource.
       # (+Hash+)
       #
-      # === Examples
-      #
-      # Labels are read-only and cannot be changed by direct assignment.
-      #
+      # @example Labels are read-only and cannot be changed:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -127,9 +124,7 @@ module Gcloud
       #   project.labels["env"] #=> "dev" # read only
       #   project.labels["env"] = "production" # raises error
       #
-      # Labels can be updated by passing a block, or by calling the #labels=
-      # method.
-      #
+      # @example Labels can be updated by passing a block, or with {#labels=}:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -163,8 +158,7 @@ module Gcloud
       # No more than 256 labels can be associated with a given resource.
       # (+Hash+)
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -238,10 +232,9 @@ module Gcloud
       end
 
       ##
-      # Updates the project in a single API call. See Project::Updater
+      # Updates the project in a single API call. See {Project::Updater}
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -267,8 +260,7 @@ module Gcloud
       # Reloads the project (with updated state) from the Google Cloud Resource
       # Manager service.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -306,8 +298,7 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -336,8 +327,7 @@ module Gcloud
       #
       # The caller must have modify permissions for this project.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -360,20 +350,7 @@ module Gcloud
 
       ##
       # Gets the {Cloud IAM}[https://cloud.google.com/iam/] access control
-      # policy. See {Managing
-      # Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
-      #
-      # === Parameters
-      #
-      # +force+::
-      #   Force load the latest policy when +true+. Otherwise the policy will be
-      #   memoized to reduce the number of API calls made. The default is
-      #   +false+. (+Boolean+)
-      #
-      # === Returns
-      #
-      # A hash that conforms to the following structure:
+      # policy. Returns a hash that conforms to the following structure:
       #
       #   {
       #     "bindings" => [{
@@ -384,11 +361,16 @@ module Gcloud
       #     "etag" => "CAE="
       #   }
       #
-      # === Examples
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # By default the policy values are memoized to reduce the number of API
-      # calls made.
+      # @param [Boolean] force Force load the latest policy when +true+.
+      #   Otherwise the policy will be memoized to reduce the number of API
+      #   calls made. The default is +false+.
       #
+      # @return [Hash] See description
+      #
+      # @example Policy values are memoized by default:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -400,8 +382,7 @@ module Gcloud
       #   puts policy["version"]
       #   puts policy["etag"]
       #
-      # Use the +force+ option to retrieve the latest policy from the service.
-      #
+      # @example Use the +force+ option to retrieve the latest policy:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -409,7 +390,7 @@ module Gcloud
       #   project = resource_manager.project "tokyo-rain-123"
       #   policy = project.policy force: true
       #
-      def policy force: nil
+      def policy force: false
         @policy = nil if force
         @policy ||= begin
           ensure_connection!
@@ -423,14 +404,13 @@ module Gcloud
 
       ##
       # Sets the {Cloud IAM}[https://cloud.google.com/iam/] access control
-      # policy. See {Managing
-      # Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +new_policy+::
-      #   A hash that conforms to the following structure:
+      # @param [String] new_policy A hash that conforms to the following
+      #   structure:
       #
       #     {
       #       "bindings" => [{
@@ -439,8 +419,7 @@ module Gcloud
       #       }]
       #     }
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -468,23 +447,18 @@ module Gcloud
 
       ##
       # Tests the specified permissions against the {Cloud
-      # IAM}[https://cloud.google.com/iam/] access control policy. See
-      # {Managing Policies}[https://cloud.google.com/iam/docs/managing-policies]
-      # for more information.
+      # IAM}[https://cloud.google.com/iam/] access control policy.
       #
-      # === Parameters
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing
+      #   Policies
       #
-      # +permissions+::
-      #   The set of permissions to check access for. Permissions with wildcards
-      #   (such as +*+ or +storage.*+) are not allowed.
-      #   (String or Array of Strings)
+      # @param [String, Array<String>] permissions The set of permissions to
+      #   check access for. Permissions with wildcards (such as +*+ or
+      #   +storage.*+) are not allowed.
       #
-      # === Returns
+      # @return [Array<String>] The permissions that have access
       #
-      # The permissions that have access. (Array of Strings)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -507,8 +481,8 @@ module Gcloud
       end
 
       ##
-      # New Change from a Google API Client object.
-      def self.from_gapi gapi, connection #:nodoc:
+      # @private New Change from a Google API Client object.
+      def self.from_gapi gapi, connection
         new.tap do |p|
           p.gapi = gapi
           p.connection = connection

--- a/lib/gcloud/resource_manager/project/list.rb
+++ b/lib/gcloud/resource_manager/project/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module ResourceManager

--- a/lib/gcloud/resource_manager/project/list.rb
+++ b/lib/gcloud/resource_manager/project/list.rb
@@ -48,8 +48,7 @@ module Gcloud
         # Retrieves all projects by repeatedly loading pages until #next?
         # returns false. Returns the list instance for method chaining.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -66,8 +65,8 @@ module Gcloud
         end
 
         ##
-        # New Projects::List from a response object.
-        def self.from_response resp, manager #:nodoc:
+        # @private New Projects::List from a response object.
+        def self.from_response resp, manager
           projects = new(Array(resp.data["projects"]).map do |gapi_object|
             Project.from_gapi gapi_object, manager.connection
           end)

--- a/lib/gcloud/resource_manager/project/updater.rb
+++ b/lib/gcloud/resource_manager/project/updater.rb
@@ -74,7 +74,7 @@ module Gcloud
         # to the regular expression <code>([a-z]([-a-z0-9]*[a-z0-9])?)?</code>.
         #
         # No more than 256 labels can be associated with a given resource.
-        # (+Hash+)
+        # (`Hash`)
         #
         # @example
         #   require "gcloud"
@@ -101,7 +101,7 @@ module Gcloud
         # to the regular expression <code>([a-z]([-a-z0-9]*[a-z0-9])?)?</code>.
         #
         # No more than 256 labels can be associated with a given resource.
-        # (+Hash+)
+        # (`Hash`)
         #
         # @example
         #   require "gcloud"

--- a/lib/gcloud/resource_manager/project/updater.rb
+++ b/lib/gcloud/resource_manager/project/updater.rb
@@ -37,8 +37,8 @@ module Gcloud
       #
       class Updater < DelegateClass(Project)
         ##
-        # Create an Updater object.
-        def initialize project #:nodoc:
+        # @private Create an Updater object.
+        def initialize project
           super project
         end
 
@@ -49,8 +49,7 @@ module Gcloud
         # Allowed characters are: lowercase and uppercase letters, numbers,
         # hyphen, single-quote, double-quote, space, and exclamation point.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -77,8 +76,7 @@ module Gcloud
         # No more than 256 labels can be associated with a given resource.
         # (+Hash+)
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -105,8 +103,7 @@ module Gcloud
         # No more than 256 labels can be associated with a given resource.
         # (+Hash+)
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -121,8 +118,8 @@ module Gcloud
         end
 
         ##
-        # Create an Updater object.
-        def self.from_project project #:nodoc:
+        # @private Create an Updater object.
+        def self.from_project project
           dupe_gapi = project.gapi.dup
           dupe_gapi = dupe_gapi.to_hash if dupe_gapi.respond_to? :to_hash
           if dupe_gapi["labels"].respond_to? :to_hash

--- a/lib/gcloud/resource_manager/project/updater.rb
+++ b/lib/gcloud/resource_manager/project/updater.rb
@@ -20,7 +20,7 @@ module Gcloud
   module ResourceManager
     class Project
       ##
-      # = Project Updater
+      # # Project Updater
       #
       # This object is used by Project#update when passed a block. These methods
       # are used to update the project data in a single API call.

--- a/lib/gcloud/resource_manager/project/updater.rb
+++ b/lib/gcloud/resource_manager/project/updater.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "time"
 require "gcloud/resource_manager/errors"

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -22,7 +22,7 @@ module Gcloud
   # Creates a new +Project+ instance connected to the Search service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +project+::
   #   Identifier for a Search project. If not present, the default project for
@@ -41,7 +41,7 @@ module Gcloud
   #   * +https://www.googleapis.com/auth/cloudsearch+
   #   * +https://www.googleapis.com/auth/userinfo.email+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Search::Project
   def self.search project = nil, keyfile = nil, scope: nil
@@ -58,7 +58,7 @@ module Gcloud
   # Disabled because there are links in the docs that are long.
 
   ##
-  # = Google Cloud Search
+  # # Google Cloud Search
   #
   # Google Cloud Search allows an application to quickly perform full-text and
   # geo-spatial searches without having to spin up instances and without the
@@ -74,13 +74,13 @@ module Gcloud
   # backward-incompatible ways. It is not currently recommended for production
   # use. It is not subject to any SLA or deprecation policy.
   #
-  # == Accessing the Service
+  # ## Accessing the Service
   #
   # Currently, the Cloud Search API is available only to white-listed users.
   # Contact your account manager or a member of the Google Cloud sales team if
   # you are interested in access.
   #
-  # == Authentication
+  # ## Authentication
   #
   # Authentication is handled by Gcloud#search. You can provide the project and
   # credential information to connect to the Cloud Search service, or if you are
@@ -88,7 +88,7 @@ module Gcloud
   # you. You can read more about the options for connecting in the
   # {Authentication Guide}[link:AUTHENTICATION.md].
   #
-  # == Managing Indexes
+  # ## Managing Indexes
   #
   # An Index is a searchable collection of documents that belongs to a Project.
   #
@@ -118,7 +118,7 @@ module Gcloud
   # documents which are created "within" them. A new index will exist in the
   # service once you save a document that references it.
   #
-  # == Managing Documents
+  # ## Managing Documents
   #
   # Using an index, create a new, unsaved Document instance, providing
   # your own unique document ID, as shown below, or omitting this argument to
@@ -184,7 +184,7 @@ module Gcloud
   #   document.add "price", 9.95 # replace existing number value
   #   index.save document # API call
   #
-  # == Adding document fields
+  # ## Adding document fields
   #
   # Fields belong to documents and are the data that actually gets searched.
   # Each field has a FieldValues collection, which facilitates access to
@@ -226,7 +226,7 @@ module Gcloud
   #   document.add "description", "<p>The best T-shirt ever.</p>", type: :html, lang: "en"
   #   document["description"].size #=> 2
   #
-  # == Searching
+  # ## Searching
   #
   # After populating an index with documents, you can request search results
   # with a query:

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -29,7 +29,7 @@ module Gcloud
   # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
   #   readable. (`String` or `Hash`)
-  # +scope::
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
   #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -21,28 +21,22 @@ module Gcloud
   # Creates a new `Project` instance connected to the Search service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Identifier for a Search project. If not present, the default project for
-  #   the credentials is used. (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Identifier for a Search project. If not present, the
+  #   default project for the credentials is used.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scopes are:
   #
   #   * `https://www.googleapis.com/auth/cloudsearch`
   #   * `https://www.googleapis.com/auth/userinfo.email`
   #
-  # ### Returns
+  # @return [Gcloud::Search::Project]
   #
-  # Gcloud::Search::Project
   def self.search project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Search::Project.default_project
     if keyfile.nil?

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -86,7 +86,7 @@ module Gcloud
   # credential information to connect to the Cloud Search service, or if you are
   # running on Google Compute Engine this configuration is taken care of for
   # you. You can read more about the options for connecting in the
-  # [Authentication Guide](link:AUTHENTICATION.md).
+  # [Authentication Guide](../AUTHENTICATION).
   #
   # ## Managing Indexes
   #

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -32,8 +32,8 @@ module Gcloud
   #   readable. (+String+ or +Hash+)
   # +scope::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scopes are:
@@ -86,7 +86,7 @@ module Gcloud
   # credential information to connect to the Cloud Search service, or if you are
   # running on Google Compute Engine this configuration is taken care of for
   # you. You can read more about the options for connecting in the
-  # {Authentication Guide}[link:AUTHENTICATION.md].
+  # [Authentication Guide](link:AUTHENTICATION.md).
   #
   # ## Managing Indexes
   #
@@ -135,7 +135,7 @@ module Gcloud
   #   #=> nil
   #   document.rank #=> nil
   #
-  # Add one or more fields to the document. (See {Adding document fields}[#module-Gcloud::Search-label-Adding+document+fields], below.)
+  # Add one or more fields to the document. (See [Adding document fields](#module-Gcloud::Search-label-Adding+document+fields), below.)
   #
   #   document.add "price", 24.95
   #
@@ -189,7 +189,7 @@ module Gcloud
   # Fields belong to documents and are the data that actually gets searched.
   # Each field has a FieldValues collection, which facilitates access to
   # FieldValue objects. Each FieldValue object will be saved as one of the
-  # {Cloud Search types}[https://cloud.google.com/search/documents_indexes#document_fields_field_names_and_multi-valued_fields].
+  # [Cloud Search types](https://cloud.google.com/search/documents_indexes#document_fields_field_names_and_multi-valued_fields).
   # The type will be inferred from the value when possible, or you can
   # explicitly specify it by passing a symbol with the +type+ option to
   # Document#add.
@@ -243,7 +243,7 @@ module Gcloud
   #   end
   #
   # By default, Result objects are sorted by document rank. For more information
-  # see the {REST API documentation for Document.rank}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank].
+  # see the [REST API documentation for Document.rank](https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank).
   #
   # You can specify how to sort results with the +order+ option:
   #

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -94,24 +94,28 @@ module Gcloud
   #
   # You can list the indexes in your current project:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
+  # gcloud = Gcloud.new
+  # search = gcloud.search
   #
-  #   indexes = search.indexes  # API call
-  #   indexes.each do |index|
-  #     puts index.index_id
-  #   end
+  # indexes = search.indexes  # API call
+  # indexes.each do |index|
+  #   puts index.index_id
+  # end
+  # ```
   #
   # And you can use the project to create new indexes:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
+  # gcloud = Gcloud.new
+  # search = gcloud.search
   #
-  #   index = search.index "products", skip_lookup: true
+  # index = search.index "products", skip_lookup: true
+  # ```
   #
   # A new index is an unsaved value object. Indexes cannot be created,
   # updated, or deleted directly in the service: They are derived from the
@@ -124,65 +128,77 @@ module Gcloud
   # your own unique document ID, as shown below, or omitting this argument to
   # let the service assign the ID.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
+  # gcloud = Gcloud.new
+  # search = gcloud.search
   #
-  #   index = search.index "products"
-  #   document = index.document "product-sku-000001"
-  #   index.find document # API call
-  #   #=> nil
-  #   document.rank #=> nil
+  # index = search.index "products"
+  # document = index.document "product-sku-000001"
+  # index.find document # API call
+  # #=> nil
+  # document.rank #=> nil
+  # ```
   #
   # Add one or more fields to the document. (See [Adding document fields](#module-Gcloud::Search-label-Adding`document`fields), below.)
   #
-  #   document.add "price", 24.95
+  # ```ruby
+  # document.add "price", 24.95
+  # ```
   #
   # When your document is complete, save it:
   #
-  #   index.save document # API call
-  #   document.rank # set by the server
-  #   #=> 1443648166
+  # ```ruby
+  # index.save document # API call
+  # document.rank # set by the server
+  # #=> 1443648166
+  # ```
   #
   # You can list the documents in an index:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
-  #   index = search.index "products"
+  # gcloud = Gcloud.new
+  # search = gcloud.search
+  # index = search.index "products"
   #
-  #   documents = index.documents # API call
-  #   documents.map &:doc_id #=> ["product-sku-000001"]
+  # documents = index.documents # API call
+  # documents.map &:doc_id #=> ["product-sku-000001"]
+  # ```
   #
   # And you can delete documents:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
-  #   index = search.index "products"
+  # gcloud = Gcloud.new
+  # search = gcloud.search
+  # index = search.index "products"
   #
-  #   document = index.find "product-sku-000001"
+  # document = index.find "product-sku-000001"
   #
-  #   document.delete  # API call
-  #   index.find document # API call
-  #   #=> nil
+  # document.delete  # API call
+  # index.find document # API call
+  # #=> nil
+  # ```
   #
   # To update a document after manipulating its fields or rank, just re-save it:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
-  #   index = search.index "products"
+  # gcloud = Gcloud.new
+  # search = gcloud.search
+  # index = search.index "products"
   #
-  #   document = index.find "product-sku-000001"
+  # document = index.find "product-sku-000001"
   #
-  #   document.rank = 12345
-  #   document.add "price", 9.95 # replace existing number value
-  #   index.save document # API call
+  # document.rank = 12345
+  # document.add "price", 9.95 # replace existing number value
+  # index.save document # API call
+  # ```
   #
   # ## Adding document fields
   #
@@ -215,79 +231,89 @@ module Gcloud
   # Again, you can add more than one value to a field, and the values may be of
   # different types.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
+  # gcloud = Gcloud.new
+  # search = gcloud.search
   #
-  #   index = search.index "products"
-  #   document = index.find "product-sku-000001"
-  #   document.add "description", "The best T-shirt ever.", type: :text, lang: "en"
-  #   document.add "description", "<p>The best T-shirt ever.</p>", type: :html, lang: "en"
-  #   document["description"].size #=> 2
+  # index = search.index "products"
+  # document = index.find "product-sku-000001"
+  # document.add "description", "The best T-shirt ever.", type: :text, lang: "en"
+  # document.add "description", "<p>The best T-shirt ever.</p>", type: :html, lang: "en"
+  # document["description"].size #=> 2
+  # ```
   #
   # ## Searching
   #
   # After populating an index with documents, you can request search results
   # with a query:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
-  #   index = search.index "books"
+  # gcloud = Gcloud.new
+  # search = gcloud.search
+  # index = search.index "books"
   #
-  #   results = index.search "dark stormy"
-  #   results.each do |result|
-  #     puts result.doc_id
-  #   end
+  # results = index.search "dark stormy"
+  # results.each do |result|
+  #   puts result.doc_id
+  # end
+  # ```
   #
   # By default, Result objects are sorted by document rank. For more information
   # see the [REST API documentation for Document.rank](https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank).
   #
   # You can specify how to sort results with the `order` option:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
-  #   index = search.index "books"
+  # gcloud = Gcloud.new
+  # search = gcloud.search
+  # index = search.index "books"
   #
-  #   results = index.search "dark stormy", order: "published, avg_review desc"
-  #   documents = index.search query # API call
+  # results = index.search "dark stormy", order: "published, avg_review desc"
+  # documents = index.search query # API call
+  # ```
   #
   # You can add computed fields with the `expressions` option, and specify the
   # fields that are returned with the `fields` option. No document data will be
   # returned if you omit the `fields` option, only `doc_id` references to any
   # matched documents.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
-  #   index = search.index "products"
+  # gcloud = Gcloud.new
+  # search = gcloud.search
+  # index = search.index "products"
   #
-  #   results = index.search "cotton T-shirt",
-  #                          expressions: { total_price: "(price + tax)" },
-  #                          fields: ["name", "total_price", "highlight"]
+  # results = index.search "cotton T-shirt",
+  #                        expressions: { total_price: "(price + tax)" },
+  #                        fields: ["name", "total_price", "highlight"]
+  # ```
   #
   # Just as in documents, Result data is accessible via Fields methods:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   search = gcloud.search
-  #   index = search.index "products"
-  #   document = index.find "product-sku-000001"
-  #   results = index.search "cotton T-shirt"
-  #   values = results[0]["description"]
+  # gcloud = Gcloud.new
+  # search = gcloud.search
+  # index = search.index "products"
+  # document = index.find "product-sku-000001"
+  # results = index.search "cotton T-shirt"
+  # values = results[0]["description"]
   #
-  #   values[0] #=> "100% organic cotton ruby gem T-shirt"
-  #   values[0].type #=> :text
-  #   values[0].lang #=> "en"
-  #   values[1] #=> "<p>100% organic cotton ruby gem T-shirt</p>"
-  #   values[1].type #=> :html
-  #   values[1].lang #=> "en"
+  # values[0] #=> "100% organic cotton ruby gem T-shirt"
+  # values[0].type #=> :text
+  # values[0].lang #=> "en"
+  # values[1] #=> "<p>100% organic cotton ruby gem T-shirt</p>"
+  # values[1].type #=> :html
+  # values[1].lang #=> "en"
+  # ```
   #
   module Search
   end

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -19,27 +19,27 @@ require "gcloud/search/project"
 # Google Cloud Search
 module Gcloud
   ##
-  # Creates a new +Project+ instance connected to the Search service.
+  # Creates a new `Project` instance connected to the Search service.
   # Each call creates a new connection.
   #
   # ### Parameters
   #
-  # +project+::
+  # `project`::
   #   Identifier for a Search project. If not present, the default project for
-  #   the credentials is used. (+String+)
-  # +keyfile+::
+  #   the credentials is used. (`String`)
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
+  #   readable. (`String` or `Hash`)
   # +scope::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scopes are:
   #
-  #   * +https://www.googleapis.com/auth/cloudsearch+
-  #   * +https://www.googleapis.com/auth/userinfo.email+
+  #   * `https://www.googleapis.com/auth/cloudsearch`
+  #   * `https://www.googleapis.com/auth/userinfo.email`
   #
   # ### Returns
   #
@@ -135,7 +135,7 @@ module Gcloud
   #   #=> nil
   #   document.rank #=> nil
   #
-  # Add one or more fields to the document. (See [Adding document fields](#module-Gcloud::Search-label-Adding+document+fields), below.)
+  # Add one or more fields to the document. (See [Adding document fields](#module-Gcloud::Search-label-Adding`document`fields), below.)
   #
   #   document.add "price", 24.95
   #
@@ -191,25 +191,25 @@ module Gcloud
   # FieldValue objects. Each FieldValue object will be saved as one of the
   # [Cloud Search types](https://cloud.google.com/search/documents_indexes#document_fields_field_names_and_multi-valued_fields).
   # The type will be inferred from the value when possible, or you can
-  # explicitly specify it by passing a symbol with the +type+ option to
+  # explicitly specify it by passing a symbol with the `type` option to
   # Document#add.
   #
-  # - String (+:atom+, +:html+, +:text+, or +:default+)
-  # - Number (+:number+)
-  # - Timestamp (+:datetime+)
-  # - Geovalue (+:geo+)
+  # - String (`:atom`, `:html`, `:text`, or `:default`)
+  # - Number (`:number`)
+  # - Timestamp (`:datetime`)
+  # - Geovalue (`:geo`)
   #
   # String values can be tokenized using one of three different types of
-  # tokenization, which can be passed with the +type+ option when the value is
+  # tokenization, which can be passed with the `type` option when the value is
   # added:
   #
-  # - +:atom+ means "don't tokenize this string", treat it as one
+  # - `:atom` means "don't tokenize this string", treat it as one
   #   thing to compare against
   #
-  # - +:html+ means "treat this string as HTML", not comparing against the
-  #   tags, and treating the rest of the content like +:text+
+  # - `:html` means "treat this string as HTML", not comparing against the
+  #   tags, and treating the rest of the content like `:text`
   #
-  # - +:text+ means "treat this string as normal text" and split words
+  # - `:text` means "treat this string as normal text" and split words
   #   apart to be compared against
   #
   # Again, you can add more than one value to a field, and the values may be of
@@ -245,7 +245,7 @@ module Gcloud
   # By default, Result objects are sorted by document rank. For more information
   # see the [REST API documentation for Document.rank](https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank).
   #
-  # You can specify how to sort results with the +order+ option:
+  # You can specify how to sort results with the `order` option:
   #
   #   require "gcloud"
   #
@@ -256,9 +256,9 @@ module Gcloud
   #   results = index.search "dark stormy", order: "published, avg_review desc"
   #   documents = index.search query # API call
   #
-  # You can add computed fields with the +expressions+ option, and specify the
-  # fields that are returned with the +fields+ option. No document data will be
-  # returned if you omit the +fields+ option, only `doc_id` references to any
+  # You can add computed fields with the `expressions` option, and specify the
+  # fields that are returned with the `fields` option. No document data will be
+  # returned if you omit the `fields` option, only `doc_id` references to any
   # matched documents.
   #
   #   require "gcloud"

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 require "gcloud/search/project"
 
-#--
-# Google Cloud Search
 module Gcloud
   ##
   # Creates a new `Project` instance connected to the Search service.

--- a/lib/gcloud/search/api_client.rb
+++ b/lib/gcloud/search/api_client.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/version"
 require "google/api_client"

--- a/lib/gcloud/search/api_client.rb
+++ b/lib/gcloud/search/api_client.rb
@@ -19,10 +19,10 @@ require "google/api_client"
 module Gcloud
   module Search
     ##
-    # Temporary substitute for Google::APIClient. Once the Search API is
-    # discoverable, initialization of this class in Connection should be
+    # @private Temporary substitute for Google::APIClient. Once the Search API
+    # is discoverable, initialization of this class in Connection should be
     # replaced with the Google API Client.
-    class APIClient #:nodoc:
+    class APIClient
       attr_accessor :authorization, :connection
 
       ##
@@ -50,7 +50,7 @@ module Gcloud
 
       ##
       # Return type for APIClient#discovered_api
-      class DiscoveredApi #:nodoc:
+      class DiscoveredApi
         def initialize name, version
           @name = name
           @version = version
@@ -70,7 +70,7 @@ module Gcloud
 
       ##
       # Return type for DiscoveredApi http verb methods
-      class ResourcePath #:nodoc:
+      class ResourcePath
         def initialize api_name, api_version, resource_root, resource_id_param
           @root = "https://#{api_name}.googleapis.com/#{api_version}" \
                   "/projects/{projectId}/#{resource_root}"
@@ -100,7 +100,7 @@ module Gcloud
 
       ##
       # Special-case return type for DiscoveredApi http search verb method
-      class IndexResourcePath < ResourcePath #:nodoc:
+      class IndexResourcePath < ResourcePath
         def search
           api_method :get, "/{indexId}/search"
         end

--- a/lib/gcloud/search/connection.rb
+++ b/lib/gcloud/search/connection.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/version"
 require "gcloud/search/api_client"

--- a/lib/gcloud/search/connection.rb
+++ b/lib/gcloud/search/connection.rb
@@ -19,19 +19,19 @@ require "gcloud/search/api_client"
 module Gcloud
   module Search
     ##
-    # Represents the connection to Search,
+    # @private Represents the connection to Search,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
-      attr_accessor :client #:nodoc:
-      attr_accessor :connection #:nodoc:
+      attr_accessor :credentials
+      attr_accessor :client
+      attr_accessor :connection
 
       ##
       # Creates a new Connection instance.
-      def initialize project, credentials #:nodoc:
+      def initialize project, credentials
         @project = project
         @credentials = credentials
         client_config = {
@@ -120,7 +120,7 @@ module Gcloud
         )
       end
 
-      def inspect #:nodoc:
+      def inspect
         "#{self.class}(#{@project})"
       end
 

--- a/lib/gcloud/search/credentials.rb
+++ b/lib/gcloud/search/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Search
     ##
-    # Represents the Oauth2 signing logic for Search.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the Oauth2 signing logic for Search.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/cloudsearch",
                "https://www.googleapis.com/auth/userinfo.email"]
       PATH_ENV_VARS = %w(SEARCH_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)

--- a/lib/gcloud/search/credentials.rb
+++ b/lib/gcloud/search/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/credentials"
 

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -20,7 +20,7 @@ require "gcloud/search/fields"
 module Gcloud
   module Search
     ##
-    # = Document
+    # # Document
     #
     # A document is an object that stores data that can be searched. Each
     # document has a {#doc_id} that is unique within its index, a {#rank}, and a

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -131,9 +131,6 @@ module Gcloud
 
       # rubocop:enable Style/TrivialAccessors
 
-      # rubocop:disable Metrics/LineLength
-      # Disabled because there are links in the docs that are long.
-
       ##
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
@@ -158,13 +155,13 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     [ways of writing coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
       # @param [String] lang The language of a string value. Must be a valid
-      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
+      #   [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
       #
       # @example
       #   require "gcloud"
@@ -184,8 +181,6 @@ module Gcloud
       def add name, value, type: nil, lang: nil
         @fields[name].add value, type: type, lang: lang
       end
-
-      # rubocop:enable Metrics/LineLength
 
       ##
       # Deletes a field and all values. (See {Fields#delete})

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/search/document/list"
 require "gcloud/search/connection"

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -87,8 +87,8 @@ module Gcloud
       # never be assigned to more than 10,000 documents. By default (when it is
       # not specified or set to 0), it is set at the time the document is
       # created to the number of seconds since January 1, 2011. The rank can be
-      # used in {Index#search} options +expressions+, +order+, and
-      # +fields+, where it is referenced as +rank+.
+      # used in {Index#search} options `expressions`, `order`, and
+      # `fields`, where it is referenced as `rank`.
       def rank= new_rank
         @raw["rank"] = new_rank
       end
@@ -134,30 +134,30 @@ module Gcloud
       ##
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
-      # +:datetime+ or +:number+, then the added value will replace any existing
+      # `:datetime` or `:number`, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
       # @param [String] name The name of the field.
       # @param [String, Datetime, Float] value The value to add to the field.
       # @param [Symbol] type The type of the field value. An attempt is made to
       #   set the correct type when this option is missing, although it must be
-      #   provided for +:geo+ values. A field can have multiple values with same
-      #   or different types; however, it cannot have multiple +:datetime+ or
-      #   +:number+ values.
+      #   provided for `:geo` values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple `:datetime` or
+      #   `:number` values.
       #
       #   The following values are supported:
-      #   * +:default+ - The value is a string. The format will be automatically
+      #   * `:default` - The value is a string. The format will be automatically
       #     detected. This is the default value for strings.
-      #   * +:text+ - The value is a string with maximum length 1024**2
+      #   * `:text` - The value is a string with maximum length 1024**2
       #     characters.
-      #   * +:html+ - The value is an HTML-formatted string with maximum length
+      #   * `:html` - The value is an HTML-formatted string with maximum length
       #     1024**2 characters.
-      #   * +:atom+ - The value is a string with maximum length 500 characters.
-      #   * +:geo+ - The value is a point on earth described by latitude and
+      #   * `:atom` - The value is a string with maximum length 500 characters.
+      #   * `:geo` - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
       #     [ways of writing coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
-      #   * +:datetime+ - The value is a +DateTime+.
-      #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
+      #   * `:datetime` - The value is a `DateTime`.
+      #   * `:number` - The value is a `Numeric` between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
       # @param [String] lang The language of a string value. Must be a valid

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -23,11 +23,11 @@ module Gcloud
     # = Document
     #
     # A document is an object that stores data that can be searched. Each
-    # document has a #doc_id that is
-    # unique within its index, a #rank, and a list of #fields that contain typed
-    # data. Its field values can be accessed through hash-like methods such as
-    # #[] and #each.
+    # document has a {#doc_id} that is unique within its index, a {#rank}, and a
+    # list of {#fields} that contain typed data. Its field values can be
+    # accessed through hash-like methods such as {#[]} and {#each}.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -40,22 +40,22 @@ module Gcloud
     #   document.rank #=> 1443648166
     #   document["price"] #=> 24.95
     #
-    # For more information, see {Documents and
-    # Indexes}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   Indexes
     #
     class Document
       ##
-      # Creates a new Document instance.
+      # @private Creates a new Document instance.
       #
-      def initialize #:nodoc:
+      def initialize
         @fields = Fields.new
         @raw = {}
       end
 
       ##
       # The unique identifier for the document. Can be set explicitly when the
-      # document is saved. (See Index#document and #doc_id= .) If missing, it is
-      # automatically assigned to the document when saved.
+      # document is saved. (See {Index#document} and {#doc_id=}.) If missing, it
+      # is automatically assigned to the document when saved.
       def doc_id
         @raw["docId"]
       end
@@ -74,7 +74,7 @@ module Gcloud
       ##
       # A positive integer which determines the default ordering of documents
       # returned from a search. The rank can be set explicitly when the document
-      # is saved. (See Index#document and #rank= .)  If missing, it is
+      # is saved. (See {Index#document} and {#rank=}.)  If missing, it is
       # automatically assigned to the document when saved.
       def rank
         @raw["rank"]
@@ -87,7 +87,7 @@ module Gcloud
       # never be assigned to more than 10,000 documents. By default (when it is
       # not specified or set to 0), it is set at the time the document is
       # created to the number of seconds since January 1, 2011. The rank can be
-      # used in Index#search options +expressions+, +order+, and
+      # used in {Index#search} options +expressions+, +order+, and
       # +fields+, where it is referenced as +rank+.
       def rank= new_rank
         @raw["rank"] = new_rank
@@ -96,18 +96,12 @@ module Gcloud
       ##
       # Retrieve the field values associated to a field name.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @return [FieldValues]
       #
-      # === Returns
-      #
-      # FieldValues
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -130,7 +124,7 @@ module Gcloud
 
       ##
       # The fields in the document. Each field has a name (String) and a list of
-      # values (FieldValues). (See Fields)
+      # values ({FieldValues}). (See {Fields})
       def fields
         @fields
       end
@@ -144,20 +138,15 @@ module Gcloud
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
       # +:datetime+ or +:number+, then the added value will replace any existing
-      # values of the same type (since there can be only one). (See Fields#add)
+      # values of the same type (since there can be only one).
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The name of the field. (+String+)
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. An attempt is made to set the correct
-      #   type when this option is missing, although it must be provided for
-      #   +:geo+ values. A field can have multiple values with same or different
-      #   types; however, it cannot have multiple +:datetime+ or +:number+
-      #   values. (+Symbol+)
+      # @param [String] name The name of the field.
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. An attempt is made to
+      #   set the correct type when this option is missing, although it must be
+      #   provided for +:geo+ values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple +:datetime+ or
+      #   +:number+ values.
       #
       #   The following values are supported:
       #   * +:default+ - The value is a string. The format will be automatically
@@ -169,19 +158,15 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing
-      #     coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
-      #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
+      # @param [String] lang The language of a string value. Must be a valid
+      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -203,15 +188,11 @@ module Gcloud
       # rubocop:enable Metrics/LineLength
 
       ##
-      # Deletes a field and all values. (See Fields#delete)
+      # Deletes a field and all values. (See {Fields#delete})
       #
-      # === Parameters
+      # @param [String] name The name of the field.
       #
-      # +name+::
-      #   The name of the field. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -228,10 +209,9 @@ module Gcloud
       ##
       # Calls block once for each field, passing the field name and values pair
       # as parameters. If no block is given an enumerator is returned instead.
-      # (See Fields#each)
+      # (See {Fields#each})
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -253,8 +233,9 @@ module Gcloud
 
       ##
       # Returns a new array populated with all the field names.
-      # (See Fields#names)
+      # (See {Fields#names})
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -272,8 +253,8 @@ module Gcloud
       end
 
       ##
-      # Override to keep working in interactive shells manageable.
-      def inspect #:nodoc:
+      # @private Override to keep working in interactive shells manageable.
+      def inspect
         insp_rank = ""
         insp_rank = ", rank: #{rank}" if rank
         insp_fields = ", fields: (#{fields.names.map(&:inspect).join ', '})"
@@ -281,8 +262,8 @@ module Gcloud
       end
 
       ##
-      # New Document from a raw data object.
-      def self.from_hash hash #:nodoc:
+      # @private New Document from a raw data object.
+      def self.from_hash hash
         doc = new
         doc.instance_variable_set "@raw", hash
         doc.instance_variable_set "@fields", Fields.from_raw(hash["fields"])
@@ -290,8 +271,8 @@ module Gcloud
       end
 
       ##
-      # Returns the Document data as a hash
-      def to_hash #:nodoc:
+      # @private Returns the Document data as a hash
+      def to_hash
         hash = @raw.dup
         hash["fields"] = @fields.to_raw
         hash

--- a/lib/gcloud/search/document/list.rb
+++ b/lib/gcloud/search/document/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Search

--- a/lib/gcloud/search/document/list.rb
+++ b/lib/gcloud/search/document/list.rb
@@ -25,7 +25,7 @@ module Gcloud
         attr_accessor :token
 
         ##
-        # Create a new Document::List with an array of Document instances.
+        # Create a new Document::List with an array of {Document} instances.
         def initialize arr = []
           super arr
         end
@@ -45,7 +45,7 @@ module Gcloud
         end
 
         ##
-        # Retrieves all documents by repeatedly loading pages until #next?
+        # Retrieves all documents by repeatedly loading pages until {#next?}
         # returns false. Returns the list instance for method chaining.
         def all
           while next?
@@ -57,8 +57,8 @@ module Gcloud
         end
 
         ##
-        # New Documents::List from a response object.
-        def self.from_response resp, index #:nodoc:
+        # @private New Documents::List from a response object.
+        def self.from_response resp, index
           data = JSON.parse resp.body
           documents = new(Array(data["documents"]).map do |doc_hash|
             Document.from_hash doc_hash

--- a/lib/gcloud/search/errors.rb
+++ b/lib/gcloud/search/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/errors"
 

--- a/lib/gcloud/search/errors.rb
+++ b/lib/gcloud/search/errors.rb
@@ -33,13 +33,15 @@ module Gcloud
       # The errors encountered.
       attr_reader :errors
 
-      def initialize message, code, errors = [] #:nodoc:
+      # @private
+      def initialize message, code, errors = []
         super message
         @code   = code
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         data = JSON.parse resp.body
         if data["error"]
           from_response_data data["error"]
@@ -50,11 +52,13 @@ module Gcloud
         from_response_status resp
       end
 
-      def self.from_response_data error #:nodoc:
+      # @private
+      def self.from_response_data error
         new error["message"], error["code"], error["errors"]
       end
 
-      def self.from_response_status resp #:nodoc:
+      # @private
+      def self.from_response_status resp
         if resp.status == 404
           new "#{resp.body}: #{resp.request.uri.request_uri}",
               resp.status

--- a/lib/gcloud/search/field_value.rb
+++ b/lib/gcloud/search/field_value.rb
@@ -26,8 +26,8 @@ module Gcloud
     # provided it will be determined by looking at the value.
     #
     # String values (text, html, atom) can also specify a lang value, which is
-    # an {ISO 639-1
-    # code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
+    # an [ISO 639-1
+    # code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
     #
     # @example
     #   require "gcloud"
@@ -67,14 +67,14 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing
-      #     coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     [ways of writing
+      #     coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # @param [String] lang The language of a string value. Must be a valid {ISO 639-1
-      #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
+      # @param [String] lang The language of a string value. Must be a valid [ISO 639-1
+      #   code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
       # @param [String] name The name of the field. New values will be configured with this name.
       #
       def initialize value, type: nil, lang: nil, name: nil

--- a/lib/gcloud/search/field_value.rb
+++ b/lib/gcloud/search/field_value.rb
@@ -60,17 +60,17 @@ module Gcloud
       #   number values.
       #
       #   The following values are supported:
-      #   * +:text+ - The value is a string with maximum length 1024**2
+      #   * `:text` - The value is a string with maximum length 1024**2
       #     characters.
-      #   * +:html+ - The value is an HTML-formatted string with maximum length
+      #   * `:html` - The value is an HTML-formatted string with maximum length
       #     1024**2 characters.
-      #   * +:atom+ - The value is a string with maximum length 500 characters.
-      #   * +:geo+ - The value is a point on earth described by latitude and
+      #   * `:atom` - The value is a string with maximum length 500 characters.
+      #   * `:geo` - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
       #     [ways of writing
       #     coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
-      #   * +:datetime+ - The value is a +DateTime+.
-      #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
+      #   * `:datetime` - The value is a `DateTime`.
+      #   * `:number` - The value is a `Numeric` between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
       # @param [String] lang The language of a string value. Must be a valid [ISO 639-1

--- a/lib/gcloud/search/field_value.rb
+++ b/lib/gcloud/search/field_value.rb
@@ -19,7 +19,7 @@ module Gcloud
     # = FieldValue
     #
     # FieldValue is used to represent a value that belongs to a field. (See
-    # Fields and FieldValues)
+    # {Fields} and {FieldValues})
     #
     # A field value must have a type. A value that is a Numeric will default to
     # `:number`, while a DateTime will default to `:datetime`. If a type is not
@@ -29,6 +29,7 @@ module Gcloud
     # an {ISO 639-1
     # code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -41,8 +42,8 @@ module Gcloud
     #     puts "* #{value} (#{value.type}) [#{value.lang}]"
     #   end
     #
-    # For more information see {Documents and
-    # fields}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   fields
     #
     class FieldValue < DelegateClass(::Object)
       attr_reader :type, :lang, :name
@@ -51,16 +52,12 @@ module Gcloud
       # Disabled because there are links in the docs that are long.
 
       ##
-      # Create a new FieldValue object.
+      # @private Create a new FieldValue object.
       #
-      # === Parameters
-      #
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. A field can have multiple values with
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. A field can have multiple values with
       #   same or different types; however, it cannot have multiple Timestamp or
-      #   number values. (+Symbol+)
+      #   number values.
       #
       #   The following values are supported:
       #   * +:text+ - The value is a string with maximum length 1024**2
@@ -76,15 +73,11 @@ module Gcloud
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
+      # @param [String] lang The language of a string value. Must be a valid {ISO 639-1
       #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @param [String] name The name of the field. New values will be configured with this name.
       #
-      def initialize value, type: nil, lang: nil, name: nil #:nodoc:
+      def initialize value, type: nil, lang: nil, name: nil
         super value
         if type
           @type = type.to_s.downcase.to_sym
@@ -105,14 +98,14 @@ module Gcloud
       end
 
       ##
-      # Get the original value object.
-      def value #:nodoc:
+      # @private Get the original value object.
+      def value
         __getobj__
       end
 
       ##
-      # Create a new FieldValue instance from a value Hash.
-      def self.from_raw field_value, name = nil #:nodoc:
+      # @private Create a new FieldValue instance from a value Hash.
+      def self.from_raw field_value, name = nil
         value = field_value["stringValue"]
         type = field_value["stringFormat"]
         if field_value["timestampValue"]
@@ -130,8 +123,8 @@ module Gcloud
       end
 
       ##
-      # Create a raw Hash object containing the field value.
-      def to_raw #:nodoc:
+      # @private Create a raw Hash object containing the field value.
+      def to_raw
         case type
         when :atom, :default, :html, :text
           {
@@ -150,7 +143,7 @@ module Gcloud
 
       protected
 
-      def infer_type #:nodoc:
+      def infer_type
         if respond_to? :rfc3339
           :datetime
         elsif value.is_a? Numeric # must call on original object...

--- a/lib/gcloud/search/field_value.rb
+++ b/lib/gcloud/search/field_value.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Search

--- a/lib/gcloud/search/field_value.rb
+++ b/lib/gcloud/search/field_value.rb
@@ -16,7 +16,7 @@
 module Gcloud
   module Search
     ##
-    # = FieldValue
+    # # FieldValue
     #
     # FieldValue is used to represent a value that belongs to a field. (See
     # {Fields} and {FieldValues})

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -30,8 +30,9 @@ module Gcloud
     # Each field on a document can have multiple values. FieldValues is the
     # object that manages the multiple values. Values can be the same or
     # different types; however, it cannot have multiple datetime (DateTime) or
-    # number (Float) values. (See FieldValue)
+    # number (Float) values. (See {FieldValue})
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -44,25 +45,20 @@ module Gcloud
     #     puts "* #{value} (#{value.type}) [#{value.lang}]"
     #   end
     #
-    # For more information see {Documents and
-    # fields}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   Indexes
     #
     class FieldValues
       include Enumerable
 
       ##
-      # Create a new FieldValues object.
+      # @private Create a new FieldValues object.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
+      # @param [Array<FieldValue>] values A list of values to add to the field.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
-      # +values+::
-      #   A list of values to add to the field. (+Array+ of +FieldValue+
-      #   objects)
-      #
-      def initialize name, values = [] # :nodoc:
+      def initialize name, values = []
         @name = name
         @values = values
       end
@@ -77,7 +73,8 @@ module Gcloud
       # before an element. Additionally, an empty array is returned when the
       # starting index for an element range is at the end of the array.
       #
-      # Returns nil if the index (or starting index) are out of range.
+      # @return [FieldValue, nil] Returns nil if the index (or starting index)
+      #   are out of range.
       def [] index
         @values[index]
       end
@@ -86,21 +83,18 @@ module Gcloud
       # Disabled because there are links in the docs that are long.
 
       ##
-      # Add a new value. The field name will be added to the value object. If
+      # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
       # +:datetime+ or +:number+, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
-      # === Parameters
-      #
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. An attempt is made to set the correct
-      #   type when this option is missing, although it must be provided for
-      #   +:geo+ values. A field can have multiple values with same or different
-      #   types; however, it cannot have multiple +:datetime+ or +:number+
-      #   values. (+Symbol+)
+      # @param [String] name The name of the field.
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. An attempt is made to
+      #   set the correct type when this option is missing, although it must be
+      #   provided for +:geo+ values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple +:datetime+ or
+      #   +:number+ values.
       #
       #   The following values are supported:
       #   * +:default+ - The value is a string. The format will be automatically
@@ -112,23 +106,17 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing
-      #     coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
-      #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
+      # @param [String] lang The language of a string value. Must be a valid
+      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
       #
-      # === Returns
+      # @return [FieldValue]
       #
-      # FieldValue
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -156,17 +144,12 @@ module Gcloud
       ##
       # Deletes all values that are equal to value.
       #
-      # === Parameters
+      # @param [String] value The value to remove from the list of values.
       #
-      # +value+::
-      #   The value to remove from the list of values.
+      # @return [FieldValue, nil] The last deleted +FieldValue+, or +nil+ if no
+      #   matching value is found.
       #
-      # === Returns
-      #
-      # The last deleted +FieldValue+, or +nil+ if no matching value is found.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -186,21 +169,14 @@ module Gcloud
       ##
       # Deletes the value at the specified index, returning that FieldValue, or
       # +nil+ if the index is out of range.
-      ##
-      # Deletes all values that are equal to value.
       #
-      # === Parameters
+      # @param [String] index The index of the value to be removed from the list
+      #   of values.
       #
-      # +index+::
-      #   The index of the value to be removed from the list of values.
+      # @return [FieldValue] The deleted +FieldValue+ found at the specified
+      #   index, or # +nil+ if the index is out of range.
       #
-      # === Returns
-      #
-      # The deleted +FieldValue+ found at the specified index, or # +nil+ if the
-      # index is out of range.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -222,8 +198,7 @@ module Gcloud
       #
       # An Enumerator is returned if no block is given.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -247,15 +222,15 @@ module Gcloud
       end
 
       ##
-      # Create a new FieldValues instance from a name and values Hash.
-      def self.from_raw name, values #:nodoc:
+      # @private Create a new FieldValues instance from a name and values Hash.
+      def self.from_raw name, values
         field_values = values.map { |value| FieldValue.from_raw value, name }
         FieldValues.new name, field_values
       end
 
       ##
-      # Create a raw Hash object containing all the field values.
-      def to_raw #:nodoc:
+      # @private Create a raw Hash object containing all the field values.
+      def to_raw
         { "values" => @values.map(&:to_raw) }
       end
     end

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -88,7 +88,6 @@ module Gcloud
       # +:datetime+ or +:number+, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
-      # @param [String] name The name of the field.
       # @param [String, Datetime, Float] value The value to add to the field.
       # @param [Symbol] type The type of the field value. An attempt is made to
       #   set the correct type when this option is missing, although it must be

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/search/field_value"
 

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -79,9 +79,6 @@ module Gcloud
         @values[index]
       end
 
-      # rubocop:disable Metrics/LineLength
-      # Disabled because there are links in the docs that are long.
-
       ##
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
@@ -105,13 +102,13 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     [ways of writing coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
       # @param [String] lang The language of a string value. Must be a valid
-      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
+      #   [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
       #
       # @return [FieldValue]
       #
@@ -137,8 +134,6 @@ module Gcloud
         end
         @values << new_field
       end
-
-      # rubocop:enable Metrics/LineLength
 
       ##
       # Deletes all values that are equal to value.

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -82,29 +82,29 @@ module Gcloud
       ##
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
-      # +:datetime+ or +:number+, then the added value will replace any existing
+      # `:datetime` or `:number`, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
       # @param [String, Datetime, Float] value The value to add to the field.
       # @param [Symbol] type The type of the field value. An attempt is made to
       #   set the correct type when this option is missing, although it must be
-      #   provided for +:geo+ values. A field can have multiple values with same
-      #   or different types; however, it cannot have multiple +:datetime+ or
-      #   +:number+ values.
+      #   provided for `:geo` values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple `:datetime` or
+      #   `:number` values.
       #
       #   The following values are supported:
-      #   * +:default+ - The value is a string. The format will be automatically
+      #   * `:default` - The value is a string. The format will be automatically
       #     detected. This is the default value for strings.
-      #   * +:text+ - The value is a string with maximum length 1024**2
+      #   * `:text` - The value is a string with maximum length 1024**2
       #     characters.
-      #   * +:html+ - The value is an HTML-formatted string with maximum length
+      #   * `:html` - The value is an HTML-formatted string with maximum length
       #     1024**2 characters.
-      #   * +:atom+ - The value is a string with maximum length 500 characters.
-      #   * +:geo+ - The value is a point on earth described by latitude and
+      #   * `:atom` - The value is a string with maximum length 500 characters.
+      #   * `:geo` - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
       #     [ways of writing coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
-      #   * +:datetime+ - The value is a +DateTime+.
-      #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
+      #   * `:datetime` - The value is a `DateTime`.
+      #   * `:number` - The value is a `Numeric` between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
       # @param [String] lang The language of a string value. Must be a valid
@@ -140,7 +140,7 @@ module Gcloud
       #
       # @param [String] value The value to remove from the list of values.
       #
-      # @return [FieldValue, nil] The last deleted +FieldValue+, or +nil+ if no
+      # @return [FieldValue, nil] The last deleted `FieldValue`, or `nil` if no
       #   matching value is found.
       #
       # @example
@@ -162,13 +162,13 @@ module Gcloud
 
       ##
       # Deletes the value at the specified index, returning that FieldValue, or
-      # +nil+ if the index is out of range.
+      # `nil` if the index is out of range.
       #
       # @param [String] index The index of the value to be removed from the list
       #   of values.
       #
-      # @return [FieldValue] The deleted +FieldValue+ found at the specified
-      #   index, or # +nil+ if the index is out of range.
+      # @return [FieldValue] The deleted `FieldValue` found at the specified
+      #   index, or # `nil` if the index is out of range.
       #
       # @example
       #   require "gcloud"
@@ -210,7 +210,7 @@ module Gcloud
       end
 
       ##
-      # Returns +true+ if there are no values.
+      # Returns `true` if there are no values.
       def empty?
         @values.empty?
       end

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -18,7 +18,7 @@ require "gcloud/search/field_value"
 module Gcloud
   module Search
     ##
-    # = FieldValues
+    # # FieldValues
     #
     # The list of values for a field.
     #

--- a/lib/gcloud/search/fields.rb
+++ b/lib/gcloud/search/fields.rb
@@ -85,9 +85,6 @@ module Gcloud
         @hash[name] ||= FieldValues.new name
       end
 
-      # rubocop:disable Metrics/LineLength
-      # Disabled because there are links in the docs that are long.
-
       ##
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
@@ -112,13 +109,13 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     [ways of writing coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
       # @param [String] lang The language of a string value. Must be a valid
-      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
+      #   [ISO 639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
       #
       # @example
       #   require "gcloud"
@@ -139,8 +136,6 @@ module Gcloud
         @hash[name] ||= FieldValues.new name
         @hash[name].add value, type: type, lang: lang
       end
-
-      # rubocop:enable Metrics/LineLength
 
       ##
       # Deletes a field and all values.

--- a/lib/gcloud/search/fields.rb
+++ b/lib/gcloud/search/fields.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/search/field_values"
 require "gcloud/search/field_value"

--- a/lib/gcloud/search/fields.rb
+++ b/lib/gcloud/search/fields.rb
@@ -19,7 +19,7 @@ require "gcloud/search/field_value"
 module Gcloud
   module Search
     ##
-    # = Fields
+    # # Fields
     #
     # Fields is the object that provides access to a document's fields.
     #

--- a/lib/gcloud/search/fields.rb
+++ b/lib/gcloud/search/fields.rb
@@ -30,8 +30,9 @@ module Gcloud
     #
     # A field can have multiple values with same or different types; however, it
     # cannot have multiple datetime (DateTime) or number (Float) values. (See
-    # FieldValues and FieldValue)
+    # {FieldValues} and {FieldValue})
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -47,33 +48,27 @@ module Gcloud
     #     end
     #   end
     #
-    # For more information see {Documents and
-    # fields}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   fields
     #
     class Fields
       include Enumerable
 
       ##
-      # Create a new empty fields object.
-      def initialize #:nodoc:
+      # @private Create a new empty fields object.
+      def initialize
         @hash = {}
       end
 
       ##
       # Retrieve the field values associated to a field name.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @return [FieldValues]
       #
-      # === Returns
-      #
-      # FieldValues
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -99,18 +94,13 @@ module Gcloud
       # +:datetime+ or +:number+, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
-      # === Parameters
-      #
-      # +name+::
-      #   The name of the field. (+String+)
-      # +value+::
-      #   The value to add to the field. (+String+ or +Datetime+ or +Float+)
-      # +type+::
-      #   The type of the field value. An attempt is made to set the correct
-      #   type when this option is missing, although it must be provided for
-      #   +:geo+ values. A field can have multiple values with same or different
-      #   types; however, it cannot have multiple +:datetime+ or +:number+
-      #   values. (+Symbol+)
+      # @param [String] name The name of the field.
+      # @param [String, Datetime, Float] value The value to add to the field.
+      # @param [Symbol] type The type of the field value. An attempt is made to
+      #   set the correct type when this option is missing, although it must be
+      #   provided for +:geo+ values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple +:datetime+ or
+      #   +:number+ values.
       #
       #   The following values are supported:
       #   * +:default+ - The value is a string. The format will be automatically
@@ -122,19 +112,15 @@ module Gcloud
       #   * +:atom+ - The value is a string with maximum length 500 characters.
       #   * +:geo+ - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
-      #     {ways of writing
-      #     coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
+      #     {ways of writing coordinates}[http://en.wikipedia.org/wiki/Geographic_coordinate_conversion].
       #   * +:datetime+ - The value is a +DateTime+.
       #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
-      # +lang+::
-      #   The language of a string value. Must be a valid {ISO 639-1
-      #   code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
-      #   (+String+)
+      # @param [String] lang The language of a string value. Must be a valid
+      #   {ISO 639-1 code}[https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes].
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -159,13 +145,9 @@ module Gcloud
       ##
       # Deletes a field and all values.
       #
-      # === Parameters
+      # @param [String] name The name of the field.
       #
-      # +name+::
-      #   The name of the field. (+String+)
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -183,8 +165,7 @@ module Gcloud
       # Calls block once for each field, passing the field name and values pair
       # as parameters. If no block is given an enumerator is returned instead.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -208,6 +189,7 @@ module Gcloud
       ##
       # Returns a new array populated with all the field names.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -226,8 +208,8 @@ module Gcloud
       end
 
       ##
-      # Create a new Fields instance from a raw Hash.
-      def self.from_raw raw #:nodoc:
+      # @private Create a new Fields instance from a raw Hash.
+      def self.from_raw raw
         hsh = {}
         raw.each do |k, v|
           hsh[k] = FieldValues.from_raw k, v["values"]
@@ -238,8 +220,9 @@ module Gcloud
       end
 
       ##
-      # Create a raw Hash object containing all the field names and values.
-      def to_raw #:nodoc:
+      # @private Create a raw Hash object containing all the field names and
+      # values.
+      def to_raw
         hsh = {}
         @hash.each do |k, v|
           hsh[k] = v.to_raw unless v.empty?
@@ -250,8 +233,8 @@ module Gcloud
       protected
 
       ##
-      # Find all the fields that have values. This is needed because a field is
-      # required to have at least one value.
+      # @private Find all the fields that have values. This is needed because a
+      # field is required to have at least one value.
       #
       # Users can remove all values, and the empty FieldValues object will
       # remain in the internal hash. This is the same as not having that field.
@@ -259,7 +242,7 @@ module Gcloud
       # Users can also reference the field by name before adding a value. So we
       # have multiple valid use cases which add an empty FieldValues object to
       # the hash.
-      def fields_with_values #:nodoc:
+      def fields_with_values
         @hash.select { |_name, values| values.any? }
       end
     end

--- a/lib/gcloud/search/fields.rb
+++ b/lib/gcloud/search/fields.rb
@@ -88,30 +88,30 @@ module Gcloud
       ##
       # Add a new value. If the field name does not exist it will be added. If
       # the field value is a DateTime or Numeric, or the type is set to
-      # +:datetime+ or +:number+, then the added value will replace any existing
+      # `:datetime` or `:number`, then the added value will replace any existing
       # values of the same type (since there can be only one).
       #
       # @param [String] name The name of the field.
       # @param [String, Datetime, Float] value The value to add to the field.
       # @param [Symbol] type The type of the field value. An attempt is made to
       #   set the correct type when this option is missing, although it must be
-      #   provided for +:geo+ values. A field can have multiple values with same
-      #   or different types; however, it cannot have multiple +:datetime+ or
-      #   +:number+ values.
+      #   provided for `:geo` values. A field can have multiple values with same
+      #   or different types; however, it cannot have multiple `:datetime` or
+      #   `:number` values.
       #
       #   The following values are supported:
-      #   * +:default+ - The value is a string. The format will be automatically
+      #   * `:default` - The value is a string. The format will be automatically
       #     detected. This is the default value for strings.
-      #   * +:text+ - The value is a string with maximum length 1024**2
+      #   * `:text` - The value is a string with maximum length 1024**2
       #     characters.
-      #   * +:html+ - The value is an HTML-formatted string with maximum length
+      #   * `:html` - The value is an HTML-formatted string with maximum length
       #     1024**2 characters.
-      #   * +:atom+ - The value is a string with maximum length 500 characters.
-      #   * +:geo+ - The value is a point on earth described by latitude and
+      #   * `:atom` - The value is a string with maximum length 500 characters.
+      #   * `:geo` - The value is a point on earth described by latitude and
       #     longitude coordinates, represented in string with any of the listed
       #     [ways of writing coordinates](http://en.wikipedia.org/wiki/Geographic_coordinate_conversion).
-      #   * +:datetime+ - The value is a +DateTime+.
-      #   * +:number+ - The value is a +Numeric+ between -2,147,483,647 and
+      #   * `:datetime` - The value is a `DateTime`.
+      #   * `:number` - The value is a `Numeric` between -2,147,483,647 and
       #     2,147,483,647. The value will be stored as a double precision
       #     floating point value in Cloud Search.
       # @param [String] lang The language of a string value. Must be a valid

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -401,7 +401,7 @@ module Gcloud
       # query.
       #
       # By default, Result objects are sorted by document rank. For more information
-      # see the {REST API documentation for Document.rank}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank].
+      # see the [REST API documentation for Document.rank](https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank).
       #
       # You can specify how to sort results with the +order+ option. In the
       # example below, the <code>-</code> character before +avg_review+ means
@@ -415,8 +415,8 @@ module Gcloud
       #
       # @param [String] query The query string in search query syntax. If the
       #   query is +nil+ or empty, all documents are returned. For more
-      #   information see {Query
-      #   Strings}[https://cloud.google.com/search/query].
+      #   information see [Query
+      #   Strings](https://cloud.google.com/search/query).
       # @param [Hash] expressions Customized expressions used in +order+ or
       #   +fields+. The expression can contain fields in Document, the built-in
       #   fields ( +rank+, the document +rank+, and +score+ if scoring is

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -22,15 +22,16 @@ module Gcloud
     ##
     # = Index
     #
-    # An index manages Document instances for retrieval. Indexes cannot be
+    # An index manages {Document} instances for retrieval. Indexes cannot be
     # created, updated, or deleted directly on the server: They are derived from
     # the documents that reference them. You can manage groups of documents by
     # putting them into separate indexes.
     #
-    # With an index, you can retrieve documents with #find and #documents;
-    # manage them with #document, #save, and #remove; and perform searches over
-    # their fields with #search.
+    # With an index, you can retrieve documents with {#find} and {#documents};
+    # manage them with {#document}, {#save}, and {#remove}; and perform searches
+    # over their fields with {#search}.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -42,22 +43,22 @@ module Gcloud
     #     puts result.doc_id
     #   end
     #
-    # For more information, see {Documents and
-    # Indexes}[https://cloud.google.com/search/documents_indexes].
+    # @see https://cloud.google.com/search/documents_indexes Documents and
+    #   Indexes
     #
     class Index
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The raw data object.
-      attr_accessor :raw #:nodoc:
+      # @private The raw data object.
+      attr_accessor :raw
 
       ##
-      # Creates a new Index instance.
+      # @private Creates a new Index instance.
       #
-      def initialize #:nodoc:
+      def initialize
         @connection = nil
         @raw = nil
       end
@@ -74,48 +75,54 @@ module Gcloud
       end
 
       ##
-      # The names of fields in which TEXT values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which TEXT values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def text_fields
         return @raw["indexedField"]["textFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which HTML values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which HTML values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def html_fields
         return @raw["indexedField"]["htmlFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which ATOM values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which ATOM values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def atom_fields
         return @raw["indexedField"]["atomFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which DATE values are stored. See {Index schemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which DATE values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def datetime_fields
         return @raw["indexedField"]["dateFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which NUMBER values are stored. See {Indexschemas
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which NUMBER values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def number_fields
         return @raw["indexedField"]["numberFields"] if @raw["indexedField"]
         []
       end
 
       ##
-      # The names of fields in which GEO values are stored. See {Index
-      # }[https://cloud.google.com/search/documents_indexes#index_schemas].
+      # The names of fields in which GEO values are stored.
+      # @see https://cloud.google.com/search/documents_indexes#index_schemas
+      #   Index schemas
       def geo_fields
         return @raw["indexedField"]["geoFields"] if @raw["indexedField"]
         []
@@ -144,17 +151,12 @@ module Gcloud
       ##
       # Retrieves an existing document by id.
       #
-      # === Parameters
+      # @param [String, Gcloud::Search::Document] doc_id The id of a document or
+      #   a Document instance.
+      # @return [Gcloud::Search::Document, nil] Returns +nil+ if the document
+      #   does not exist
       #
-      # +doc_id+::
-      #   The id of a document or a Document instance. (+String+ or Document)
-      #
-      # === Returns
-      #
-      # Gcloud::Search::Document or +nil+ if the document does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -179,36 +181,29 @@ module Gcloud
 
       ##
       # Helper for creating a new Document instance. The returned instance is
-      # local: It is either not yet saved to the service (see #save), or if it
+      # local: It is either not yet saved to the service (see {#save}), or if it
       # has been given the id of an existing document, it is not yet populated
-      # with the document's data (see #find).
+      # with the document's data (see {#find}).
       #
-      # === Parameters
+      # @param [String, nil] doc_id An optional unique ID for the new document.
+      #   When the document is saved, this value must contain only visible,
+      #   printable ASCII characters (ASCII codes 33 through 126 inclusive) and
+      #   be no longer than 500 characters. It cannot begin with an exclamation
+      #   point (<code>!</code>), and it cannot begin and end with double
+      #   underscores (<code>__</code>).
+      # @param [Integer, nil] rank An optional rank for the new document. An
+      #   integer which determines the default ordering of documents returned
+      #   from a search. It is a bad idea to assign the same rank to many
+      #   documents, and the same rank should never be assigned to more than
+      #   10,000 documents. By default (when it is not specified or set to 0),
+      #   it is set at the time the document is saved to the number of seconds
+      #   since January 1, 2011. The rank can be used in the +expressions+,
+      #   +order+, and +fields+ options in {#search}, where it should referenced
+      #   as +rank+.
       #
-      # +doc_id+::
-      #   The unique identifier of the new document. This is optional. When the
-      #   document is saved, this value must contain only visible, printable
-      #   ASCII characters (ASCII codes 33 through 126 inclusive) and be no
-      #   longer than 500 characters. It cannot begin with an exclamation point
-      #   (<code>!</code>), and it cannot begin and end with double underscores
-      #   (<code>__</code>). (+String+)
-      # +rank+::
-      #   The rank of the new document. This is optional. A positive integer
-      #   which determines the default ordering of documents returned from a
-      #   search. It is a bad idea to assign the same rank to many documents,
-      #   and the same rank should never be assigned to more than 10,000
-      #   documents. By default (when it is not specified or set to 0), it is
-      #   set at the time the document is saved to the number of seconds since
-      #   January 1, 2011. The rank can be used in the +expressions+, +order+,
-      #   and +fields+ options in #search, where it should referenced as
-      #   +rank+. (+Integer+)
+      # @return [Gcloud::Search::Document]
       #
-      # === Returns
-      #
-      # Gcloud::Search::Document
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -219,8 +214,7 @@ module Gcloud
       #   document.doc_id #=> nil
       #   document.rank #=> nil
       #
-      # To check if an index already contains a document with the same id, pass
-      # the instance to #find:
+      # @example To check if an index already contains a document:
       #
       #   require "gcloud"
       #
@@ -241,21 +235,14 @@ module Gcloud
       ##
       # Retrieves the list of documents belonging to the index.
       #
-      # === Parameters
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of documents to return. The default
+      #   is +100+.
+      # @return [Array<Gcloud::Search::Document>] See
+      #   {Gcloud::Search::Document::List})
       #
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of documents to return. The default is +100+.
-      #   (+Integer+)
-      #
-      # === Returns
-      #
-      # Array of Gcloud::Search::Document (See Gcloud::Search::Document::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -267,8 +254,7 @@ module Gcloud
       #     puts index.index_id
       #   end
       #
-      # If you have a significant number of documents, you may need to paginate
-      # through them: (See Gcloud::Search::Document::List)
+      # @example With pagination: (See {Gcloud::Search::Document::List})
       #
       #   require "gcloud"
       #
@@ -295,21 +281,15 @@ module Gcloud
 
       ##
       # Saves a new or existing document to the index. If the document instance
-      # is new and has been given an id (see #document), it will replace an
+      # is new and has been given an id (see {#document}), it will replace an
       # existing document in the index that has the same unique id.
       #
-      # === Parameters
+      # @param [Gcloud::Search::Document] document A Document instance, either
+      #   new (see {#document}) or existing (see {#find}).
       #
-      # +document+::
-      #   A Document instance, either new (see #document) or existing (see
-      #   #find).
+      # @return [Gcloud::Search::Document]
       #
-      # === Returns
-      #
-      # Gcloud::Search::Document
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -340,17 +320,10 @@ module Gcloud
       ##
       # Permanently deletes the document from the index.
       #
-      # === Parameters
+      # @param [String] doc_id The id of the document.
+      # @return [Boolean] +true+ if successful
       #
-      # +doc_id+::
-      #   The id of the document. (+String+)
-      #
-      # === Returns
-      #
-      # +true+ if successful
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -373,24 +346,19 @@ module Gcloud
       # be created, updated, or deleted directly on the server: They are derived
       # from the documents that reference them.)
       #
-      # === Parameters
+      # @param [Boolean] force If +true+, ensures the deletion of the index by
+      #   first deleting all documents. If +false+ and the index contains
+      #   documents, the request will fail. Default is +false+.
       #
-      # +force+::
-      #   If +true+, ensures the deletion of the index by first deleting all
-      #   documents. If +false+ and the index contains documents, the request
-      #   will fail. Default is +false+. (+Boolean+)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   search = gcloud.search
       #   index = search.index "books"
+      #   index.delete
       #
-      # An index containing documents can be forcefully deleted with the +force+
-      # option:
-      #
+      # @example Deleting an index containing documents with the +force+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -417,8 +385,8 @@ module Gcloud
       end
 
       ##
-      # New Index from a raw data object.
-      def self.from_raw raw, conn #:nodoc:
+      # @private New Index from a raw data object.
+      def self.from_raw raw, conn
         new.tap do |f|
           f.raw = raw
           f.connection = conn
@@ -430,76 +398,76 @@ module Gcloud
 
       ##
       # Runs a search against the documents in the index using the provided
-      # query. For more information see the REST API documentation for
-      # {indexes.search}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/search].
+      # query.
       #
-      # === Parameters
+      # By default, Result objects are sorted by document rank. For more information
+      # see the {REST API documentation for Document.rank}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank].
       #
-      # +query+::
-      #   The query string in search query syntax. If the query is +nil+ or
-      #   empty, all documents are returned. For more information see {Query
-      #   Strings}[https://cloud.google.com/search/query]. (+String+)
-      # +expressions+::
-      #   Customized expressions used in +order+ or +fields+. The expression can
-      #   contain fields in Document, the built-in fields ( +rank+, the document
-      #   +rank+, and +score+ if scoring is enabled) and fields defined in
-      #   +expressions+. All field expressions expressed as a +Hash+ with the
-      #   keys as the +name+ and the values as the +expression+. The expression
-      #   value can be a combination of supported functions encoded in the
-      #   string. Expressions involving number fields can use the arithmetical
-      #   operators (+, -, *, /) and the built-in numeric functions (+max+,
-      #   +min+, +pow+, +count+, +log+, +abs+). Expressions involving geopoint
-      #   fields can use the +geopoint+ and +distance+ functions. Expressions
-      #   for text and html fields can use the +snippet+ function. (+Hash+)
-      # +matched_count_accuracy+::
-      #   Minimum accuracy requirement for Result::List#matched_count. If
-      #   specified, +matched_count+ will be accurate to at least that number.
-      #   For example, when set to 100, any <code>matched_count <= 100</code> is
-      #   accurate. This option may add considerable latency/expense. By default
-      #   (when it is not specified or set to 0), the accuracy is the same as
-      #   +max+. (+Integer+)
-      # +offset+::
-      #   Used to advance pagination to an arbitrary result, independent of the
-      #   previous results. Offsets are an inefficient alternative to using
-      #   +token+. (Both cannot be both set.) The default is 0.
-      #   (+Integer+)
-      # +order+::
-      #   A comma-separated list of fields for sorting on the search result,
-      #   including fields from Document, the built-in fields (+rank+ and
-      #   +score+), and fields defined in expressions. The default sorting
-      #   order is ascending. To specify descending order for a field, a suffix
-      #   <code>" desc"</code> should be appended to the field name. For
+      # You can specify how to sort results with the +order+ option. In the
+      # example below, the <code>-</code> character before +avg_review+ means
+      # that results will be sorted in ascending order by +published+ and then
+      # in descending order by +avg_review+. You can add computed fields with
+      # the +expressions+ option, and limit the fields that are returned with
+      # the +fields+ option.
+      #
+      # @see https://cloud.google.com/search/reference/rest/v1/projects/indexes/search
+      #   The REST API documentation for indexes.search
+      #
+      # @param [String] query The query string in search query syntax. If the
+      #   query is +nil+ or empty, all documents are returned. For more
+      #   information see {Query
+      #   Strings}[https://cloud.google.com/search/query].
+      # @param [Hash] expressions Customized expressions used in +order+ or
+      #   +fields+. The expression can contain fields in Document, the built-in
+      #   fields ( +rank+, the document +rank+, and +score+ if scoring is
+      #   enabled) and fields defined in +expressions+. All field expressions
+      #   expressed as a +Hash+ with the keys as the +name+ and the values as
+      #   the +expression+. The expression value can be a combination of
+      #   supported functions encoded in the string. Expressions involving
+      #   number fields can use the arithmetical operators (+, -, *, /) and the
+      #   built-in numeric functions (+max+, +min+, +pow+, +count+, +log+,
+      #   +abs+). Expressions involving geopoint fields can use the +geopoint+
+      #   and +distance+ functions. Expressions for text and html fields can use
+      #   the +snippet+ function.
+      # @param [Integer] matched_count_accuracy Minimum accuracy requirement for
+      #   {Result::List#matched_count}. If specified, +matched_count+ will be
+      #   accurate to at least that number. For example, when set to 100, any
+      #   <code>matched_count <= 100</code> is accurate. This option may add
+      #   considerable latency/expense. By default (when it is not specified or
+      #   set to 0), the accuracy is the same as +max+.
+      # @param [Integer] offset Used to advance pagination to an arbitrary
+      #   result, independent of the previous results. Offsets are an
+      #   inefficient alternative to using +token+. (Both cannot be both set.)
+      #   The default is 0.
+      # @param [String] order A comma-separated list of fields for sorting on
+      #   the search result, including fields from Document, the built-in fields
+      #   (+rank+ and +score+), and fields defined in expressions. The default
+      #   sorting order is ascending. To specify descending order for a field, a
+      #   suffix <code>" desc"</code> should be appended to the field name. For
       #   example: <code>orderBy="foo desc,bar"</code>. The default value for
       #   text sort is the empty string, and the default value for numeric sort
       #   is 0. If not specified, the search results are automatically sorted by
       #   descending +rank+. Sorting by ascending +rank+ is not allowed.
-      #   (+String+)
-      # +fields+::
-      #   The fields to return in the Search::Result objects. These can be
-      #   fields from Document, the built-in fields +rank+ and +score+, and
-      #   fields defined in expressions. The default is to return all fields.
-      #   (+String+ or +Array+ of +String+)
-      # +scorer+::
-      #   The scoring function to invoke on a search result for this query. If
-      #   scorer is not set, scoring is disabled and +score+ is 0 for all
-      #   documents in the search result. To enable document relevancy score
-      #   based on term frequency, set +scorer+ to +:generic+.
-      #   (+String+ or +Symbol+)
-      # +scorer_size+::
-      #   Maximum number of top retrieved results to score. It is valid only
-      #   when +scorer+ is set. The default is 100. (+Integer+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of results to return per page. (+Integer+)
+      # @param [String, Array<String>] fields The fields to return in the
+      #   {Search::Result} objects. These can be fields from {Document}, the
+      #   built-in fields +rank+ and +score+, and fields defined in expressions.
+      #   The default is to return all fields.
+      # @param [String, Symbol] scorer The scoring function to invoke on a
+      #   search result for this query. If scorer is not set, scoring is
+      #   disabled and +score+ is 0 for all documents in the search result. To
+      #   enable document relevancy score based on term frequency, set +scorer+
+      #   to +:generic+.
+      # @param [Integer] scorer_size Maximum number of top retrieved results to
+      #   score. It is valid only when +scorer+ is set. The default is 100.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set
+      #   of results to view.
+      # @param [Integer] max Maximum number of results to return per page.
       #
-      # === Returns
+      # @return [Array<Gcloud::Search::Result>] (See
+      #   {Gcloud::Search::Result::List})
       #
-      # Array of Gcloud::Search::Result (See Gcloud::Search::Result::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -511,8 +479,7 @@ module Gcloud
       #     puts result.doc_id
       #   end
       #
-      # If you have a significant number of search results, you may need to
-      # paginate through them: (See Gcloud::Search::Result::List)
+      # @example With pagination: (See {Gcloud::Search::Result::List})
       #
       #   require "gcloud"
       #
@@ -529,14 +496,7 @@ module Gcloud
       #     results = results.next
       #   end
       #
-      # By default, Result objects are sorted by document rank. For more information
-      # see the {REST API documentation for Document.rank}[https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank].
-      #
-      # You can specify how to sort results with the +order+ option. In the example
-      # below, the <code>-</code> character before +avg_review+ means that results
-      # will be sorted in ascending order by +published+ and then in descending
-      # order by +avg_review+.
-      #
+      # @example With the +order+ option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -546,8 +506,7 @@ module Gcloud
       #   results = index.search "dark stormy", order: "published, avg_review desc"
       #   documents = index.search query # API call
       #
-      # You can add computed fields with the +expressions+ option, and limit the
-      # fields that are returned with the +fields+ option:
+      # @example With the +fields+ option:
       #
       #   require "gcloud"
       #
@@ -559,7 +518,7 @@ module Gcloud
       #                          expressions: { total_price: "(price + tax)" },
       #                          fields: ["name", "total_price", "highlight"]
       #
-      # Just as in documents, Result data is accessible via Fields methods:
+      # @example Just as in documents, data is accessible via {Fields} methods:
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -20,7 +20,7 @@ require "gcloud/search/result"
 module Gcloud
   module Search
     ##
-    # = Index
+    # # Index
     #
     # An index manages {Document} instances for retrieval. Indexes cannot be
     # created, updated, or deleted directly on the server: They are derived from

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -153,7 +153,7 @@ module Gcloud
       #
       # @param [String, Gcloud::Search::Document] doc_id The id of a document or
       #   a Document instance.
-      # @return [Gcloud::Search::Document, nil] Returns +nil+ if the document
+      # @return [Gcloud::Search::Document, nil] Returns `nil` if the document
       #   does not exist
       #
       # @example
@@ -197,9 +197,9 @@ module Gcloud
       #   documents, and the same rank should never be assigned to more than
       #   10,000 documents. By default (when it is not specified or set to 0),
       #   it is set at the time the document is saved to the number of seconds
-      #   since January 1, 2011. The rank can be used in the +expressions+,
-      #   +order+, and +fields+ options in {#search}, where it should referenced
-      #   as +rank+.
+      #   since January 1, 2011. The rank can be used in the `expressions`,
+      #   `order`, and `fields` options in {#search}, where it should referenced
+      #   as `rank`.
       #
       # @return [Gcloud::Search::Document]
       #
@@ -238,7 +238,7 @@ module Gcloud
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
       # @param [Integer] max Maximum number of documents to return. The default
-      #   is +100+.
+      #   is `100`.
       # @return [Array<Gcloud::Search::Document>] See
       #   {Gcloud::Search::Document::List})
       #
@@ -321,7 +321,7 @@ module Gcloud
       # Permanently deletes the document from the index.
       #
       # @param [String] doc_id The id of the document.
-      # @return [Boolean] +true+ if successful
+      # @return [Boolean] `true` if successful
       #
       # @example
       #   require "gcloud"
@@ -346,9 +346,9 @@ module Gcloud
       # be created, updated, or deleted directly on the server: They are derived
       # from the documents that reference them.)
       #
-      # @param [Boolean] force If +true+, ensures the deletion of the index by
-      #   first deleting all documents. If +false+ and the index contains
-      #   documents, the request will fail. Default is +false+.
+      # @param [Boolean] force If `true`, ensures the deletion of the index by
+      #   first deleting all documents. If `false` and the index contains
+      #   documents, the request will fail. Default is `false`.
       #
       # @example
       #   require "gcloud"
@@ -358,7 +358,7 @@ module Gcloud
       #   index = search.index "books"
       #   index.delete
       #
-      # @example Deleting an index containing documents with the +force+ option:
+      # @example Deleting an index containing documents with the `force` option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -403,62 +403,62 @@ module Gcloud
       # By default, Result objects are sorted by document rank. For more information
       # see the [REST API documentation for Document.rank](https://cloud.google.com/search/reference/rest/v1/projects/indexes/documents#resource_representation.google.cloudsearch.v1.Document.rank).
       #
-      # You can specify how to sort results with the +order+ option. In the
-      # example below, the <code>-</code> character before +avg_review+ means
-      # that results will be sorted in ascending order by +published+ and then
-      # in descending order by +avg_review+. You can add computed fields with
-      # the +expressions+ option, and limit the fields that are returned with
-      # the +fields+ option.
+      # You can specify how to sort results with the `order` option. In the
+      # example below, the <code>-</code> character before `avg_review` means
+      # that results will be sorted in ascending order by `published` and then
+      # in descending order by `avg_review`. You can add computed fields with
+      # the `expressions` option, and limit the fields that are returned with
+      # the `fields` option.
       #
       # @see https://cloud.google.com/search/reference/rest/v1/projects/indexes/search
       #   The REST API documentation for indexes.search
       #
       # @param [String] query The query string in search query syntax. If the
-      #   query is +nil+ or empty, all documents are returned. For more
+      #   query is `nil` or empty, all documents are returned. For more
       #   information see [Query
       #   Strings](https://cloud.google.com/search/query).
-      # @param [Hash] expressions Customized expressions used in +order+ or
-      #   +fields+. The expression can contain fields in Document, the built-in
-      #   fields ( +rank+, the document +rank+, and +score+ if scoring is
-      #   enabled) and fields defined in +expressions+. All field expressions
-      #   expressed as a +Hash+ with the keys as the +name+ and the values as
-      #   the +expression+. The expression value can be a combination of
+      # @param [Hash] expressions Customized expressions used in `order` or
+      #   `fields`. The expression can contain fields in Document, the built-in
+      #   fields ( `rank`, the document `rank`, and `score` if scoring is
+      #   enabled) and fields defined in `expressions`. All field expressions
+      #   expressed as a `Hash` with the keys as the `name` and the values as
+      #   the `expression`. The expression value can be a combination of
       #   supported functions encoded in the string. Expressions involving
       #   number fields can use the arithmetical operators (+, -, *, /) and the
-      #   built-in numeric functions (+max+, +min+, +pow+, +count+, +log+,
-      #   +abs+). Expressions involving geopoint fields can use the +geopoint+
-      #   and +distance+ functions. Expressions for text and html fields can use
-      #   the +snippet+ function.
+      #   built-in numeric functions (`max`, `min`, `pow`, `count`, `log`,
+      #   `abs`). Expressions involving geopoint fields can use the `geopoint`
+      #   and `distance` functions. Expressions for text and html fields can use
+      #   the `snippet` function.
       # @param [Integer] matched_count_accuracy Minimum accuracy requirement for
-      #   {Result::List#matched_count}. If specified, +matched_count+ will be
+      #   {Result::List#matched_count}. If specified, `matched_count` will be
       #   accurate to at least that number. For example, when set to 100, any
       #   <code>matched_count <= 100</code> is accurate. This option may add
       #   considerable latency/expense. By default (when it is not specified or
-      #   set to 0), the accuracy is the same as +max+.
+      #   set to 0), the accuracy is the same as `max`.
       # @param [Integer] offset Used to advance pagination to an arbitrary
       #   result, independent of the previous results. Offsets are an
-      #   inefficient alternative to using +token+. (Both cannot be both set.)
+      #   inefficient alternative to using `token`. (Both cannot be both set.)
       #   The default is 0.
       # @param [String] order A comma-separated list of fields for sorting on
       #   the search result, including fields from Document, the built-in fields
-      #   (+rank+ and +score+), and fields defined in expressions. The default
+      #   (`rank` and `score`), and fields defined in expressions. The default
       #   sorting order is ascending. To specify descending order for a field, a
       #   suffix <code>" desc"</code> should be appended to the field name. For
       #   example: <code>orderBy="foo desc,bar"</code>. The default value for
       #   text sort is the empty string, and the default value for numeric sort
       #   is 0. If not specified, the search results are automatically sorted by
-      #   descending +rank+. Sorting by ascending +rank+ is not allowed.
+      #   descending `rank`. Sorting by ascending `rank` is not allowed.
       # @param [String, Array<String>] fields The fields to return in the
       #   {Search::Result} objects. These can be fields from {Document}, the
-      #   built-in fields +rank+ and +score+, and fields defined in expressions.
+      #   built-in fields `rank` and `score`, and fields defined in expressions.
       #   The default is to return all fields.
       # @param [String, Symbol] scorer The scoring function to invoke on a
       #   search result for this query. If scorer is not set, scoring is
-      #   disabled and +score+ is 0 for all documents in the search result. To
-      #   enable document relevancy score based on term frequency, set +scorer+
-      #   to +:generic+.
+      #   disabled and `score` is 0 for all documents in the search result. To
+      #   enable document relevancy score based on term frequency, set `scorer`
+      #   to `:generic`.
       # @param [Integer] scorer_size Maximum number of top retrieved results to
-      #   score. It is valid only when +scorer+ is set. The default is 100.
+      #   score. It is valid only when `scorer` is set. The default is 100.
       # @param [String] token A previously-returned page token representing part
       #   of the larger set
       #   of results to view.
@@ -496,7 +496,7 @@ module Gcloud
       #     results = results.next
       #   end
       #
-      # @example With the +order+ option:
+      # @example With the `order` option:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -506,7 +506,7 @@ module Gcloud
       #   results = index.search "dark stormy", order: "published, avg_review desc"
       #   documents = index.search query # API call
       #
-      # @example With the +fields+ option:
+      # @example With the `fields` option:
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/search/document"
 require "gcloud/search/index/list"

--- a/lib/gcloud/search/index/list.rb
+++ b/lib/gcloud/search/index/list.rb
@@ -25,7 +25,7 @@ module Gcloud
         attr_accessor :token
 
         ##
-        # Create a new Index::List with an array of Index instances.
+        # Create a new Index::List with an array of {Index} instances.
         def initialize arr = []
           super arr
         end
@@ -50,7 +50,7 @@ module Gcloud
         end
 
         ##
-        # Retrieves all indexes by repeatedly loading pages until #next?
+        # Retrieves all indexes by repeatedly loading pages until {#next?}
         # returns false. Returns the list instance for method chaining.
         def all
           while next?
@@ -62,8 +62,8 @@ module Gcloud
         end
 
         ##
-        # New Indexs::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Index::List from a response object.
+        def self.from_response resp, conn
           data = JSON.parse resp.body
           indexes = new(Array(data["indexes"]).map do |raw_index|
             Index.from_raw raw_index, conn

--- a/lib/gcloud/search/index/list.rb
+++ b/lib/gcloud/search/index/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Search

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/gce"
 require "gcloud/search/connection"

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -22,7 +22,7 @@ require "gcloud/search/errors"
 module Gcloud
   module Search
     ##
-    # = Project
+    # # Project
     #
     # Projects are top-level containers in Google Cloud Platform. They store
     # information about billing and authorized users, and they control access to

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -85,7 +85,7 @@ module Gcloud
       # @param [Boolean] skip_lookup Optionally create an Index object without
       #   verifying the index resource exists on the Search service. Documents
       #   saved on this object will create the index resource if the resource
-      #   does not yet exist. Default is +false+.
+      #   does not yet exist. Default is `false`.
       #
       # @return [Gcloud::Search::Index, nil] nil if the index does not exist
       #
@@ -98,7 +98,7 @@ module Gcloud
       #   index = search.index "books"
       #   index.index_id #=> "books"
       #
-      # @example A new index can be created with +index_id+ and +skip_lookup+:
+      # @example A new index can be created with `index_id` and `skip_lookup`:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -127,7 +127,7 @@ module Gcloud
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
       # @param [Integer] max Maximum number of indexes to return. The default is
-      #   +100+.
+      #   `100`.
       #
       # @return [Array<Gcloud::Search::Index>] (See
       #   {Gcloud::Search::Index::List})

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -27,8 +27,8 @@ module Gcloud
     # Projects are top-level containers in Google Cloud Platform. They store
     # information about billing and authorized users, and they control access to
     # Google Cloud Search resources. Each project has a friendly name and a
-    # unique ID. Projects can be created only in the {Google Developers
-    # Console}[https://console.developers.google.com]. See {Gcloud#search}.
+    # unique ID. Projects can be created only in the [Google Developers
+    # Console](https://console.developers.google.com). See {Gcloud#search}.
     #
     # @example
     #   require "gcloud"

--- a/lib/gcloud/search/project.rb
+++ b/lib/gcloud/search/project.rb
@@ -28,25 +28,25 @@ module Gcloud
     # information about billing and authorized users, and they control access to
     # Google Cloud Search resources. Each project has a friendly name and a
     # unique ID. Projects can be created only in the {Google Developers
-    # Console}[https://console.developers.google.com].
+    # Console}[https://console.developers.google.com]. See {Gcloud#search}.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
     #   search = gcloud.search
     #   index = search.index "books"
     #
-    # See Gcloud#search
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Connection instance.
+      # @private Creates a new Connection instance.
       #
       # See Gcloud.search
-      def initialize project, credentials #:nodoc:
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -55,8 +55,9 @@ module Gcloud
       ##
       # The ID of the current project.
       #
-      # === Example
+      # @return [String]
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-project", "/path/to/keyfile.json"
@@ -69,8 +70,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["SEARCH_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -80,22 +81,15 @@ module Gcloud
       ##
       # Retrieves an existing index by ID.
       #
-      # === Parameters
+      # @param [String] index_id The ID of an index.
+      # @param [Boolean] skip_lookup Optionally create an Index object without
+      #   verifying the index resource exists on the Search service. Documents
+      #   saved on this object will create the index resource if the resource
+      #   does not yet exist. Default is +false+.
       #
-      # +index_id+::
-      #   The ID of an index. (+String+)
-      # +skip_lookup+::
-      #   Optionally create an Index object without verifying the index resource
-      #   exists on the Search service. Documents saved on this object will
-      #   create the index resource if the resource does not yet exist. Default
-      #   is +false+. (+Boolean+)
+      # @return [Gcloud::Search::Index, nil] nil if the index does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Search::Index or nil if the index does not exist
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -104,9 +98,7 @@ module Gcloud
       #   index = search.index "books"
       #   index.index_id #=> "books"
       #
-      # A new index can be created by providing the desired +index_id+ and the
-      # +skip_lookup+ option:
-      #
+      # @example A new index can be created with +index_id+ and +skip_lookup+:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -130,23 +122,17 @@ module Gcloud
       ##
       # Retrieves the list of indexes belonging to the project.
       #
-      # === Parameters
+      # @param [String] prefix The prefix of the index name. It is used to list
+      #   all indexes with names that have this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of indexes to return. The default is
+      #   +100+.
       #
-      # +prefix+::
-      #   The prefix of the index name. It is used to list all indexes with
-      #   names that have this prefix. (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of indexes to return. The default is +100+. (+Integer+)
+      # @return [Array<Gcloud::Search::Index>] (See
+      #   {Gcloud::Search::Index::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Search::Index (See Gcloud::Search::Index::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -157,9 +143,7 @@ module Gcloud
       #     puts index.index_id
       #   end
       #
-      # If you have a significant number of indexes, you may need to paginate
-      # through them: (See Gcloud::Search::Index::List)
-      #
+      # @example Using pagination: (See {Gcloud::Search::Index::List})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/search/result.rb
+++ b/lib/gcloud/search/result.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/search/result/list"
 require "gcloud/search/fields"

--- a/lib/gcloud/search/result.rb
+++ b/lib/gcloud/search/result.rb
@@ -19,7 +19,7 @@ require "gcloud/search/fields"
 module Gcloud
   module Search
     ##
-    # = Result
+    # # Result
     #
     # See {Gcloud#search}
     class Result

--- a/lib/gcloud/search/result.rb
+++ b/lib/gcloud/search/result.rb
@@ -21,23 +21,27 @@ module Gcloud
     ##
     # = Result
     #
-    # See Gcloud#search
+    # See {Gcloud#search}
     class Result
       ##
-      # Creates a new Result instance.
-      def initialize #:nodoc:
+      # @private Creates a new Result instance.
+      def initialize
         @fields = Fields.new
         @raw = {}
       end
 
       ##
       # The unique identifier of the document referenced in the search result.
+      #
+      # @return [String]
       def doc_id
         @raw["docId"]
       end
 
       ##
       # The token for the next page of results.
+      #
+      # @return [String]
       def token
         @raw["nextPageToken"]
       end
@@ -45,18 +49,12 @@ module Gcloud
       ##
       # Retrieve the field values associated to a field name.
       #
-      # === Parameters
+      # @param [String] name The name of the field. New values will be
+      #   configured with this name.
       #
-      # +name+::
-      #   The name of the field. New values will be configured with this name.
-      #   (+String+)
+      # @return [FieldValue]
       #
-      # === Returns
-      #
-      # FieldValue
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -80,7 +78,7 @@ module Gcloud
 
       ##
       # The fields in the search result. Each field has a name (String) and a
-      # list of values (FieldValues). (See Fields)
+      # list of values ({FieldValues}). (See {Fields})
       def fields
         @fields
       end
@@ -90,10 +88,9 @@ module Gcloud
       ##
       # Calls block once for each field, passing the field name and values pair
       # as parameters. If no block is given an enumerator is returned instead.
-      # (See Fields#each)
+      # (See {Fields#each})
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -116,8 +113,11 @@ module Gcloud
 
       ##
       # Returns a new array populated with all the field names.
-      # (See Fields#names)
+      # (See {Fields#names})
       #
+      # @return [Array<String>]
+      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -136,8 +136,8 @@ module Gcloud
       end
 
       ##
-      # Override to keep working in interactive shells manageable.
-      def inspect #:nodoc:
+      # @private Override to keep working in interactive shells manageable.
+      def inspect
         insp_token = ""
         if token
           trunc_token = "#{token[0, 8]}...#{token[-5..-1]}"
@@ -149,8 +149,8 @@ module Gcloud
       end
 
       ##
-      # New Result from a raw data object.
-      def self.from_hash hash #:nodoc:
+      # @private New Result from a raw data object.
+      def self.from_hash hash
         result = new
         result.instance_variable_set "@raw", hash
         result.instance_variable_set "@fields", Fields.from_raw(hash["fields"])
@@ -158,8 +158,8 @@ module Gcloud
       end
 
       ##
-      # Returns the Result data as a hash
-      def to_hash #:nodoc:
+      # @private Returns the Result data as a hash
+      def to_hash
         hash = @raw.dup
         hash["fields"] = @fields.to_raw
         hash

--- a/lib/gcloud/search/result/list.rb
+++ b/lib/gcloud/search/result/list.rb
@@ -28,7 +28,7 @@ module Gcloud
         # The number of documents that match the query. It is greater than or
         # equal to the number of documents actually returned. This is an
         # approximation and not an exact count unless it is less than or equal
-        # to the {Index#search} +matched_count_accuracy+ option.
+        # to the {Index#search} `matched_count_accuracy` option.
         attr_reader :matched_count
 
         ##

--- a/lib/gcloud/search/result/list.rb
+++ b/lib/gcloud/search/result/list.rb
@@ -28,11 +28,11 @@ module Gcloud
         # The number of documents that match the query. It is greater than or
         # equal to the number of documents actually returned. This is an
         # approximation and not an exact count unless it is less than or equal
-        # to the Index#search +matched_count_accuracy+ option.
+        # to the {Index#search} +matched_count_accuracy+ option.
         attr_reader :matched_count
 
         ##
-        # Create a new Result::List with an array of Result instances.
+        # Create a new Result::List with an array of {Result} instances.
         def initialize arr = []
           super arr
         end
@@ -52,7 +52,7 @@ module Gcloud
         end
 
         ##
-        # Retrieves all results by repeatedly loading pages until #next?
+        # Retrieves all results by repeatedly loading pages until {#next?}
         # returns false. Returns the list instance for method chaining.
         def all
           while next?
@@ -64,8 +64,8 @@ module Gcloud
         end
 
         ##
-        # New Result::List from a response object.
-        def self.from_response resp, index, query, search_options #:nodoc:
+        # @private New Result::List from a response object.
+        def self.from_response resp, index, query, search_options
           data = JSON.parse resp.body
           results = new(Array(data["results"]).map do |raw|
             Result.from_hash raw

--- a/lib/gcloud/search/result/list.rb
+++ b/lib/gcloud/search/result/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Search

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -21,30 +21,22 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
-  # ### Parameters
-  #
-  # `project`::
-  #   Project identifier for the Storage service you are connecting to.
-  #   (`String`)
-  # `keyfile`::
-  #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (`String` or `Hash`)
-  # `scope`::
-  #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
-  #   or `Array`)
+  # @param [String] project Project identifier for the Storage service you are
+  #   connecting to.
+  # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
+  #   path the file must be readable.
+  # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
+  #   set of resources and operations that the connection can access. See [Using
+  #   OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
   #
-  # ### Returns
+  # @return [Gcloud::Storage::Project]
   #
-  # Gcloud::Storage::Project
-  #
-  # ### Example
-  #
+  # @example
   #   require "gcloud/storage"
   #
   #   storage = Gcloud.storage "my-todo-project",

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -23,7 +23,7 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
-  # === Parameters
+  # ### Parameters
   #
   # +project+::
   #   Project identifier for the Storage service you are connecting to.
@@ -41,11 +41,11 @@ module Gcloud
   #
   #   * +https://www.googleapis.com/auth/devstorage.full_control+
   #
-  # === Returns
+  # ### Returns
   #
   # Gcloud::Storage::Project
   #
-  # === Example
+  # ### Example
   #
   #   require "gcloud/storage"
   #
@@ -66,7 +66,7 @@ module Gcloud
   end
 
   ##
-  # = Google Cloud Storage
+  # # Google Cloud Storage
   #
   # Google Cloud Storage is an Internet service to store data in Google's cloud.
   # It allows world-wide storage and retrieval of any amount of data and at any
@@ -95,7 +95,7 @@ module Gcloud
   # {Google Cloud Storage Overview
   # }[https://cloud.google.com/storage/docs/overview].
   #
-  # == Retrieving Buckets
+  # ## Retrieving Buckets
   #
   # A Bucket is the container for your data. There is no limit on the number of
   # buckets that you can create in a project. You can use buckets to organize
@@ -138,7 +138,7 @@ module Gcloud
   #     tmp_buckets = storage.buckets token: tmp_buckets.token
   #   end
   #
-  # == Creating a Bucket
+  # ## Creating a Bucket
   #
   # A unique name is all that is needed to create a new bucket:
   # (See Project#create_bucket)
@@ -150,7 +150,7 @@ module Gcloud
   #
   #   bucket = storage.create_bucket "my-todo-app-attachments"
   #
-  # == Retrieving Files
+  # ## Retrieving Files
   #
   # A File is an individual pieces of data that you store in Google Cloud
   # Storage. Files contain the data stored as well as metadata describing the
@@ -210,7 +210,7 @@ module Gcloud
   #     tmp_files = bucket.files token: tmp_files.token
   #   end
   #
-  # == Creating a File
+  # ## Creating a File
   #
   # A new File can be uploaded by specifying the location of a file on the local
   # file system, and the name/path that the file should be stored in the bucket.
@@ -225,7 +225,7 @@ module Gcloud
   #   bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
   #                      "avatars/heidi/400x400.png"
   #
-  # === A note about large uploads
+  # ### A note about large uploads
   #
   # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to
   # upload large files. To avoid this problem, add the
@@ -250,7 +250,7 @@ module Gcloud
   #   gcloud = Gcloud.new
   #   storage = gcloud.storage
   #
-  # == Downloading a File
+  # ## Downloading a File
   #
   # Files can be downloaded to the local file system. (See File#download)
   #
@@ -263,7 +263,7 @@ module Gcloud
   #   file = bucket.file "avatars/heidi/400x400.png"
   #   file.download "/var/todo-app/avatars/heidi/400x400.png"
   #
-  # == Using Signed URLs
+  # ## Using Signed URLs
   #
   # Access without authentication can be granted to a File for a specified
   # period of time. This URL uses a cryptographic signature
@@ -279,7 +279,7 @@ module Gcloud
   #   shared_url = file.signed_url method: "GET",
   #                                expires: 300 # 5 minutes from now
   #
-  # == Controlling Access to a Bucket
+  # ## Controlling Access to a Bucket
   #
   # Access to a bucket is controlled with Bucket#acl. A bucket has owners,
   # writers, and readers. Permissions can be granted to an individual user's
@@ -325,7 +325,7 @@ module Gcloud
   #
   #   bucket.acl.public!
   #
-  # == Controlling Access to a File
+  # ## Controlling Access to a File
   #
   # Access to a file is controlled in two ways, either by the setting the
   # default permissions to all files in a bucket with Bucket#default_acl, or by

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -79,14 +79,16 @@ module Gcloud
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new "my-todo-project",
-  #                       "/path/to/keyfile.json"
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new "my-todo-project",
+  #                     "/path/to/keyfile.json"
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-bucket"
-  #   file = bucket.file "path/to/my-file.ext"
+  # bucket = storage.bucket "my-bucket"
+  # file = bucket.file "path/to/my-file.ext"
+  # ```
   #
   # You can learn more about various options for connection on the
   # [Authentication Guide](link:AUTHENTICATION.md).
@@ -102,53 +104,61 @@ module Gcloud
   # and control access to your data. Each bucket has a unique name, which is how
   # they are retrieved: (See Project#bucket)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
+  # bucket = storage.bucket "my-todo-app"
+  # ```
   #
   # You can also retrieve all buckets on a project: (See Project#buckets)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   all_buckets = storage.buckets
+  # all_buckets = storage.buckets
+  # ```
   #
   # If you have a significant number of buckets, you may need to paginate
   # through them: (See Bucket::List#token)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   all_buckets = []
-  #   tmp_buckets = storage.buckets
-  #   while tmp_buckets.any? do
-  #     tmp_buckets.each do |bucket|
-  #       all_buckets << bucket
-  #     end
-  #     # break loop if no more buckets available
-  #     break if tmp_buckets.token.nil?
-  #     # get the next group of buckets
-  #     tmp_buckets = storage.buckets token: tmp_buckets.token
+  # all_buckets = []
+  # tmp_buckets = storage.buckets
+  # while tmp_buckets.any? do
+  #   tmp_buckets.each do |bucket|
+  #     all_buckets << bucket
   #   end
+  #   # break loop if no more buckets available
+  #   break if tmp_buckets.token.nil?
+  #   # get the next group of buckets
+  #   tmp_buckets = storage.buckets token: tmp_buckets.token
+  # end
+  # ```
   #
   # ## Creating a Bucket
   #
   # A unique name is all that is needed to create a new bucket:
   # (See Project#create_bucket)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.create_bucket "my-todo-app-attachments"
+  # bucket = storage.create_bucket "my-todo-app-attachments"
+  # ```
   #
   # ## Retrieving Files
   #
@@ -160,55 +170,63 @@ module Gcloud
   # Files are retrieved by their name, which is the path of the file in the
   # bucket: (See Bucket#file)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.file "avatars/heidi/400x400.png"
+  # bucket = storage.bucket "my-todo-app"
+  # file = bucket.file "avatars/heidi/400x400.png"
+  # ```
   #
   # You can also retrieve all files in a bucket: (See Bucket#files)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   all_files = bucket.files
+  # bucket = storage.bucket "my-todo-app"
+  # all_files = bucket.files
+  # ```
   #
   # Or you can retrieve all files in a specified path:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   avatar_files = bucket.files prefix: "avatars/"
+  # bucket = storage.bucket "my-todo-app"
+  # avatar_files = bucket.files prefix: "avatars/"
+  # ```
   #
   # If you have a significant number of files, you may need to paginate through
   # them: (See File::List#token)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
+  # bucket = storage.bucket "my-todo-app"
   #
-  #   all_files = []
-  #   tmp_files = bucket.files
-  #   while tmp_files.any? do
-  #     tmp_files.each do |file|
-  #       all_files << file
-  #     end
-  #     # break loop if no more files available
-  #     break if tmp_files.token.nil?
-  #     # get the next group of files
-  #     tmp_files = bucket.files token: tmp_files.token
+  # all_files = []
+  # tmp_files = bucket.files
+  # while tmp_files.any? do
+  #   tmp_files.each do |file|
+  #     all_files << file
   #   end
+  #   # break loop if no more files available
+  #   break if tmp_files.token.nil?
+  #   # get the next group of files
+  #   tmp_files = bucket.files token: tmp_files.token
+  # end
+  # ```
   #
   # ## Creating a File
   #
@@ -216,14 +234,16 @@ module Gcloud
   # file system, and the name/path that the file should be stored in the bucket.
   # (See Bucket#create_file)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
-  #                      "avatars/heidi/400x400.png"
+  # bucket = storage.bucket "my-todo-app"
+  # bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
+  #                    "avatars/heidi/400x400.png"
+  # ```
   #
   # ### A note about large uploads
   #
@@ -237,31 +257,35 @@ module Gcloud
   # are using a version of Faraday at or above 0.9.2, is a workaround for [this
   # gzip issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   # Use httpclient to avoid broken pipe errors with large uploads
-  #   Faraday.default_adapter = :httpclient
+  # # Use httpclient to avoid broken pipe errors with large uploads
+  # Faraday.default_adapter = :httpclient
   #
-  #   # Only add the following statement if using Faraday >= 0.9.2
-  #   # Override gzip middleware with no-op for httpclient
-  #   Faraday::Response.register_middleware :gzip =>
-  #                                           Faraday::Response::Middleware
+  # # Only add the following statement if using Faraday >= 0.9.2
+  # # Override gzip middleware with no-op for httpclient
+  # Faraday::Response.register_middleware :gzip =>
+  #                                         Faraday::Response::Middleware
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
+  # ```
   #
   # ## Downloading a File
   #
   # Files can be downloaded to the local file system. (See File#download)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.file "avatars/heidi/400x400.png"
-  #   file.download "/var/todo-app/avatars/heidi/400x400.png"
+  # bucket = storage.bucket "my-todo-app"
+  # file = bucket.file "avatars/heidi/400x400.png"
+  # file.download "/var/todo-app/avatars/heidi/400x400.png"
+  # ```
   #
   # ## Using Signed URLs
   #
@@ -269,15 +293,17 @@ module Gcloud
   # period of time. This URL uses a cryptographic signature
   # of your credentials to access the file. (See File#signed_url)
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.file "avatars/heidi/400x400.png"
-  #   shared_url = file.signed_url method: "GET",
-  #                                expires: 300 # 5 minutes from now
+  # bucket = storage.bucket "my-todo-app"
+  # file = bucket.file "avatars/heidi/400x400.png"
+  # shared_url = file.signed_url method: "GET",
+  #                              expires: 300 # 5 minutes from now
+  # ```
   #
   # ## Controlling Access to a Bucket
   #
@@ -291,39 +317,45 @@ module Gcloud
   # Access to a bucket can be granted to a user by appending `"user-"` to the
   # email address:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
+  # bucket = storage.bucket "my-todo-app"
   #
-  #   email = "heidi@example.net"
-  #   bucket.acl.add_reader "user-#{email}"
+  # email = "heidi@example.net"
+  # bucket.acl.add_reader "user-#{email}"
+  # ```
   #
   # Access to a bucket can be granted to a group by appending `"group-"` to the
   # email address:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
+  # bucket = storage.bucket "my-todo-app"
   #
-  #   email = "authors@example.net"
-  #   bucket.acl.add_reader "group-#{email}"
+  # email = "authors@example.net"
+  # bucket.acl.add_reader "group-#{email}"
+  # ```
   #
   # Access to a bucket can also be granted to a predefined list of permissions:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
+  # bucket = storage.bucket "my-todo-app"
   #
-  #   bucket.acl.public!
+  # bucket.acl.public!
+  # ```
   #
   # ## Controlling Access to a File
   #
@@ -334,42 +366,48 @@ module Gcloud
   # Access to a file can be granted to a user by appending `"user-"` to the
   # email address:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.file "avatars/heidi/400x400.png"
+  # bucket = storage.bucket "my-todo-app"
+  # file = bucket.file "avatars/heidi/400x400.png"
   #
-  #   email = "heidi@example.net"
-  #   file.acl.add_reader "user-#{email}"
+  # email = "heidi@example.net"
+  # file.acl.add_reader "user-#{email}"
+  # ```
   #
   # Access to a file can be granted to a group by appending `"group-"` to the
   # email address:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.file "avatars/heidi/400x400.png"
+  # bucket = storage.bucket "my-todo-app"
+  # file = bucket.file "avatars/heidi/400x400.png"
   #
-  #   email = "authors@example.net"
-  #   file.acl.add_reader "group-#{email}"
+  # email = "authors@example.net"
+  # file.acl.add_reader "group-#{email}"
+  # ```
   #
   # Access to a file can also be granted to a predefined list of permissions:
   #
-  #   require "gcloud"
+  # ```ruby
+  # require "gcloud"
   #
-  #   gcloud = Gcloud.new
-  #   storage = gcloud.storage
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
   #
-  #   bucket = storage.bucket "my-todo-app"
-  #   file = bucket.file "avatars/heidi/400x400.png"
+  # bucket = storage.bucket "my-todo-app"
+  # file = bucket.file "avatars/heidi/400x400.png"
   #
-  #   file.acl.public!
+  # file.acl.public!
+  # ```
   #
   module Storage
   end

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 require "gcloud/storage/project"
 
-#--
-# Google Cloud Storage
 module Gcloud
   ##
   # Creates a new object for connecting to the Storage service.

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -33,8 +33,8 @@ module Gcloud
   #   readable. (+String+ or +Hash+)
   # +scope+::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
-  #   the connection can access. See {Using OAuth 2.0 to Access Google
-  #   APIs}[https://developers.google.com/identity/protocols/OAuth2]. (+String+
+  #   the connection can access. See [Using OAuth 2.0 to Access Google
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
   #   or +Array+)
   #
   #   The default scope is:
@@ -89,11 +89,11 @@ module Gcloud
   #   file = bucket.file "path/to/my-file.ext"
   #
   # You can learn more about various options for connection on the
-  # {Authentication Guide}[link:AUTHENTICATION.md].
+  # [Authentication Guide](link:AUTHENTICATION.md).
   #
   # To learn more about Cloud Storage, read the
-  # {Google Cloud Storage Overview
-  # }[https://cloud.google.com/storage/docs/overview].
+  # [Google Cloud Storage Overview
+  # ](https://cloud.google.com/storage/docs/overview).
   #
   # ## Retrieving Buckets
   #
@@ -229,13 +229,13 @@ module Gcloud
   #
   # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to
   # upload large files. To avoid this problem, add the
-  # {httpclient}[https://rubygems.org/gems/httpclient] gem to your project, and
+  # [httpclient](https://rubygems.org/gems/httpclient) gem to your project, and
   # the line (or lines) of configuration shown below. These lines must execute
   # after you require gcloud but before you make your first gcloud connection.
-  # The first statement configures {Faraday}[https://rubygems.org/gems/faraday]
+  # The first statement configures [Faraday](https://rubygems.org/gems/faraday)
   # to use httpclient. The second statement, which should only be added if you
-  # are using a version of Faraday at or above 0.9.2, is a workaround for {this
-  # gzip issue}[https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367].
+  # are using a version of Faraday at or above 0.9.2, is a workaround for [this
+  # gzip issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
   #
   #   require "gcloud"
   #
@@ -285,7 +285,7 @@ module Gcloud
   # writers, and readers. Permissions can be granted to an individual user's
   # email address, a group's email address, as well as many predefined lists.
   # See the
-  # {Access Control guide}[https://cloud.google.com/storage/docs/access-control]
+  # [Access Control guide](https://cloud.google.com/storage/docs/access-control)
   # for more.
   #
   # Access to a bucket can be granted to a user by appending +"user-"+ to the

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -91,7 +91,7 @@ module Gcloud
   # ```
   #
   # You can learn more about various options for connection on the
-  # [Authentication Guide](link:AUTHENTICATION.md).
+  # [Authentication Guide](../AUTHENTICATION).
   #
   # To learn more about Cloud Storage, read the
   # [Google Cloud Storage Overview

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -25,21 +25,21 @@ module Gcloud
   #
   # ### Parameters
   #
-  # +project+::
+  # `project`::
   #   Project identifier for the Storage service you are connecting to.
-  #   (+String+)
-  # +keyfile+::
+  #   (`String`)
+  # `keyfile`::
   #   Keyfile downloaded from Google Cloud. If file path the file must be
-  #   readable. (+String+ or +Hash+)
-  # +scope+::
+  #   readable. (`String` or `Hash`)
+  # `scope`::
   #   The OAuth 2.0 scopes controlling the set of resources and operations that
   #   the connection can access. See [Using OAuth 2.0 to Access Google
-  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (+String+
-  #   or +Array+)
+  #   APIs](https://developers.google.com/identity/protocols/OAuth2). (`String`
+  #   or `Array`)
   #
   #   The default scope is:
   #
-  #   * +https://www.googleapis.com/auth/devstorage.full_control+
+  #   * `https://www.googleapis.com/auth/devstorage.full_control`
   #
   # ### Returns
   #
@@ -288,7 +288,7 @@ module Gcloud
   # [Access Control guide](https://cloud.google.com/storage/docs/access-control)
   # for more.
   #
-  # Access to a bucket can be granted to a user by appending +"user-"+ to the
+  # Access to a bucket can be granted to a user by appending `"user-"` to the
   # email address:
   #
   #   require "gcloud"
@@ -301,7 +301,7 @@ module Gcloud
   #   email = "heidi@example.net"
   #   bucket.acl.add_reader "user-#{email}"
   #
-  # Access to a bucket can be granted to a group by appending +"group-"+ to the
+  # Access to a bucket can be granted to a group by appending `"group-"` to the
   # email address:
   #
   #   require "gcloud"
@@ -331,7 +331,7 @@ module Gcloud
   # default permissions to all files in a bucket with Bucket#default_acl, or by
   # setting permissions to an individual file with File#acl.
   #
-  # Access to a file can be granted to a user by appending +"user-"+ to the
+  # Access to a file can be granted to a user by appending `"user-"` to the
   # email address:
   #
   #   require "gcloud"
@@ -345,7 +345,7 @@ module Gcloud
   #   email = "heidi@example.net"
   #   file.acl.add_reader "user-#{email}"
   #
-  # Access to a file can be granted to a group by appending +"group-"+ to the
+  # Access to a file can be granted to a group by appending `"group-"` to the
   # email address:
   #
   #   require "gcloud"

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/storage/bucket/acl"
 require "gcloud/storage/bucket/list"

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -22,7 +22,7 @@ require "gcloud/upload"
 module Gcloud
   module Storage
     ##
-    # = Bucket
+    # # Bucket
     #
     # Represents a Storage bucket. Belongs to a Project and has many Files.
     #
@@ -555,18 +555,18 @@ module Gcloud
       #                      "destination/path/file.ext",
       #                      chunk_size: 1024*1024 # 1 MB chunk
       #
-      # ==== Troubleshooting large uploads
+      # #### Troubleshooting large uploads
       #
       # You may encounter errors while attempting to upload large files. Below
       # are a couple of common cases and their solutions.
       #
-      # ===== Handling memory errors
+      # ##### Handling memory errors
       #
       # If you encounter a memory error such as +NoMemoryError+, try performing
       # a resumable upload and setting the +chunk_size+ option to a value that
       # works for your environment, as explained in the final example above.
       #
-      # ===== Handling broken pipe errors
+      # ##### Handling broken pipe errors
       #
       # To avoid broken pipe (+Errno::EPIPE+) errors when uploading, add the
       # {httpclient}[https://rubygems.org/gems/httpclient] gem to your project,

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -53,7 +53,7 @@ module Gcloud
 
       ##
       # The kind of item this is.
-      # For buckets, this is always +storage#bucket+.
+      # For buckets, this is always `storage#bucket`.
       def kind
         @gapi["kind"]
       end
@@ -204,7 +204,7 @@ module Gcloud
       ##
       # The bucket's storage class. This defines how objects in the bucket are
       # stored and determines the SLA and the cost of storage. Values include
-      # +STANDARD+, +NEARLINE+, and +DURABLE_REDUCED_AVAILABILITY+.
+      # `STANDARD`, `NEARLINE`, and `DURABLE_REDUCED_AVAILABILITY`.
       def storage_class
         @gapi["storageClass"]
       end
@@ -322,12 +322,12 @@ module Gcloud
       #
       # The API call to delete the bucket may be retried under certain
       # conditions. See {Gcloud::Backoff} to control this behavior, or
-      # specify the wanted behavior using the +retries+ option.
+      # specify the wanted behavior using the `retries` option.
       #
       # @param [Integer] retries The number of times the API call should be
       #   retried. Default is Gcloud::Backoff.retries.
       #
-      # @return [Boolean] Returns +true+ if the bucket was deleted.
+      # @return [Boolean] Returns `true` if the bucket was deleted.
       #
       # @example
       #   require "gcloud"
@@ -368,8 +368,8 @@ module Gcloud
       # @param [Integer] max Maximum number of items plus prefixes to return. As
       #   duplicate prefixes are omitted, fewer total results may be returned
       #   than requested. The default value of this parameter is 1,000 items.
-      # @param [Boolean] versions If +true+, lists all versions of an object as
-      #   distinct results. The default is +false+. For more information, see
+      # @param [Boolean] versions If `true`, lists all versions of an object as
+      #   distinct results. The default is `false`. For more information, see
       #   [Object Versioning
       #   ](https://cloud.google.com/storage/docs/object-versioning).
       #
@@ -462,7 +462,7 @@ module Gcloud
       # Create a new File object by providing a path to a local file to upload
       # and the path to store it with in the bucket.
       #
-      # A +chunk_size+ value can be provided in the options to be used
+      # A `chunk_size` value can be provided in the options to be used
       # in resumable uploads. This value is the number of bytes per
       # chunk and must be divisible by 256KB. If it is not divisible
       # by 256KB then it will be lowered to the nearest acceptable
@@ -474,17 +474,17 @@ module Gcloud
       #   file.
       #
       #   Acceptable values are:
-      #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
-      #     +authenticatedRead+ - File owner gets OWNER access, and
+      #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
+      #     `authenticatedRead` - File owner gets OWNER access, and
       #     allAuthenticatedUsers get READER access.
-      #   * +owner_full+, +bucketOwnerFullControl+ - File owner gets OWNER
+      #   * `owner_full`, `bucketOwnerFullControl` - File owner gets OWNER
       #     access, and project team owners get OWNER access.
-      #   * +owner_read+, +bucketOwnerRead+ - File owner gets OWNER access, and
+      #   * `owner_read`, `bucketOwnerRead` - File owner gets OWNER access, and
       #     project team owners get READER access.
-      #   * +private+ - File owner gets OWNER access.
-      #   * +project_private+, +projectPrivate+ - File owner gets OWNER access,
+      #   * `private` - File owner gets OWNER access.
+      #   * `project_private`, `projectPrivate` - File owner gets OWNER access,
       #     and project team members get access according to their roles.
-      #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
+      #   * `public`, `public_read`, `publicRead` - File owner gets OWNER
       #     access, and allUsers get READER access.
       # @param [String] cache_control The
       #   [Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
@@ -562,13 +562,13 @@ module Gcloud
       #
       # ##### Handling memory errors
       #
-      # If you encounter a memory error such as +NoMemoryError+, try performing
-      # a resumable upload and setting the +chunk_size+ option to a value that
+      # If you encounter a memory error such as `NoMemoryError`, try performing
+      # a resumable upload and setting the `chunk_size` option to a value that
       # works for your environment, as explained in the final example above.
       #
       # ##### Handling broken pipe errors
       #
-      # To avoid broken pipe (+Errno::EPIPE+) errors when uploading, add the
+      # To avoid broken pipe (`Errno::EPIPE`) errors when uploading, add the
       # [httpclient](https://rubygems.org/gems/httpclient) gem to your project,
       # and the configuration shown below. These lines must execute after you
       # require gcloud but before you make your first gcloud connection. The
@@ -621,7 +621,7 @@ module Gcloud
       # @see https://cloud.google.com/storage/docs/access-control Access Control
       #   guide
       #
-      # @example Grant access to a user by pre-pending +"user-"+ to an email:
+      # @example Grant access to a user by pre-pending `"user-"` to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -632,7 +632,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   bucket.acl.add_reader "user-#{email}"
       #
-      # @example Grant access to a group by pre-pending +"group-"+ to an email:
+      # @example Grant access to a group by pre-pending `"group-"` to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -668,7 +668,7 @@ module Gcloud
       # @see https://cloud.google.com/storage/docs/access-control Access Control
       #   guide
       #
-      # @example Grant access to a user by pre-pending +"user-"+ to an email:
+      # @example Grant access to a user by pre-pending `"user-"` to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -679,7 +679,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   bucket.default_acl.add_reader "user-#{email}"
       #
-      # @example Grant access to a group by pre-pending +"group-"+ to an email
+      # @example Grant access to a group by pre-pending `"group-"` to an email
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -26,6 +26,7 @@ module Gcloud
     #
     # Represents a Storage bucket. Belongs to a Project and has many Files.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -36,16 +37,16 @@ module Gcloud
     #
     class Bucket
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty Bucket object.
-      def initialize #:nodoc:
+      # @private Create an empty Bucket object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -83,19 +84,19 @@ module Gcloud
 
       ##
       # Returns the current CORS configuration for a static website served from
-      # the bucket. For more information, see {Cross-Origin Resource
-      # Sharing (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # the bucket.
+      #
       # The return value is a frozen (unmodifiable) array of hashes containing
       # the attributes specified for the Bucket resource field
       # {cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
       #
       # This method also accepts a block for updating the bucket's CORS rules.
-      # See Bucket::Cors for details.
+      # See {Bucket::Cors} for details.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
       #
-      # Retrieving the bucket's CORS rules.
-      #
+      # @example Retrieving the bucket's CORS rules.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -107,8 +108,7 @@ module Gcloud
       #               #     "responseHeader"=>["X-My-Custom-Header"],
       #               #     "maxAgeSeconds"=>3600}]
       #
-      # Updating the bucket's CORS rules inside a block.
-      #
+      # @example Updating the bucket's CORS rules inside a block.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -135,11 +135,14 @@ module Gcloud
 
       ##
       # Updates the CORS configuration for a static website served from the
-      # bucket. For more information, see {Cross-Origin Resource
-      # Sharing (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # bucket.
+      #
       # Accepts an array of hashes containing the attributes specified for the
       # {resource description of
       # cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
+      #
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
       def cors= new_cors
         patch_gapi! cors: new_cors
       end
@@ -150,29 +153,36 @@ module Gcloud
       # storage within this region. Defaults to US.
       # See the developer's guide for the authoritative list.
       #
-      # https://cloud.google.com/storage/docs/concepts-techniques
+      # @see https://cloud.google.com/storage/docs/concepts-techniques
       def location
         @gapi["location"]
       end
 
       ##
-      # The destination bucket name for the bucket's logs. For more information,
-      # see {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
+      # The destination bucket name for the bucket's logs.
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
       def logging_bucket
         @gapi["logging"]["logBucket"] if @gapi["logging"]
       end
 
       ##
-      # Updates the destination bucket for the bucket's logs. For more
-      # information, see {Access
-      # Logs}[https://cloud.google.com/storage/docs/access-logs]. (+String+)
+      # Updates the destination bucket for the bucket's logs.
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
+      # @param [String] logging_bucket The bucket to hold the logging output
+      #
       def logging_bucket= logging_bucket
         patch_gapi! logging_bucket: logging_bucket
       end
 
       ##
       # The logging object prefix for the bucket's logs. For more information,
-      # see {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
       def logging_prefix
         @gapi["logging"]["logObjectPrefix"] if @gapi["logging"]
       end
@@ -183,9 +193,10 @@ module Gcloud
       # must be a {valid object
       # name}[https://cloud.google.com/storage/docs/bucket-naming#objectnames].
       # By default, the object prefix is the name
-      # of the bucket for which the logs are enabled. For more information, see
-      # {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
-      # (+String+)
+      # of the bucket for which the logs are enabled.
+      #
+      # @see https://cloud.google.com/storage/docs/access-logs Access Logs
+      #
       def logging_prefix= logging_prefix
         patch_gapi! logging_prefix: logging_prefix
       end
@@ -209,58 +220,67 @@ module Gcloud
       ##
       # Updates whether {Object
       # Versioning}[https://cloud.google.com/storage/docs/object-versioning] is
-      # enabled for the bucket. (+Boolean+)
+      # enabled for the bucket.
+      #
+      # @return [Boolean]
+      #
       def versioning= new_versioning
         patch_gapi! versioning: new_versioning
       end
 
       ##
       # The index page returned from a static website served from the bucket
-      # when a site visitor requests the top level directory. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
+      # when a site visitor requests the top level directory.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_main
         @gapi["website"]["mainPageSuffix"] if @gapi["website"]
       end
 
       ##
       # Updates the index page returned from a static website served from the
-      # bucket when a site visitor requests the top level directory. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
-      # (+String+)
+      # bucket when a site visitor requests the top level directory.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_main= website_main
         patch_gapi! website_main: website_main
       end
 
       ##
       # The page returned from a static website served from the bucket when a
-      # site visitor requests a resource that does not exist. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
+      # site visitor requests a resource that does not exist.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_404
         @gapi["website"]["notFoundPage"] if @gapi["website"]
       end
 
       ##
       # Updates the page returned from a static website served from the bucket
-      # when a site visitor requests a resource that does not exist. For more
-      # information, see {How to Host a Static Website
-      # }[https://cloud.google.com/storage/docs/website-configuration#step4].
-      # (+String+)
+      # when a site visitor requests a resource that does not exist.
+      #
+      # @see https://cloud.google.com/storage/docs/website-configuration#step4
+      #   How to Host a Static Website
+      #
       def website_404= website_404
         patch_gapi! website_404: website_404
       end
 
       ##
       # Updates the bucket with changes made in the given block in a single
-      # PATCH request. The following attributes may be set: #cors=,
-      # #logging_bucket=, #logging_prefix=, #versioning=, #website_main=, and
-      # #website_404=. In addition, the #cors configuration accessible in the
-      # block is completely mutable and will be included in the request.
+      # PATCH request. The following attributes may be set: {#cors=},
+      # {#logging_bucket=}, {#logging_prefix=}, {#versioning=},
+      # {#website_main=}, and {#website_404=}. In addition, the #cors
+      # configuration accessible in the block is completely mutable and will be
+      # included in the request. (See {Bucket::Cors})
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -274,9 +294,7 @@ module Gcloud
       #     b.cors[1]["responseHeader"] << "X-Another-Custom-Header"
       #   end
       #
-      # New CORS rules can also be added in a nested block. See Bucket::Cors for
-      # details.
-      #
+      # @example New CORS rules can also be added in a nested block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -302,18 +320,16 @@ module Gcloud
       # Permanently deletes the bucket.
       # The bucket must be empty before it can be deleted.
       #
-      # === Parameters
+      # The API call to delete the bucket may be retried under certain
+      # conditions. See {Gcloud::Backoff} to control this behavior, or
+      # specify the wanted behavior using the +retries+ option.
       #
-      # +retries+::
-      #   The number of times the API call should be retried.
-      #   Default is Gcloud::Backoff.retries. (+Integer+)
+      # @param [Integer] retries The number of times the API call should be
+      #   retried. Default is Gcloud::Backoff.retries.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the bucket was deleted.
       #
-      # +true+ if the bucket was deleted.
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -322,10 +338,7 @@ module Gcloud
       #   bucket = storage.bucket "my-bucket"
       #   bucket.delete
       #
-      # The API call to delete the bucket may be retried under certain
-      # conditions. See Gcloud::Backoff to control this behavior, or
-      # specify the wanted behavior in the call:
-      #
+      # @example Specify the number of retries to attempt:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -348,37 +361,22 @@ module Gcloud
       ##
       # Retrieves a list of files matching the criteria.
       #
-      # === Parameters
-      #
-      # +prefix+::
-      #   Filter results to files whose names begin with this prefix.
-      #   (+String+)
-      # +delimiter+::
-      #   Returns results in a directory-like mode. +items+ will contain only
-      #   objects whose names, aside from the +prefix+, do not contain
-      #   +delimiter+. Objects whose names, aside from the +prefix+, contain
-      #   +delimiter+ will have their name, truncated after the +delimiter+,
-      #   returned in +prefixes+. Duplicate +prefixes+ are omitted.
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of items plus prefixes to return. As duplicate prefixes
-      #   are omitted, fewer total results may be returned than requested.
-      #   The default value of this parameter is 1,000 items. (+Integer+)
-      # +versions+::
-      #   If +true+, lists all versions of an object as distinct results.
-      #   The default is +false+. For more information, see
+      # @param [String] prefix Filter results to files whose names begin with
+      #   this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of items plus prefixes to return. As
+      #   duplicate prefixes are omitted, fewer total results may be returned
+      #   than requested. The default value of this parameter is 1,000 items.
+      # @param [Boolean] versions If +true+, lists all versions of an object as
+      #   distinct results. The default is +false+. For more information, see
       #   {Object Versioning
       #   }[https://cloud.google.com/storage/docs/object-versioning].
-      #   (+Boolean+)
       #
-      # === Returns
+      # @return [Array<Gcloud::Storage::File>] (See
+      #   {Gcloud::Storage::File::List})
       #
-      # Array of Gcloud::Storage::File (See Gcloud::Storage::File::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -390,9 +388,7 @@ module Gcloud
       #     puts file.name
       #   end
       #
-      # If you have a significant number of files, you may need to paginate
-      # through them: (See File::List#token)
-      #
+      # @example With pagination: (See {File::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -433,20 +429,13 @@ module Gcloud
       ##
       # Retrieves a file matching the path.
       #
-      # === Parameters
+      # @param [String] path Name (path) of the file.
+      # @param [Integer] generation When present, selects a specific revision of
+      #   this object. Default is the latest version.
       #
-      # +path+::
-      #   Name (path) of the file. (+String+)
-      # +generation+::
-      #   When present, selects a specific revision of this object.
-      #   Default is the latest version. (+Integer+)
+      # @return [Gcloud::Storage::File, nil] Returns nil if file does not exist
       #
-      # === Returns
-      #
-      # Gcloud::Storage::File or nil if file does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -473,15 +462,16 @@ module Gcloud
       # Create a new File object by providing a path to a local file to upload
       # and the path to store it with in the bucket.
       #
-      # === Parameters
+      # A +chunk_size+ value can be provided in the options to be used
+      # in resumable uploads. This value is the number of bytes per
+      # chunk and must be divisible by 256KB. If it is not divisible
+      # by 256KB then it will be lowered to the nearest acceptable
+      # value.
       #
-      # +file+::
-      #   Path of the file on the filesystem to upload. (+String+)
-      # +path+::
-      #   Path to store the file in Google Cloud Storage. (+String+)
-      # +acl+::
-      #   A predefined set of access controls to apply to this file.
-      #   (+String+)
+      # @param [String] file Path of the file on the filesystem to upload.
+      # @param [String] path Path to store the file in Google Cloud Storage.
+      # @param [String] acl A predefined set of access controls to apply to this
+      #   file.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -496,50 +486,43 @@ module Gcloud
       #     and project team members get access according to their roles.
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
-      # +cache_control+::
-      #   The {Cache-Control}[https://tools.ietf.org/html/rfc7234#section-5.2]
-      #   response header to be returned when the file is downloaded. (+String+)
-      # +content_disposition+::
-      #   The {Content-Disposition}[https://tools.ietf.org/html/rfc6266]
-      #   response header to be returned when the file is downloaded. (+String+)
-      # +content_encoding+::
-      #   The {Content-Encoding
+      # @param [String] cache_control The
+      #   {Cache-Control}[https://tools.ietf.org/html/rfc7234#section-5.2]
+      #   response header to be returned when the file is downloaded.
+      # @param [String] content_disposition The
+      #   {Content-Disposition}[https://tools.ietf.org/html/rfc6266]
+      #   response header to be returned when the file is downloaded.
+      # @param [String] content_encoding The {Content-Encoding
       #   }[https://tools.ietf.org/html/rfc7231#section-3.1.2.2] response header
-      #   to be returned when the file is downloaded. (+String+)
-      # +content_language+::
-      #   The {Content-Language}[http://tools.ietf.org/html/bcp47] response
-      #   header to be returned when the file is downloaded. (+String+)
-      # +content_type+::
-      #   The {Content-Type}[https://tools.ietf.org/html/rfc2616#section-14.17]
-      #   response header to be returned when the file is downloaded. (+String+)
-      # +chunk_size+::
-      #   The number of bytes per chunk in a resumable upload. Must be divisible
-      #   by 256KB. If it is not divisible by 265KB then it will be lowered to
-      #   the nearest acceptable value. (+Integer+)
-      # +crc32c+::
-      #   The CRC32c checksum of the file data, as described in
-      #   {RFC 4960, Appendix B}[http://tools.ietf.org/html/rfc4960#appendix-B].
+      #   to be returned when the file is downloaded.
+      # @param [String] content_language The
+      #   {Content-Language}[http://tools.ietf.org/html/bcp47] response
+      #   header to be returned when the file is downloaded.
+      # @param [String] content_type The
+      #   {Content-Type}[https://tools.ietf.org/html/rfc2616#section-14.17]
+      #   response header to be returned when the file is downloaded.
+      # @param [Integer] chunk_size The number of bytes per chunk in a resumable
+      #   upload. Must be divisible by 256KB. If it is not divisible by 265KB
+      #   then it will be lowered to the nearest acceptable value.
+      # @param [String] crc32c The CRC32c checksum of the file data, as
+      #   described in {RFC 4960, Appendix
+      #   B}[http://tools.ietf.org/html/rfc4960#appendix-B].
       #   If provided, Cloud Storage will only create the file if the value
       #   matches the value calculated by the service. See
       #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags]
-      #   for more information. (+String+)
-      # +md5+::
-      #   The MD5 hash of the file data. If provided, Cloud Storage will only
-      #   create the file if the value matches the value calculated by the
-      #   service. See
-      #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags]
-      #   for more information. (+String+)
-      # +metadata+::
-      #   A hash of custom, user-provided web-safe keys and arbitrary string
-      #   values that will returned with requests for the file as "x-goog-meta-"
-      #   response headers. (+Hash+)
+      #   for more information.
+      # @param [String] md5 The MD5 hash of the file data. If provided, Cloud
+      #   Storage will only create the file if the value matches the value
+      #   calculated by the service. See
+      #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags] for
+      #   more information.
+      # @param [Hash] metadata A hash of custom, user-provided web-safe keys and
+      #   arbitrary string values that will returned with requests for the file
+      #   as "x-goog-meta-" response headers.
       #
-      # === Returns
+      # @return [Gcloud::Storage::File]
       #
-      # Gcloud::Storage::File
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -549,8 +532,7 @@ module Gcloud
       #
       #   bucket.create_file "path/to/local.file.ext"
       #
-      # Additionally, a destination path can be specified.
-      #
+      # @example Additionally, a destination path can be specified.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -561,12 +543,7 @@ module Gcloud
       #   bucket.create_file "path/to/local.file.ext",
       #                      "destination/path/file.ext"
       #
-      # A +chunk_size+ value can be provided in the options to be used
-      # in resumable uploads. This value is the number of bytes per
-      # chunk and must be divisible by 256KB. If it is not divisible
-      # by 265KB then it will be lowered to the nearest acceptable
-      # value.
-      #
+      # @example Specify the chunk size as a number of bytes:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -639,16 +616,12 @@ module Gcloud
       #
       # A bucket has owners, writers, and readers. Permissions can be granted to
       # an individual user's email address, a group's email address, as well as
-      # many predefined lists. See the
-      # {Access Control guide
-      # }[https://cloud.google.com/storage/docs/access-control]
-      # for more.
+      # many predefined lists.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/access-control Access Control
+      #   guide
       #
-      # Access to a bucket can be granted to a user by appending +"user-"+ to
-      # the email address:
-      #
+      # @example Grant access to a user by pre-pending +"user-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -659,9 +632,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   bucket.acl.add_reader "user-#{email}"
       #
-      # Access to a bucket can be granted to a group by appending +"group-"+ to
-      # the email address:
-      #
+      # @example Grant access to a group by pre-pending +"group-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -672,9 +643,7 @@ module Gcloud
       #   email = "authors@example.net"
       #   bucket.acl.add_reader "group-#{email}"
       #
-      # Access to a bucket can also be granted to a predefined list of
-      # permissions:
-      #
+      # @example Or, grant access via a predefined permissions list:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -694,16 +663,12 @@ module Gcloud
       #
       # A bucket's files have owners, writers, and readers. Permissions can be
       # granted to an individual user's email address, a group's email address,
-      # as well as many predefined lists. See the
-      # {Access Control guide
-      # }[https://cloud.google.com/storage/docs/access-control]
-      # for more.
+      # as well as many predefined lists.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/access-control Access Control
+      #   guide
       #
-      # Access to a bucket's files can be granted to a user by appending
-      # +"user-"+ to the email address:
-      #
+      # @example Grant access to a user by pre-pending +"user-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -714,9 +679,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   bucket.default_acl.add_reader "user-#{email}"
       #
-      # Access to a bucket's files can be granted to a group by appending
-      # +"group-"+ to the email address:
-      #
+      # @example Grant access to a group by pre-pending +"group-"+ to an email
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -727,9 +690,7 @@ module Gcloud
       #   email = "authors@example.net"
       #   bucket.default_acl.add_reader "group-#{email}"
       #
-      # Access to a bucket's files can also be granted to a predefined list of
-      # permissions:
-      #
+      # @example Or, grant access via a predefined permissions list:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -738,6 +699,7 @@ module Gcloud
       #   bucket = storage.bucket "my-todo-app"
       #
       #   bucket.default_acl.public!
+      #
       def default_acl
         @default_acl ||= Bucket::DefaultAcl.new self
       end
@@ -756,8 +718,8 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # New Bucket from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New Bucket from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -790,8 +752,8 @@ module Gcloud
       end
 
       ##
-      # Determines if a resumable upload should be used.
-      def resumable_upload? file #:nodoc:
+      # @private Determines if a resumable upload should be used.
+      def resumable_upload? file
         ::File.size?(file).to_i > Upload.resumable_threshold
       end
 

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -88,7 +88,7 @@ module Gcloud
       #
       # The return value is a frozen (unmodifiable) array of hashes containing
       # the attributes specified for the Bucket resource field
-      # {cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
+      # [cors](https://cloud.google.com/storage/docs/json_api/v1/buckets#cors).
       #
       # This method also accepts a block for updating the bucket's CORS rules.
       # See {Bucket::Cors} for details.
@@ -138,8 +138,8 @@ module Gcloud
       # bucket.
       #
       # Accepts an array of hashes containing the attributes specified for the
-      # {resource description of
-      # cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
+      # [resource description of
+      # cors](https://cloud.google.com/storage/docs/json_api/v1/buckets#cors).
       #
       # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
       #   Resource Sharing (CORS)
@@ -190,8 +190,8 @@ module Gcloud
       ##
       # Updates the logging object prefix. This prefix will be used to create
       # log object names for the bucket. It can be at most 900 characters and
-      # must be a {valid object
-      # name}[https://cloud.google.com/storage/docs/bucket-naming#objectnames].
+      # must be a [valid object
+      # name](https://cloud.google.com/storage/docs/bucket-naming#objectnames).
       # By default, the object prefix is the name
       # of the bucket for which the logs are enabled.
       #
@@ -210,16 +210,16 @@ module Gcloud
       end
 
       ##
-      # Whether {Object
-      # Versioning}[https://cloud.google.com/storage/docs/object-versioning] is
+      # Whether [Object
+      # Versioning](https://cloud.google.com/storage/docs/object-versioning) is
       # enabled for the bucket.
       def versioning?
         !@gapi["versioning"].nil? && @gapi["versioning"]["enabled"]
       end
 
       ##
-      # Updates whether {Object
-      # Versioning}[https://cloud.google.com/storage/docs/object-versioning] is
+      # Updates whether [Object
+      # Versioning](https://cloud.google.com/storage/docs/object-versioning) is
       # enabled for the bucket.
       #
       # @return [Boolean]
@@ -370,8 +370,8 @@ module Gcloud
       #   than requested. The default value of this parameter is 1,000 items.
       # @param [Boolean] versions If +true+, lists all versions of an object as
       #   distinct results. The default is +false+. For more information, see
-      #   {Object Versioning
-      #   }[https://cloud.google.com/storage/docs/object-versioning].
+      #   [Object Versioning
+      #   ](https://cloud.google.com/storage/docs/object-versioning).
       #
       # @return [Array<Gcloud::Storage::File>] (See
       #   {Gcloud::Storage::File::List})
@@ -487,34 +487,34 @@ module Gcloud
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
       # @param [String] cache_control The
-      #   {Cache-Control}[https://tools.ietf.org/html/rfc7234#section-5.2]
+      #   [Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
       #   response header to be returned when the file is downloaded.
       # @param [String] content_disposition The
-      #   {Content-Disposition}[https://tools.ietf.org/html/rfc6266]
+      #   [Content-Disposition](https://tools.ietf.org/html/rfc6266)
       #   response header to be returned when the file is downloaded.
-      # @param [String] content_encoding The {Content-Encoding
-      #   }[https://tools.ietf.org/html/rfc7231#section-3.1.2.2] response header
+      # @param [String] content_encoding The [Content-Encoding
+      #   ](https://tools.ietf.org/html/rfc7231#section-3.1.2.2) response header
       #   to be returned when the file is downloaded.
       # @param [String] content_language The
-      #   {Content-Language}[http://tools.ietf.org/html/bcp47] response
+      #   [Content-Language](http://tools.ietf.org/html/bcp47) response
       #   header to be returned when the file is downloaded.
       # @param [String] content_type The
-      #   {Content-Type}[https://tools.ietf.org/html/rfc2616#section-14.17]
+      #   [Content-Type](https://tools.ietf.org/html/rfc2616#section-14.17)
       #   response header to be returned when the file is downloaded.
       # @param [Integer] chunk_size The number of bytes per chunk in a resumable
       #   upload. Must be divisible by 256KB. If it is not divisible by 265KB
       #   then it will be lowered to the nearest acceptable value.
       # @param [String] crc32c The CRC32c checksum of the file data, as
-      #   described in {RFC 4960, Appendix
-      #   B}[http://tools.ietf.org/html/rfc4960#appendix-B].
+      #   described in [RFC 4960, Appendix
+      #   B](http://tools.ietf.org/html/rfc4960#appendix-B).
       #   If provided, Cloud Storage will only create the file if the value
       #   matches the value calculated by the service. See
-      #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags]
+      #   [Validation](https://cloud.google.com/storage/docs/hashes-etags)
       #   for more information.
       # @param [String] md5 The MD5 hash of the file data. If provided, Cloud
       #   Storage will only create the file if the value matches the value
       #   calculated by the service. See
-      #   {Validation}[https://cloud.google.com/storage/docs/hashes-etags] for
+      #   [Validation](https://cloud.google.com/storage/docs/hashes-etags) for
       #   more information.
       # @param [Hash] metadata A hash of custom, user-provided web-safe keys and
       #   arbitrary string values that will returned with requests for the file
@@ -569,14 +569,14 @@ module Gcloud
       # ##### Handling broken pipe errors
       #
       # To avoid broken pipe (+Errno::EPIPE+) errors when uploading, add the
-      # {httpclient}[https://rubygems.org/gems/httpclient] gem to your project,
+      # [httpclient](https://rubygems.org/gems/httpclient) gem to your project,
       # and the configuration shown below. These lines must execute after you
       # require gcloud but before you make your first gcloud connection. The
-      # first statement configures {Faraday}[https://rubygems.org/gems/faraday]
+      # first statement configures [Faraday](https://rubygems.org/gems/faraday)
       # to use httpclient. The second statement, which should only be added if
       # you are using a version of Faraday at or above 0.9.2, is a workaround
-      # for {this gzip
-      # issue}[https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367].
+      # for [this gzip
+      # issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
       #
       #   require "gcloud"
       #

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -363,6 +363,12 @@ module Gcloud
       #
       # @param [String] prefix Filter results to files whose names begin with
       #   this prefix.
+      # @param [String] delimiter Returns results in a directory-like mode.
+      #   `items` will contain only objects whose names, aside from the
+      #   `prefix`, do not contain `delimiter`. Objects whose names, aside from
+      #   the `prefix`, contain `delimiter` will have their name, truncated
+      #   after the `delimiter`, returned in `prefixes`. Duplicate `prefixes`
+      #   are omitted.
       # @param [String] token A previously-returned page token representing part
       #   of the larger set of results to view.
       # @param [Integer] max Maximum number of items plus prefixes to return. As

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -156,7 +156,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -167,7 +167,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_owner "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -203,7 +203,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -214,7 +214,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_writer "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -250,7 +250,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -261,7 +261,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_reader "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -327,7 +327,7 @@ module Gcloud
         # Predefined ACL helpers
 
         ##
-        # Convenience method to apply the +authenticatedRead+ predefined ACL
+        # Convenience method to apply the `authenticatedRead` predefined ACL
         # rule to the bucket.
         #
         # @example
@@ -349,7 +349,7 @@ module Gcloud
         alias_method :authenticated_read!, :auth!
 
         ##
-        # Convenience method to apply the +private+ predefined ACL
+        # Convenience method to apply the `private` predefined ACL
         # rule to the bucket.
         #
         # @example
@@ -367,7 +367,7 @@ module Gcloud
         end
 
         ##
-        # Convenience method to apply the +projectPrivate+ predefined ACL
+        # Convenience method to apply the `projectPrivate` predefined ACL
         # rule to the bucket.
         #
         # @example
@@ -386,7 +386,7 @@ module Gcloud
         alias_method :projectPrivate!, :project_private!
 
         ##
-        # Convenience method to apply the +publicRead+ predefined ACL
+        # Convenience method to apply the `publicRead` predefined ACL
         # rule to the bucket.
         #
         # @example
@@ -405,7 +405,7 @@ module Gcloud
         alias_method :publicRead!, :public!
         alias_method :public_read!, :public!
 
-        # Convenience method to apply the +publicReadWrite+ predefined ACL
+        # Convenience method to apply the `publicReadWrite` predefined ACL
         # rule to the bucket.
         #
         # @example
@@ -588,7 +588,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -599,7 +599,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_owner "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -635,7 +635,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -646,7 +646,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_writer "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -682,7 +682,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -693,7 +693,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_reader "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -760,7 +760,7 @@ module Gcloud
         # Predefined ACL helpers
 
         ##
-        # Convenience method to apply the default +authenticatedRead+
+        # Convenience method to apply the default `authenticatedRead`
         # predefined ACL rule to files in the bucket.
         #
         # @example
@@ -782,7 +782,7 @@ module Gcloud
         alias_method :authenticated_read!, :auth!
 
         ##
-        # Convenience method to apply the default +bucketOwnerFullControl+
+        # Convenience method to apply the default `bucketOwnerFullControl`
         # predefined ACL rule to files in the bucket.
         #
         # @example
@@ -801,7 +801,7 @@ module Gcloud
         alias_method :bucketOwnerFullControl!, :owner_full!
 
         ##
-        # Convenience method to apply the default +bucketOwnerRead+
+        # Convenience method to apply the default `bucketOwnerRead`
         # predefined ACL rule to files in the bucket.
         #
         # @example
@@ -820,7 +820,7 @@ module Gcloud
         alias_method :bucketOwnerRead!, :owner_read!
 
         ##
-        # Convenience method to apply the default +private+
+        # Convenience method to apply the default `private`
         # predefined ACL rule to files in the bucket.
         #
         # @example
@@ -838,7 +838,7 @@ module Gcloud
         end
 
         ##
-        # Convenience method to apply the default +projectPrivate+
+        # Convenience method to apply the default `projectPrivate`
         # predefined ACL rule to files in the bucket.
         #
         # @example
@@ -857,7 +857,7 @@ module Gcloud
         alias_method :projectPrivate!, :project_private!
 
         ##
-        # Convenience method to apply the default +publicRead+
+        # Convenience method to apply the default `publicRead`
         # predefined ACL rule to files in the bucket.
         #
         # @example

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Storage

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -17,7 +17,7 @@ module Gcloud
   module Storage
     class Bucket
       ##
-      # = Bucket Access Control List
+      # # Bucket Access Control List
       #
       # Represents a Bucket's Access Control List.
       #
@@ -449,7 +449,7 @@ module Gcloud
       end
 
       ##
-      # = Bucket Default Access Control List
+      # # Bucket Default Access Control List
       #
       # Represents a Bucket's Default Access Control List.
       #

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -21,6 +21,7 @@ module Gcloud
       #
       # Represents a Bucket's Access Control List.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -31,6 +32,7 @@ module Gcloud
       #   bucket.acl.readers.each { |reader| puts reader }
       #
       class Acl
+        # @private
         RULES = { "authenticatedRead" => "authenticatedRead",
                   "auth" => "authenticatedRead",
                   "auth_read" => "authenticatedRead",
@@ -44,12 +46,12 @@ module Gcloud
                   "public" => "publicRead",
                   "public_read" => "publicRead",
                   "publicReadWrite" => "publicReadWrite",
-                  "public_write" => "publicReadWrite" } #:nodoc:
+                  "public_write" => "publicReadWrite" }
 
         ##
-        # Initialized a new Acl object.
+        # @private Initialized a new Acl object.
         # Must provide a valid Bucket object.
-        def initialize bucket #:nodoc:
+        def initialize bucket
           @bucket = bucket.name
           @connection = bucket.connection
           @owners  = nil
@@ -60,8 +62,7 @@ module Gcloud
         ##
         # Reloads all Access Control List data for the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -83,12 +84,9 @@ module Gcloud
         ##
         # Lists the owners of the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -106,12 +104,9 @@ module Gcloud
         ##
         # Lists the owners of the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -129,12 +124,9 @@ module Gcloud
         ##
         # Lists the readers of the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -152,11 +144,8 @@ module Gcloud
         ##
         # Grants owner permission to the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -167,11 +156,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -182,9 +167,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_owner "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -208,11 +191,8 @@ module Gcloud
         ##
         # Grants writer permission to the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -223,11 +203,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -238,9 +214,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_writer "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -264,11 +238,8 @@ module Gcloud
         ##
         # Grants reader permission to the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -279,11 +250,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -294,9 +261,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.acl.add_reader "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -320,11 +285,8 @@ module Gcloud
         ##
         # Permanently deletes the entity from the bucket's access control list.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -335,8 +297,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -358,7 +319,8 @@ module Gcloud
           false
         end
 
-        def self.predefined_rule_for rule_name #:nodoc:
+        # @private
+        def self.predefined_rule_for rule_name
           RULES[rule_name.to_s]
         end
 
@@ -368,8 +330,7 @@ module Gcloud
         # Convenience method to apply the +authenticatedRead+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -391,8 +352,7 @@ module Gcloud
         # Convenience method to apply the +private+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -410,8 +370,7 @@ module Gcloud
         # Convenience method to apply the +projectPrivate+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -430,8 +389,7 @@ module Gcloud
         # Convenience method to apply the +publicRead+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -450,8 +408,7 @@ module Gcloud
         # Convenience method to apply the +publicReadWrite+ predefined ACL
         # rule to the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -506,6 +463,7 @@ module Gcloud
       #   bucket.default_acl.readers.each { |reader| puts reader }
       #
       class DefaultAcl
+        # @private
         RULES = { "authenticatedRead" => "authenticatedRead",
                   "auth" => "authenticatedRead",
                   "auth_read" => "authenticatedRead",
@@ -520,12 +478,12 @@ module Gcloud
                   "project_private" => "projectPrivate",
                   "publicRead" => "publicRead",
                   "public" => "publicRead",
-                  "public_read" => "publicRead" } #:nodoc:
+                  "public_read" => "publicRead" }
 
         ##
-        # Initialized a new DefaultAcl object.
+        # @private Initialized a new DefaultAcl object.
         # Must provide a valid Bucket object.
-        def initialize bucket #:nodoc:
+        def initialize bucket
           @bucket = bucket.name
           @connection = bucket.connection
           @owners  = nil
@@ -536,8 +494,7 @@ module Gcloud
         ##
         # Reloads all Default Access Control List data for the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -559,12 +516,9 @@ module Gcloud
         ##
         # Lists the default owners for files in the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -582,12 +536,9 @@ module Gcloud
         ##
         # Lists the default writers for files in the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -605,12 +556,9 @@ module Gcloud
         ##
         # Lists the default readers for files in the bucket.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -628,11 +576,8 @@ module Gcloud
         ##
         # Grants default owner permission to files in the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -643,11 +588,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -658,9 +599,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_owner "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -684,11 +623,8 @@ module Gcloud
         ##
         # Grants default writer permission to files in the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -699,11 +635,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -714,9 +646,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_writer "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -740,11 +670,8 @@ module Gcloud
         ##
         # Grants default reader permission to files in the bucket.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -755,11 +682,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Examples
-        #
-        # Access to a bucket can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -770,9 +693,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   bucket.default_acl.add_reader "user-#{email}"
         #
-        # Access to a bucket can be granted to a group by appending +"group-"+
-        # to the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -797,11 +718,8 @@ module Gcloud
         # Permanently deletes the entity from the bucket's default access
         # control list for files.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -812,8 +730,7 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -835,7 +752,8 @@ module Gcloud
           false
         end
 
-        def self.predefined_rule_for rule_name #:nodoc:
+        # @private
+        def self.predefined_rule_for rule_name
           RULES[rule_name.to_s]
         end
 
@@ -845,8 +763,7 @@ module Gcloud
         # Convenience method to apply the default +authenticatedRead+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -868,8 +785,7 @@ module Gcloud
         # Convenience method to apply the default +bucketOwnerFullControl+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -888,8 +804,7 @@ module Gcloud
         # Convenience method to apply the default +bucketOwnerRead+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -908,8 +823,7 @@ module Gcloud
         # Convenience method to apply the default +private+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -927,8 +841,7 @@ module Gcloud
         # Convenience method to apply the default +projectPrivate+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -947,8 +860,7 @@ module Gcloud
         # Convenience method to apply the default +publicRead+
         # predefined ACL rule to files in the bucket.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -63,12 +63,12 @@ module Gcloud
         ##
         # Add a CORS rule to the CORS rules for a bucket. Accepts options for
         # setting preflight response headers. Preflight requests and responses
-        # are required if the request method and headers are not both {simple
-        # methods}[http://www.w3.org/TR/cors/#simple-method] and {simple
-        # headers}[http://www.w3.org/TR/cors/#simple-header].
+        # are required if the request method and headers are not both [simple
+        # methods](http://www.w3.org/TR/cors/#simple-method) and [simple
+        # headers](http://www.w3.org/TR/cors/#simple-header).
         #
         # @param [String, Array<String>] origin The
-        #   {origin}[http://tools.ietf.org/html/rfc6454] or origins permitted
+        #   [origin](http://tools.ietf.org/html/rfc6454) or origins permitted
         #   for cross origin resource sharing with the bucket. Note: "*" is
         #   permitted in the list of origins, and means "any Origin".
         # @param [String, Array<String>] methods The list of HTTP methods

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -82,7 +82,7 @@ module Gcloud
         # @param [Integer] max_age The value to send in the
         #   Access-Control-Max-Age header in the preflight response. Indicates
         #   how many seconds the results of a preflight request can be cached in
-        #   a preflight result cache. The default value is +1800+ (30 minutes.)
+        #   a preflight result cache. The default value is `1800` (30 minutes.)
         #
         # @example
         #   require "gcloud"

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -22,12 +22,13 @@ module Gcloud
       # = Bucket Cors
       #
       # A special-case Array for managing the website CORS rules for a bucket.
-      # Accessed via a block argument to Project#create_bucket, Bucket#cors, or
-      # Bucket#update.
+      # Accessed via a block argument to {Project#create_bucket}, {Bucket#cors},
+      # or {Bucket#update}.
       #
-      # For more information about CORS, see {Cross-Origin Resource
-      # Sharing (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -47,13 +48,15 @@ module Gcloud
       #
       class Cors < DelegateClass(::Array)
         ##
+        # @private
         # Initialize a new CORS rules builder with existing CORS rules, if any.
-        def initialize cors = [] #:nodoc:
+        def initialize cors = []
           super cors.dup
           @original = cors.dup
         end
 
-        def changed? #:nodoc:
+        # @private
+        def changed?
           @original != self
         end
 
@@ -64,30 +67,24 @@ module Gcloud
         # methods}[http://www.w3.org/TR/cors/#simple-method] and {simple
         # headers}[http://www.w3.org/TR/cors/#simple-header].
         #
-        # === Parameters
+        # @param [String, Array<String>] origin The
+        #   {origin}[http://tools.ietf.org/html/rfc6454] or origins permitted
+        #   for cross origin resource sharing with the bucket. Note: "*" is
+        #   permitted in the list of origins, and means "any Origin".
+        # @param [String, Array<String>] methods The list of HTTP methods
+        #   permitted in cross origin resource sharing with the bucket. (GET,
+        #   OPTIONS, POST, etc) Note: "*" is permitted in the list of methods,
+        #   and means "any method".
+        # @param [String, Array<String>] headers The list of header field names
+        #   to send in the Access-Control-Allow-Headers header in the preflight
+        #   response. Indicates the custom request headers that may be used in
+        #   the actual request.
+        # @param [Integer] max_age The value to send in the
+        #   Access-Control-Max-Age header in the preflight response. Indicates
+        #   how many seconds the results of a preflight request can be cached in
+        #   a preflight result cache. The default value is +1800+ (30 minutes.)
         #
-        # +origin+::
-        #   The {origin}[http://tools.ietf.org/html/rfc6454] or origins
-        #   permitted for cross origin resource sharing with the bucket. Note:
-        #   "*" is permitted in the list of origins, and means "any Origin".
-        #   (+String+ or +Array+)
-        # +methods+::
-        #   The list of HTTP methods permitted in cross origin resource sharing
-        #   with the bucket. (GET, OPTIONS, POST, etc) Note: "*" is permitted in
-        #   the list of methods, and means "any method". (+String+ or +Array+)
-        # +headers+::
-        #   The list of header field names to send in the
-        #   Access-Control-Allow-Headers header in the preflight response.
-        #   Indicates the custom request headers that may be used in the actual
-        #   request. (+String+ or +Array+)
-        # +max_age+::
-        #   The value to send in the Access-Control-Max-Age header in the
-        #   preflight response. Indicates how many seconds the results of a
-        #   preflight request can be cached in a preflight result cache. The
-        #   default value is +1800+ (30 minutes.) (+Integer+)
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/bucket/cors.rb
+++ b/lib/gcloud/storage/bucket/cors.rb
@@ -19,7 +19,7 @@ module Gcloud
   module Storage
     class Bucket
       ##
-      # = Bucket Cors
+      # # Bucket Cors
       #
       # A special-case Array for managing the website CORS rules for a bucket.
       # Accessed via a block argument to {Project#create_bucket}, {Bucket#cors},

--- a/lib/gcloud/storage/bucket/list.rb
+++ b/lib/gcloud/storage/bucket/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/storage/bucket/list.rb
+++ b/lib/gcloud/storage/bucket/list.rb
@@ -35,8 +35,8 @@ module Gcloud
         end
 
         ##
-        # New Bucket::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New Bucket::List from a response object.
+        def self.from_response resp, conn
           buckets = Array(resp.data["items"]).map do |gapi_object|
             Bucket.from_gapi gapi_object, conn
           end

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -22,13 +22,15 @@ require "mime/types"
 module Gcloud
   module Storage
     ##
-    # Represents the connection to Storage,
+    # @private Represents the connection to Storage,
     # as well as expose the API calls.
-    class Connection #:nodoc:
+    class Connection
       API_VERSION = "v1"
 
       attr_accessor :project
-      attr_accessor :credentials #:nodoc:
+
+      # @private
+      attr_accessor :credentials
 
       ##
       # Creates a new Connection instance.
@@ -303,7 +305,8 @@ module Gcloud
         MIME::Types.of(path).first.to_s
       end
 
-      def inspect #:nodoc:
+      # @private
+      def inspect
         "#{self.class}(#{@project})"
       end
 
@@ -354,7 +357,8 @@ module Gcloud
         }.delete_if { |_, v| v.nil? } if website_main || website_404
       end
 
-      def storage_class str #:nodoc:
+      # @private
+      def storage_class str
         { "durable_reduced_availability" => "DURABLE_REDUCED_AVAILABILITY",
           "dra" => "DURABLE_REDUCED_AVAILABILITY",
           "durable" => "DURABLE_REDUCED_AVAILABILITY",

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "pathname"
 require "gcloud/version"

--- a/lib/gcloud/storage/credentials.rb
+++ b/lib/gcloud/storage/credentials.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/credentials"
 

--- a/lib/gcloud/storage/credentials.rb
+++ b/lib/gcloud/storage/credentials.rb
@@ -18,8 +18,8 @@ require "gcloud/credentials"
 module Gcloud
   module Storage
     ##
-    # Represents the OAuth 2.0 signing logic for Storage.
-    class Credentials < Gcloud::Credentials #:nodoc:
+    # @private Represents the OAuth 2.0 signing logic for Storage.
+    class Credentials < Gcloud::Credentials
       SCOPE = ["https://www.googleapis.com/auth/devstorage.full_control"]
       PATH_ENV_VARS = %w(STORAGE_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(STORAGE_KEYFILE_JSON GCLOUD_KEYFILE_JSON

--- a/lib/gcloud/storage/errors.rb
+++ b/lib/gcloud/storage/errors.rb
@@ -43,7 +43,8 @@ module Gcloud
         @errors = errors
       end
 
-      def self.from_response resp #:nodoc:
+      # @private
+      def self.from_response resp
         new resp.data["error"]["message"],
             resp.data["error"]["code"],
             resp.data["error"]["errors"]
@@ -68,7 +69,8 @@ module Gcloud
       # The value of the digest on the downloaded file.
       attr_accessor :local_digest
 
-      def self.for_md5 gcloud_digest, local_digest #:nodoc:
+      # @private
+      def self.for_md5 gcloud_digest, local_digest
         new("The downloaded file failed MD5 verification.").tap do |e|
           e.type = :md5
           e.gcloud_digest = gcloud_digest
@@ -76,7 +78,8 @@ module Gcloud
         end
       end
 
-      def self.for_crc32c gcloud_digest, local_digest #:nodoc:
+      # @private
+      def self.for_crc32c gcloud_digest, local_digest
         new("The downloaded file failed CRC32c verification.").tap do |e|
           e.type = :crc32c
           e.gcloud_digest = gcloud_digest

--- a/lib/gcloud/storage/errors.rb
+++ b/lib/gcloud/storage/errors.rb
@@ -18,14 +18,14 @@ require "gcloud/errors"
 module Gcloud
   module Storage
     ##
-    # = Storage Error
+    # # Storage Error
     #
     # Base Storage exception class.
     class Error < Gcloud::Error
     end
 
     ##
-    # = ApiError
+    # # ApiError
     #
     # Raised when an API call is not successful.
     class ApiError < Error
@@ -52,7 +52,7 @@ module Gcloud
     end
 
     ##
-    # = FileVerificationError
+    # # FileVerificationError
     #
     # Raised when a File download fails the verification.
     class FileVerificationError < Error
@@ -89,7 +89,7 @@ module Gcloud
     end
 
     ##
-    # = SignedUrlUnavailable Error
+    # # SignedUrlUnavailable Error
     #
     # This is raised when File#signed_url is unable to generate a URL due to
     # missing credentials needed to create the URL.

--- a/lib/gcloud/storage/errors.rb
+++ b/lib/gcloud/storage/errors.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/errors"
 

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -23,7 +23,7 @@ module Gcloud
     # # File
     #
     # Represents a File
-    # ({Object}[https://cloud.google.com/storage/docs/json_api/v1/objects]) that
+    # ([Object](https://cloud.google.com/storage/docs/json_api/v1/objects)) that
     # belongs to a {Bucket}. Files (Objects) are
     # the individual pieces of data that you store in Google Cloud Storage. A
     # file can be up to 5 TB in size. Files have two components:
@@ -143,7 +143,7 @@ module Gcloud
 
       ##
       # The CRC32c checksum of the data, as described in
-      # {RFC 4960, Appendix B}[http://tools.ietf.org/html/rfc4960#appendix-B].
+      # [RFC 4960, Appendix B](http://tools.ietf.org/html/rfc4960#appendix-B).
       # Encoded using base64 in big-endian byte order.
       def crc32c
         @gapi["crc32c"]
@@ -156,7 +156,7 @@ module Gcloud
       end
 
       ##
-      # The {Cache-Control}[https://tools.ietf.org/html/rfc7234#section-5.2]
+      # The [Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
       # directive for the file data.
       def cache_control
         @gapi["cacheControl"]
@@ -164,56 +164,56 @@ module Gcloud
 
       ##
       # Updates the
-      # {Cache-Control}[https://tools.ietf.org/html/rfc7234#section-5.2]
+      # [Cache-Control](https://tools.ietf.org/html/rfc7234#section-5.2)
       # directive for the file data.
       def cache_control= cache_control
         patch_gapi! cache_control: cache_control
       end
 
       ##
-      # The {Content-Disposition}[https://tools.ietf.org/html/rfc6266] of the
+      # The [Content-Disposition](https://tools.ietf.org/html/rfc6266) of the
       # file data.
       def content_disposition
         @gapi["contentDisposition"]
       end
 
       ##
-      # Updates the {Content-Disposition}[https://tools.ietf.org/html/rfc6266]
+      # Updates the [Content-Disposition](https://tools.ietf.org/html/rfc6266)
       # of the file data.
       def content_disposition= content_disposition
         patch_gapi! content_disposition: content_disposition
       end
 
       ##
-      # The {Content-Encoding
-      # }[https://tools.ietf.org/html/rfc7231#section-3.1.2.2] of the file data.
+      # The [Content-Encoding
+      # ](https://tools.ietf.org/html/rfc7231#section-3.1.2.2) of the file data.
       def content_encoding
         @gapi["contentEncoding"]
       end
 
       ##
-      # Updates the {Content-Encoding
-      # }[https://tools.ietf.org/html/rfc7231#section-3.1.2.2] of the file data.
+      # Updates the [Content-Encoding
+      # ](https://tools.ietf.org/html/rfc7231#section-3.1.2.2) of the file data.
       def content_encoding= content_encoding
         patch_gapi! content_encoding: content_encoding
       end
 
       ##
-      # The {Content-Language}[http://tools.ietf.org/html/bcp47] of the file
+      # The [Content-Language](http://tools.ietf.org/html/bcp47) of the file
       # data.
       def content_language
         @gapi["contentLanguage"]
       end
 
       ##
-      # Updates the {Content-Language}[http://tools.ietf.org/html/bcp47] of the
+      # Updates the [Content-Language](http://tools.ietf.org/html/bcp47) of the
       # file data.
       def content_language= content_language
         patch_gapi! content_language: content_language
       end
 
       ##
-      # The {Content-Type}[https://tools.ietf.org/html/rfc2616#section-14.17] of
+      # The [Content-Type](https://tools.ietf.org/html/rfc2616#section-14.17) of
       # the file data.
       def content_type
         @gapi["contentType"]
@@ -221,7 +221,7 @@ module Gcloud
 
       ##
       # Updates the
-      # {Content-Type}[https://tools.ietf.org/html/rfc2616#section-14.17] of the
+      # [Content-Type](https://tools.ietf.org/html/rfc2616#section-14.17) of the
       # file data.
       def content_type= content_type
         patch_gapi! content_type: content_type
@@ -501,8 +501,8 @@ module Gcloud
       #
       # A SignedUrlUnavailable is raised if the service account credentials are
       # missing. Service account credentials are acquired by following the steps
-      # in {Service Account Authentication}[
-      # https://cloud.google.com/storage/docs/authentication#service_accounts].
+      # in [Service Account Authentication](
+      # https://cloud.google.com/storage/docs/authentication#service_accounts).
       #
       # @see https://cloud.google.com/storage/docs/access-control#Signed-URLs
       #   Access Control Signed URLs guide

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -24,15 +24,18 @@ module Gcloud
     #
     # Represents a File
     # ({Object}[https://cloud.google.com/storage/docs/json_api/v1/objects]) that
-    # belongs to a Bucket. Files (Objects) are
+    # belongs to a {Bucket}. Files (Objects) are
     # the individual pieces of data that you store in Google Cloud Storage. A
     # file can be up to 5 TB in size. Files have two components:
     # data and metadata. The data component is the data from an external file or
     # other data source that you want to store in Google Cloud Storage. The
     # metadata component is a collection of name-value pairs that describe
-    # various qualities of the data. For more information, see {Concepts and
-    # Techniques}[https://cloud.google.com/storage/docs/concepts-techniques].
+    # various qualities of the data.
     #
+    # @see https://cloud.google.com/storage/docs/concepts-techniques Concepts
+    #   and Techniques
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -45,16 +48,16 @@ module Gcloud
     #
     class File
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # The Google API Client object.
-      attr_accessor :gapi #:nodoc:
+      # @private The Google API Client object.
+      attr_accessor :gapi
 
       ##
-      # Create an empty File object.
-      def initialize #:nodoc:
+      # @private Create an empty File object.
+      def initialize
         @connection = nil
         @gapi = {}
       end
@@ -79,7 +82,7 @@ module Gcloud
       end
 
       ##
-      # The name of the bucket containing this file.
+      # The name of the {Bucket} containing this file.
       def bucket
         @gapi["bucket"]
       end
@@ -244,13 +247,12 @@ module Gcloud
 
       ##
       # Updates the file with changes made in the given block in a single
-      # PATCH request. The following attributes may be set: #cache_control=,
-      # #content_disposition=, #content_encoding=, #content_language=,
-      # #content_type=, and #metadata=. The #metadata hash accessible in the
-      # block is completely mutable and will be included in the request.
+      # PATCH request. The following attributes may be set: {#cache_control=},
+      # {#content_disposition=}, {#content_encoding=}, {#content_language=},
+      # {#content_type=}, and {#metadata=}. The {#metadata} hash accessible in
+      # the block is completely mutable and will be included in the request.
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -279,14 +281,12 @@ module Gcloud
       ##
       # Download the file's contents to a local file.
       #
-      # === Parameters
+      # By default, the download is verified by calculating the MD5 digest.
       #
-      # +path+::
-      #   The path on the local file system to write the data to.
-      #   The path provided must be writable. (+String+)
-      # +verify+::
-      #   The verification algoruthm used to ensure the downloaded file contents
-      #   are correct. Default is +:md5+. (+Symbol+)
+      # @param [String] path The path on the local file system to write the data
+      #   to. The path provided must be writable.
+      # @param [Symbol] verify The verification algoruthm used to ensure the
+      #   downloaded file contents are correct. Default is +:md5+.
       #
       #   Acceptable values are:
       #   * +md5+ - Verify file content match using the MD5 hash.
@@ -294,12 +294,9 @@ module Gcloud
       #   * +all+ - Perform all available file content verification.
       #   * +none+ - Don't perform file content verification.
       #
-      # === Returns
+      # @return [File] Returns a +::File+ object on the local file system
       #
-      # +::File+ object on the local file system
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -310,9 +307,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext"
       #
-      # The download is verified by calculating the MD5 digest.
-      # The CRC32c digest can be used by passing :crc32c.
-      #
+      # @example Use the CRC32c digest by passing :crc32c.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -323,8 +318,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :crc32c
       #
-      # Both the MD5 and CRC32c digest can be used by passing :all.
-      #
+      # @example Use the MD5 and CRC32c digests by passing :all.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -335,8 +329,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.download "path/to/downloaded/file.ext", verify: :all
       #
-      # The download verification can be disabled by passing :none
-      #
+      # @example Disable the download verification by passing :none.
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -363,17 +356,13 @@ module Gcloud
       ##
       # Copy the file to a new location.
       #
-      # === Parameters
-      #
-      # +dest_bucket_or_path+::
-      #   Either the bucket to copy the file to, or the path to copy the file to
-      #   in the current bucket. (+String+)
-      # +dest_path+::
-      #   If a bucket was provided in the first parameter, this contains the
-      #   path to copy the file to in the given bucket. (+String+)
-      # +acl+::
-      #   A predefined set of access controls to apply to new file.
-      #   (+String+)
+      # @param [String] dest_bucket_or_path Either the bucket to copy the file
+      #   to, or the path to copy the file to in the current bucket.
+      # @param [String] dest_path If a bucket was provided in the first
+      #   parameter, this contains the path to copy the file to in the given
+      #   bucket.
+      # @param [String] acl A predefined set of access controls to apply to new
+      #   file.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -388,18 +377,12 @@ module Gcloud
       #     and project team members get access according to their roles.
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
-      # +generation+::
-      #   Select a specific revision of the file to copy. The default is the
-      #   latest version. (+Integer+)
+      # @param [Integer] generation Select a specific revision of the file to
+      #   copy. The default is the latest version.
       #
-      # === Returns
+      # @return [Gcloud::Storage::File]
       #
-      # +File+ object
-      #
-      # === Examples
-      #
-      # The file can also be copied to a new path in the current bucket:
-      #
+      # @example The file can be copied to a new path in the current bucket:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -410,8 +393,7 @@ module Gcloud
       #   file = bucket.file "path/to/my-file.ext"
       #   file.copy "path/to/destination/file.ext"
       #
-      # The file can also be copied to a different bucket:
-      #
+      # @example The file can also be copied to a different bucket:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -423,8 +405,7 @@ module Gcloud
       #   file.copy "new-destination-bucket",
       #             "path/to/destination/file.ext"
       #
-      # The file can also be copied by specifying a generation:
-      #
+      # @example The file can also be copied by specifying a generation:
       #   file.copy "copy/of/previous/generation/file.ext",
       #             generation: 123456
       #
@@ -446,12 +427,9 @@ module Gcloud
       ##
       # Permanently deletes the file.
       #
-      # === Returns
+      # @return [Boolean] Returns +true+ if the file was deleted.
       #
-      # +true+ if the file was deleted.
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -474,19 +452,17 @@ module Gcloud
 
       ##
       # Public URL to access the file. If the file is not public, requests to
-      # the URL will return an error. (See File::Acl#public! and
-      # Bucket::DefaultAcl#public!) For more information, read [Accessing Public
-      # Data]{https://cloud.google.com/storage/docs/access-public-data}.
+      # the URL will return an error. (See {File::Acl#public!} and
+      # {Bucket::DefaultAcl#public!}) To share a file that is not public see
+      # {#signed_url}.
       #
-      # To share a file that is not public see #signed_url.
+      # @see https://cloud.google.com/storage/docs/access-public-data Accessing
+      #   Public Data
       #
-      # === Parameters
+      # @param [String] protocol The protocol to use for the URL. Default is
+      #   +HTTPS+.
       #
-      # +protocol+::
-      #   The protocol to use for the URL. Default is +HTTPS+. (+String+)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -496,9 +472,7 @@ module Gcloud
       #   file = bucket.file "avatars/heidi/400x400.png"
       #   public_url = file.public_url
       #
-      # To generate the URL with a protocol other than HTTPS, use the +protocol+
-      # option:
-      #
+      # @example Generate the URL with a protocol other than HTTPS:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -516,46 +490,41 @@ module Gcloud
       ##
       # Access without authentication can be granted to a File for a specified
       # period of time. This URL uses a cryptographic signature
-      # of your credentials to access the file. See the
-      # {Access Control Signed URLs guide
-      # }[https://cloud.google.com/storage/docs/access-control#Signed-URLs]
-      # for more.
+      # of your credentials to access the file.
       #
       # Generating a URL requires service account credentials, either by
-      # connecting with a service account when calling Gcloud.storage, or by
-      # passing in the service account +issuer+ and +signing_key+ values. A
-      # SignedUrlUnavailable is raised if the service account credentials are
+      # connecting with a service account when calling {Gcloud.storage}, or by
+      # passing in the service account +issuer+ and +signing_key+ values.
+      # Although the private key can be passed as a string for convenience,
+      # creating and storing an instance of +OpenSSL::PKey::RSA+ is more
+      # efficient when making multiple calls to +signed_url+.
+      #
+      # A SignedUrlUnavailable is raised if the service account credentials are
       # missing. Service account credentials are acquired by following the steps
       # in {Service Account Authentication}[
       # https://cloud.google.com/storage/docs/authentication#service_accounts].
       #
-      # === Parameters
+      # @see https://cloud.google.com/storage/docs/access-control#Signed-URLs
+      #   Access Control Signed URLs guide
       #
-      # +method+::
-      #   The HTTP verb to be used with the signed URL. Signed URLs can be used
+      # @param [String] method The HTTP verb to be used with the signed URL.
+      #   Signed URLs can be used
       #   with +GET+, +HEAD+, +PUT+, and +DELETE+ requests. Default is +GET+.
-      #   (+String+)
-      # +expires+::
-      #   The number of seconds until the URL expires. Default is 300/5 minutes.
-      #   (+Integer+)
-      # +content_type+::
-      #   When provided, the client (browser) must send this value in the
-      #   HTTP header. e.g. +text/plain+ (+String+)
-      # +content_md5+::
-      #   The MD5 digest value in base64. If you provide this in the string, the
-      #   client (usually a browser) must provide this HTTP header with this
-      #   same value in its request. (+String+)
-      # +issuer+::
-      #   Service Account's Client Email. (+String+)
-      # +client_email+::
-      #   Service Account's Client Email. (+String+)
-      # +signing_key+::
-      #   Service Account's Private Key. (+OpenSSL::PKey::RSA+ or +String+)
-      # +private_key+::
-      #   Service Account's Private Key. (+OpenSSL::PKey::RSA+ or +String+)
+      # @param [Integer] expires The number of seconds until the URL expires.
+      #   Default is 300/5 minutes.
+      # @param [String] content_type When provided, the client (browser) must
+      #   send this value in the HTTP header. e.g. +text/plain+
+      # @param [String] content_md5 The MD5 digest value in base64. If you
+      #   provide this in the string, the client (usually a browser) must
+      #   provide this HTTP header with this same value in its request.
+      # @param [String] issuer Service Account's Client Email.
+      # @param [String] client_email Service Account's Client Email.
+      # @param [OpenSSL::PKey::RSA, String] signing_key Service Account's
+      #   Private Key.
+      # @param [OpenSSL::PKey::RSA, String] private_key Service Account's
+      #   Private Key.
       #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -565,8 +534,7 @@ module Gcloud
       #   file = bucket.file "avatars/heidi/400x400.png"
       #   shared_url = file.signed_url
       #
-      # Any of the option parameters may be specified:
-      #
+      # @example Any of the option parameters may be specified:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -577,13 +545,7 @@ module Gcloud
       #   shared_url = file.signed_url method: "GET",
       #                                expires: 300 # 5 minutes from now
       #
-      # Signed URLs require service account credentials. If you are not
-      # authenticated with a service account, those credentials can be passed in
-      # using the +issuer+ and +signing_key+ options. Although the private key
-      # can be passed as a string for convenience, creating and storing an
-      # instance of +OpenSSL::PKey::RSA+ is more efficient when making multiple
-      # calls to +signed_url+.
-      #
+      # @example Using the +issuer+ and +signing_key+ options:
       #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
@@ -607,20 +569,16 @@ module Gcloud
       end
 
       ##
-      # The File::Acl instance used to control access to the file.
+      # The {File::Acl} instance used to control access to the file.
       #
       # A file has owners, writers, and readers. Permissions can be granted to
       # an individual user's email address, a group's email address,  as well as
-      # many predefined lists. See the
-      # {Access Control guide
-      # }[https://cloud.google.com/storage/docs/access-control]
-      # for more.
+      # many predefined lists.
       #
-      # === Examples
+      # @see https://cloud.google.com/storage/docs/access-control Access Control
+      #   guide
       #
-      # Access to a file can be granted to a user by appending +"user-"+ to the
-      # email address:
-      #
+      # @example Grant access to a user by pre-pending +"user-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -632,9 +590,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   file.acl.add_reader "user-#{email}"
       #
-      # Access to a file can be granted to a group by appending +"group-"+ to
-      # the email address:
-      #
+      # @example Grant access to a group by pre-pending +"group-"+ to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -646,9 +602,7 @@ module Gcloud
       #   email = "authors@example.net"
       #   file.acl.add_reader "group-#{email}"
       #
-      # Access to a file can also be granted to a predefined list of
-      # permissions:
-      #
+      # @example Or, grant access via a predefined permissions list:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -677,15 +631,15 @@ module Gcloud
       alias_method :refresh!, :reload!
 
       ##
-      # URI of the location and file name in the format of
+      # @private URI of the location and file name in the format of
       # <code>gs://my-bucket/file-name.json</code>.
-      def to_gs_url #:nodoc:
+      def to_gs_url
         "gs://#{bucket}/#{name}"
       end
 
       ##
-      # New File from a Google API Client object.
-      def self.from_gapi gapi, conn #:nodoc:
+      # @private New File from a Google API Client object.
+      def self.from_gapi gapi, conn
         new.tap do |f|
           f.gapi = gapi
           f.connection = conn
@@ -733,8 +687,8 @@ module Gcloud
       end
 
       ##
-      # Create a signed_url for a file.
-      class Signer #:nodoc:
+      # @private Create a signed_url for a file.
+      class Signer
         def initialize file
           @file = file
         end

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -286,15 +286,15 @@ module Gcloud
       # @param [String] path The path on the local file system to write the data
       #   to. The path provided must be writable.
       # @param [Symbol] verify The verification algoruthm used to ensure the
-      #   downloaded file contents are correct. Default is +:md5+.
+      #   downloaded file contents are correct. Default is `:md5`.
       #
       #   Acceptable values are:
-      #   * +md5+ - Verify file content match using the MD5 hash.
-      #   * +crc32c+ - Verify file content match using the CRC32c hash.
-      #   * +all+ - Perform all available file content verification.
-      #   * +none+ - Don't perform file content verification.
+      #   * `md5` - Verify file content match using the MD5 hash.
+      #   * `crc32c` - Verify file content match using the CRC32c hash.
+      #   * `all` - Perform all available file content verification.
+      #   * `none` - Don't perform file content verification.
       #
-      # @return [File] Returns a +::File+ object on the local file system
+      # @return [File] Returns a `::File` object on the local file system
       #
       # @example
       #   require "gcloud"
@@ -365,17 +365,17 @@ module Gcloud
       #   file.
       #
       #   Acceptable values are:
-      #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
-      #     +authenticatedRead+ - File owner gets OWNER access, and
+      #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
+      #     `authenticatedRead` - File owner gets OWNER access, and
       #     allAuthenticatedUsers get READER access.
-      #   * +owner_full+, +bucketOwnerFullControl+ - File owner gets OWNER
+      #   * `owner_full`, `bucketOwnerFullControl` - File owner gets OWNER
       #     access, and project team owners get OWNER access.
-      #   * +owner_read+, +bucketOwnerRead+ - File owner gets OWNER access, and
+      #   * `owner_read`, `bucketOwnerRead` - File owner gets OWNER access, and
       #     project team owners get READER access.
-      #   * +private+ - File owner gets OWNER access.
-      #   * +project_private+, +projectPrivate+ - File owner gets OWNER access,
+      #   * `private` - File owner gets OWNER access.
+      #   * `project_private`, `projectPrivate` - File owner gets OWNER access,
       #     and project team members get access according to their roles.
-      #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
+      #   * `public`, `public_read`, `publicRead` - File owner gets OWNER
       #     access, and allUsers get READER access.
       # @param [Integer] generation Select a specific revision of the file to
       #   copy. The default is the latest version.
@@ -427,7 +427,7 @@ module Gcloud
       ##
       # Permanently deletes the file.
       #
-      # @return [Boolean] Returns +true+ if the file was deleted.
+      # @return [Boolean] Returns `true` if the file was deleted.
       #
       # @example
       #   require "gcloud"
@@ -460,7 +460,7 @@ module Gcloud
       #   Public Data
       #
       # @param [String] protocol The protocol to use for the URL. Default is
-      #   +HTTPS+.
+      #   `HTTPS`.
       #
       # @example
       #   require "gcloud"
@@ -494,10 +494,10 @@ module Gcloud
       #
       # Generating a URL requires service account credentials, either by
       # connecting with a service account when calling {Gcloud.storage}, or by
-      # passing in the service account +issuer+ and +signing_key+ values.
+      # passing in the service account `issuer` and `signing_key` values.
       # Although the private key can be passed as a string for convenience,
-      # creating and storing an instance of +OpenSSL::PKey::RSA+ is more
-      # efficient when making multiple calls to +signed_url+.
+      # creating and storing an instance of `OpenSSL::PKey::RSA` is more
+      # efficient when making multiple calls to `signed_url`.
       #
       # A SignedUrlUnavailable is raised if the service account credentials are
       # missing. Service account credentials are acquired by following the steps
@@ -509,11 +509,11 @@ module Gcloud
       #
       # @param [String] method The HTTP verb to be used with the signed URL.
       #   Signed URLs can be used
-      #   with +GET+, +HEAD+, +PUT+, and +DELETE+ requests. Default is +GET+.
+      #   with `GET`, `HEAD`, `PUT`, and `DELETE` requests. Default is `GET`.
       # @param [Integer] expires The number of seconds until the URL expires.
       #   Default is 300/5 minutes.
       # @param [String] content_type When provided, the client (browser) must
-      #   send this value in the HTTP header. e.g. +text/plain+
+      #   send this value in the HTTP header. e.g. `text/plain`
       # @param [String] content_md5 The MD5 digest value in base64. If you
       #   provide this in the string, the client (usually a browser) must
       #   provide this HTTP header with this same value in its request.
@@ -545,7 +545,7 @@ module Gcloud
       #   shared_url = file.signed_url method: "GET",
       #                                expires: 300 # 5 minutes from now
       #
-      # @example Using the +issuer+ and +signing_key+ options:
+      # @example Using the `issuer` and `signing_key` options:
       #   require "gcloud/storage"
       #
       #   storage = Gcloud.storage
@@ -578,7 +578,7 @@ module Gcloud
       # @see https://cloud.google.com/storage/docs/access-control Access Control
       #   guide
       #
-      # @example Grant access to a user by pre-pending +"user-"+ to an email:
+      # @example Grant access to a user by pre-pending `"user-"` to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -590,7 +590,7 @@ module Gcloud
       #   email = "heidi@example.net"
       #   file.acl.add_reader "user-#{email}"
       #
-      # @example Grant access to a group by pre-pending +"group-"+ to an email:
+      # @example Grant access to a group by pre-pending `"group-"` to an email:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -20,7 +20,7 @@ require "gcloud/storage/file/verifier"
 module Gcloud
   module Storage
     ##
-    # = File
+    # # File
     #
     # Represents a File
     # ({Object}[https://cloud.google.com/storage/docs/json_api/v1/objects]) that

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/storage/file/acl"
 require "gcloud/storage/file/list"

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -21,6 +21,7 @@ module Gcloud
       #
       # Represents a File's Access Control List.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -32,6 +33,7 @@ module Gcloud
       #   file.acl.readers.each { |reader| puts reader }
       #
       class Acl
+        # @private
         RULES = { "authenticatedRead" => "authenticatedRead",
                   "auth" => "authenticatedRead",
                   "auth_read" => "authenticatedRead",
@@ -46,12 +48,12 @@ module Gcloud
                   "project_private" => "projectPrivate",
                   "publicRead" => "publicRead",
                   "public" => "publicRead",
-                  "public_read" => "publicRead" } #:nodoc:
+                  "public_read" => "publicRead" }
 
         ##
-        # Initialized a new Acl object.
+        # @private Initialized a new Acl object.
         # Must provide a valid Bucket object.
-        def initialize file #:nodoc:
+        def initialize file
           @bucket = file.bucket
           @file = file.name
           @connection = file.connection
@@ -63,8 +65,7 @@ module Gcloud
         ##
         # Reloads all Access Control List data for the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -87,12 +88,9 @@ module Gcloud
         ##
         # Lists the owners of the file.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -111,12 +109,9 @@ module Gcloud
         ##
         # Lists the owners of the file.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -135,12 +130,9 @@ module Gcloud
         ##
         # Lists the readers of the file.
         #
-        # === Returns
+        # @return [Array<String>]
         #
-        # Array of Strings
-        #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -159,11 +151,8 @@ module Gcloud
         ##
         # Grants owner permission to the file.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -174,15 +163,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Examples
-        #
-        # Access to a file can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -194,9 +178,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_owner "user-#{email}"
         #
-        # Access to a file can be granted to a group by appending +"group-"+ to
-        # the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -223,11 +205,8 @@ module Gcloud
         ##
         # Grants writer permission to the file.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -238,15 +217,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Examples
-        #
-        # Access to a file can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -258,9 +232,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_writer "user-#{email}"
         #
-        # Access to a file can be granted to a group by appending +"group-"+ to
-        # the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -287,11 +259,8 @@ module Gcloud
         ##
         # Grants reader permission to the file.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -302,15 +271,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Examples
-        #
-        # Access to a file can be granted to a user by appending +"user-"+ to
-        # the email address:
-        #
+        # @example Grant access to a user by pre-pending +"user-"+ to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -322,9 +286,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_reader "user-#{email}"
         #
-        # Access to a file can be granted to a group by appending +"group-"+ to
-        # the email address:
-        #
+        # @example Grant access to a group by pre-pending +"group-"+ to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -351,11 +313,8 @@ module Gcloud
         ##
         # Permanently deletes the entity from the file's access control list.
         #
-        # === Parameters
-        #
-        # +entity+::
-        #   The entity holding the permission, in one of the following forms:
-        #   (+String+)
+        # @param [String] entity The entity holding the permission, in one of
+        #   the following forms:
         #
         #   * user-userId
         #   * user-email
@@ -366,12 +325,10 @@ module Gcloud
         #   * allUsers
         #   * allAuthenticatedUsers
         #
-        # +generation+::
-        #   When present, selects a specific revision of this object.
-        #   Default is the latest version. (+Integer+)
+        # @param [Integer] generation When present, selects a specific revision
+        #   of this object. Default is the latest version.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -395,7 +352,8 @@ module Gcloud
           false
         end
 
-        def self.predefined_rule_for rule_name #:nodoc:
+        # @private
+        def self.predefined_rule_for rule_name
           RULES[rule_name.to_s]
         end
 
@@ -405,8 +363,7 @@ module Gcloud
         # Convenience method to apply the +authenticatedRead+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -429,8 +386,7 @@ module Gcloud
         # Convenience method to apply the +bucketOwnerFullControl+ predefined
         # ACL rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -450,8 +406,7 @@ module Gcloud
         # Convenience method to apply the +bucketOwnerRead+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -471,8 +426,7 @@ module Gcloud
         # Convenience method to apply the +private+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -491,8 +445,7 @@ module Gcloud
         # Convenience method to apply the +projectPrivate+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -512,8 +465,7 @@ module Gcloud
         # Convenience method to apply the +publicRead+ predefined ACL
         # rule to the file.
         #
-        # === Example
-        #
+        # @example
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 module Gcloud
   module Storage

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -17,7 +17,7 @@ module Gcloud
   module Storage
     class File
       ##
-      # = File Access Control List
+      # # File Access Control List
       #
       # Represents a File's Access Control List.
       #

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -166,7 +166,7 @@ module Gcloud
         # @param [Integer] generation When present, selects a specific revision
         #   of this object. Default is the latest version.
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -178,7 +178,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_owner "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -220,7 +220,7 @@ module Gcloud
         # @param [Integer] generation When present, selects a specific revision
         #   of this object. Default is the latest version.
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -232,7 +232,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_writer "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -274,7 +274,7 @@ module Gcloud
         # @param [Integer] generation When present, selects a specific revision
         #   of this object. Default is the latest version.
         #
-        # @example Grant access to a user by pre-pending +"user-"+ to an email:
+        # @example Grant access to a user by pre-pending `"user-"` to an email:
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -286,7 +286,7 @@ module Gcloud
         #   email = "heidi@example.net"
         #   file.acl.add_reader "user-#{email}"
         #
-        # @example Grant access to a group by pre-pending +"group-"+ to an email
+        # @example Grant access to a group by pre-pending `"group-"` to an email
         #   require "gcloud"
         #
         #   gcloud = Gcloud.new
@@ -360,7 +360,7 @@ module Gcloud
         # Predefined ACL helpers
 
         ##
-        # Convenience method to apply the +authenticatedRead+ predefined ACL
+        # Convenience method to apply the `authenticatedRead` predefined ACL
         # rule to the file.
         #
         # @example
@@ -383,7 +383,7 @@ module Gcloud
         alias_method :authenticated_read!, :auth!
 
         ##
-        # Convenience method to apply the +bucketOwnerFullControl+ predefined
+        # Convenience method to apply the `bucketOwnerFullControl` predefined
         # ACL rule to the file.
         #
         # @example
@@ -403,7 +403,7 @@ module Gcloud
         alias_method :bucketOwnerFullControl!, :owner_full!
 
         ##
-        # Convenience method to apply the +bucketOwnerRead+ predefined ACL
+        # Convenience method to apply the `bucketOwnerRead` predefined ACL
         # rule to the file.
         #
         # @example
@@ -423,7 +423,7 @@ module Gcloud
         alias_method :bucketOwnerRead!, :owner_read!
 
         ##
-        # Convenience method to apply the +private+ predefined ACL
+        # Convenience method to apply the `private` predefined ACL
         # rule to the file.
         #
         # @example
@@ -442,7 +442,7 @@ module Gcloud
         end
 
         ##
-        # Convenience method to apply the +projectPrivate+ predefined ACL
+        # Convenience method to apply the `projectPrivate` predefined ACL
         # rule to the file.
         #
         # @example
@@ -462,7 +462,7 @@ module Gcloud
         alias_method :projectPrivate!, :project_private!
 
         ##
-        # Convenience method to apply the +publicRead+ predefined ACL
+        # Convenience method to apply the `publicRead` predefined ACL
         # rule to the file.
         #
         # @example

--- a/lib/gcloud/storage/file/list.rb
+++ b/lib/gcloud/storage/file/list.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "delegate"
 

--- a/lib/gcloud/storage/file/list.rb
+++ b/lib/gcloud/storage/file/list.rb
@@ -40,8 +40,8 @@ module Gcloud
         end
 
         ##
-        # New File::List from a response object.
-        def self.from_response resp, conn #:nodoc:
+        # @private New File::List from a response object.
+        def self.from_response resp, conn
           buckets = Array(resp.data["items"]).map do |gapi_object|
             File.from_gapi gapi_object, conn
           end

--- a/lib/gcloud/storage/file/verifier.rb
+++ b/lib/gcloud/storage/file/verifier.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "pathname"
 require "digest/md5"

--- a/lib/gcloud/storage/file/verifier.rb
+++ b/lib/gcloud/storage/file/verifier.rb
@@ -22,9 +22,10 @@ module Gcloud
   module Storage
     class File
       ##
+      # @private
       # Verifies downloaded files by creating an MD5 or CRC32c hash digest
       # and comparing the value to the one from the Storage API.
-      module Verifier #:nodoc:
+      module Verifier
         def self.verify_md5! gcloud_file, local_file
           gcloud_digest = gcloud_file.md5
           local_digest = md5_for local_file

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -32,9 +32,12 @@ module Gcloud
     # authentication, and monitoring settings for those APIs.
     #
     # Gcloud::Storage::Project is the main object for interacting with
-    # Google Storage. Gcloud::Storage::Bucket objects are created,
+    # Google Storage. {Gcloud::Storage::Bucket} objects are created,
     # read, updated, and deleted by Gcloud::Storage::Project.
     #
+    # See {Gcloud#storage}
+    #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new
@@ -43,17 +46,16 @@ module Gcloud
     #   bucket = storage.bucket "my-bucket"
     #   file = bucket.file "path/to/my-file.ext"
     #
-    # See Gcloud#storage
     class Project
       ##
-      # The Connection object.
-      attr_accessor :connection #:nodoc:
+      # @private The Connection object.
+      attr_accessor :connection
 
       ##
-      # Creates a new Project instance.
+      # @private Creates a new Project instance.
       #
-      # See Gcloud#storage
-      def initialize project, credentials #:nodoc:
+      # See {Gcloud#storage}
+      def initialize project, credentials
         project = project.to_s # Always cast to a string
         fail ArgumentError, "project is missing" if project.empty?
         @connection = Connection.new project, credentials
@@ -62,8 +64,7 @@ module Gcloud
       ##
       # The Storage project connected to.
       #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new "my-todo-project",
@@ -77,8 +78,8 @@ module Gcloud
       end
 
       ##
-      # Default project.
-      def self.default_project #:nodoc:
+      # @private Default project.
+      def self.default_project
         ENV["STORAGE_PROJECT"] ||
           ENV["GCLOUD_PROJECT"] ||
           ENV["GOOGLE_CLOUD_PROJECT"] ||
@@ -88,23 +89,16 @@ module Gcloud
       ##
       # Retrieves a list of buckets for the given project.
       #
-      # === Parameters
+      # @param [String] prefix Filter results to buckets whose names begin with
+      #   this prefix.
+      # @param [String] token A previously-returned page token representing part
+      #   of the larger set of results to view.
+      # @param [Integer] max Maximum number of buckets to return.
       #
-      # +prefix+::
-      #   Filter results to buckets whose names begin with this prefix.
-      #   (+String+)
-      # +token+::
-      #   A previously-returned page token representing part of the larger set
-      #   of results to view. (+String+)
-      # +max+::
-      #   Maximum number of buckets to return. (+Integer+)
+      # @return [Array<Gcloud::Storage::Bucket>] (See
+      #   {Gcloud::Storage::Bucket::List})
       #
-      # === Returns
-      #
-      # Array of Gcloud::Storage::Bucket (See Gcloud::Storage::Bucket::List)
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -115,9 +109,7 @@ module Gcloud
       #     puts bucket.name
       #   end
       #
-      # You can also retrieve all buckets whose names begin with a prefix using
-      # the +:prefix+ option:
-      #
+      # @example Retrieve all buckets with names that begin with a given prefix:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -125,9 +117,7 @@ module Gcloud
       #
       #   user_buckets = storage.buckets prefix: "user-"
       #
-      # If you have a significant number of buckets, you may need to paginate
-      # through them: (See Bucket::List#token)
-      #
+      # @example With pagination: (See {Bucket::List#token})
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -159,17 +149,12 @@ module Gcloud
       ##
       # Retrieves bucket by name.
       #
-      # === Parameters
+      # @param [String] bucket_name Name of a bucket.
       #
-      # +bucket_name+::
-      #   Name of a bucket. (+String+)
+      # @return [Gcloud::Storage::Bucket, nil] Returns nil if bucket does not
+      #   exist
       #
-      # === Returns
-      #
-      # Gcloud::Storage::Bucket or nil if bucket does not exist
-      #
-      # === Example
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -192,18 +177,25 @@ module Gcloud
       ##
       # Creates a new bucket with optional attributes. Also accepts a block for
       # defining the CORS configuration for a static website served from the
-      # bucket. See Bucket::Cors for details. For more information about
-      # configuring buckets as static websites, see {How to Host a Static
-      # Website }[https://cloud.google.com/storage/docs/website-configuration].
-      # For more information about CORS, see {Cross-Origin Resource Sharing
-      # (CORS)}[https://cloud.google.com/storage/docs/cross-origin].
+      # bucket. See {Bucket::Cors} for details.
       #
-      # === Parameters
+      # The API call to create the bucket may be retried under certain
+      # conditions. See {Gcloud::Backoff} to control this behavior, or
+      # specify the wanted behavior in the call with the +:retries:+ option.
       #
-      # +bucket_name+::
-      #   Name of a bucket. (+String+)
-      # +acl+::
-      #   Apply a predefined set of access controls to this bucket. (+String+)
+      # You can pass {website
+      # settings}[https://cloud.google.com/storage/docs/website-configuration]
+      # for the bucket, including a block that defines CORS rule. See
+      # {Bucket::Cors} for details.
+      #
+      # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
+      #   Resource Sharing (CORS)
+      # @see https://cloud.google.com/storage/docs/website-configuration How to
+      #   Host a Static Website
+      #
+      # @param [String] bucket_name Name of a bucket.
+      # @param [String] acl Apply a predefined set of access controls to this
+      #   bucket.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -216,9 +208,8 @@ module Gcloud
       #     OWNER access, and allUsers get READER access.
       #   * +public_write+, +publicReadWrite+ - Project team owners get OWNER
       #     access, and allUsers get WRITER access.
-      # +default_acl+::
-      #   Apply a predefined set of default object access controls to this
-      #   bucket. (+String+)
+      # @param [String] default_acl Apply a predefined set of default object
+      #   access controls to this bucket.
       #
       #   Acceptable values are:
       #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
@@ -233,60 +224,51 @@ module Gcloud
       #     and project team members get access according to their roles.
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
-      # +cors+::
-      #   The CORS rules for the bucket. Accepts an array of hashes containing
-      #   the attributes specified for the {resource description of
+      # @param [String] cors The CORS rules for the bucket. Accepts an array of
+      #   hashes containing the attributes specified for the {resource
+      #   description of
       #   cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
-      # +location+::
-      #   The location of the bucket. Object data for objects in the bucket
-      #   resides in physical storage within this region. Possible values
-      #   include +ASIA+, +EU+, and +US+.(See the {developer's
+      # @param [String] location The location of the bucket. Object data for
+      #   objects in the bucket resides in physical storage within this region.
+      #   Possible values include +ASIA+, +EU+, and +US+.(See the {developer's
       #   guide}[https://cloud.google.com/storage/docs/bucket-locations] for the
-      #   authoritative list. The default value is +US+. (+String+)
-      # +logging_bucket+::
-      #   The destination bucket for the bucket's logs. For more information,
-      #   see {Access
-      #   Logs}[https://cloud.google.com/storage/docs/access-logs]. (+String+)
-      # +logging_prefix+::
-      #   The prefix used to create log object names for the bucket. It can be
-      #   at most 900 characters and must be a {valid object
+      #   authoritative list. The default value is +US+.
+      # @param [String] logging_bucket The destination bucket for the bucket's
+      #   logs. For more information, see {Access
+      #   Logs}[https://cloud.google.com/storage/docs/access-logs].
+      # @param [String] logging_prefix The prefix used to create log object
+      #   names for the bucket. It can be at most 900 characters and must be a
+      #   {valid object
       #   name}[https://cloud.google.com/storage/docs/bucket-naming#objectnames]
-      #   . By default, the object prefix is the name
-      #   of the bucket for which the logs are enabled. For more information,
-      #   see {Access Logs}[https://cloud.google.com/storage/docs/access-logs].
-      #   (+String+)
-      # +retries+::
-      #   The number of times the API call should be retried.
-      #   Default is Gcloud::Backoff.retries. (+Integer+)
-      # +storage_class+::
-      #   Defines how objects in the bucket are stored and determines the SLA
-      #   and the cost of storage. Values include +:standard+, +:nearline+, and
-      #   +:dra+ (Durable Reduced Availability), as well as the strings returned
-      #   by Bucket#storage_class. For more information, see {Storage
-      #   Classes}[https://cloud.google.com/storage/docs/storage-classes].
-      #   The default value is +:standard+. (+Symbol+ or +String+)
-      # +versioning+::
-      #   Whether {Object
+      #   . By default, the object prefix is the name of the bucket for which
+      #   the logs are enabled. For more information, see {Access
+      #   Logs}[https://cloud.google.com/storage/docs/access-logs].
+      # @param [Integer] retries The number of times the API call should be
+      #   retried. Default is {Gcloud::Backoff.retries}.
+      # @param [Symbol, String] storage_class Defines how objects in the bucket
+      #   are stored and determines the SLA and the cost of storage. Values
+      #   include +:standard+, +:nearline+, and +:dra+ (Durable Reduced
+      #   Availability), as well as the strings returned by
+      #   Bucket#storage_class. For more information, see {Storage
+      #   Classes}[https://cloud.google.com/storage/docs/storage-classes]. The
+      #   default value is +:standard+.
+      # @param [Boolean] versioning Whether {Object
       #   Versioning}[https://cloud.google.com/storage/docs/object-versioning]
       #   is to be enabled for the bucket. The default value is +false+.
-      #   (+Boolean+)
-      # +website_main+::
-      #   The index page returned from a static website served from the bucket
-      #   when a site visitor requests the top level directory. For more
-      #   information, see {How to Host a Static Website
+      # @param [String] website_main The index page returned from a static
+      #   website served from the bucket when a site visitor requests the top
+      #   level directory. For more information, see {How to Host a Static
+      #   Website
       #   }[https://cloud.google.com/storage/docs/website-configuration#step4].
-      # +website_404+::
-      #   The page returned from a static website served from the bucket when a
-      #   site visitor requests a resource that does not exist. For more
-      #   information, see {How to Host a Static Website
+      # @param [String] website_404 The page returned from a static website
+      #   served from the bucket when a site visitor requests a resource that
+      #   does not exist. For more information, see {How to Host a Static
+      #   Website
       #   }[https://cloud.google.com/storage/docs/website-configuration#step4].
       #
-      # === Returns
+      # @return [Gcloud::Storage::Bucket]
       #
-      # Gcloud::Storage::Bucket
-      #
-      # === Examples
-      #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -294,10 +276,7 @@ module Gcloud
       #
       #   bucket = storage.create_bucket "my-bucket"
       #
-      # The API call to create the bucket may be retried under certain
-      # conditions. See Gcloud::Backoff to control this behavior, or
-      # specify the wanted behavior in the call with the +:retries:+ option:
-      #
+      # @example Specify the number of retries to attempt:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -305,11 +284,7 @@ module Gcloud
       #
       #   bucket = storage.create_bucket "my-bucket", retries: 5
       #
-      # You can pass {website
-      # settings}[https://cloud.google.com/storage/docs/website-configuration]
-      # for the bucket, including a block that defines CORS rule. See
-      # Bucket::Cors for details.
-      #
+      # @example Add CORS rules in a block:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -24,7 +24,7 @@ require "gcloud/storage/file"
 module Gcloud
   module Storage
     ##
-    # = Project
+    # # Project
     #
     # Represents the project that storage buckets and files belong to.
     # All data in Google Cloud Storage belongs inside a project.

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 
 require "gcloud/gce"
 require "gcloud/storage/errors"

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -181,7 +181,7 @@ module Gcloud
       #
       # The API call to create the bucket may be retried under certain
       # conditions. See {Gcloud::Backoff} to control this behavior, or
-      # specify the wanted behavior in the call with the +:retries:+ option.
+      # specify the wanted behavior in the call with the `:retries:` option.
       #
       # You can pass [website
       # settings](https://cloud.google.com/storage/docs/website-configuration)
@@ -198,31 +198,31 @@ module Gcloud
       #   bucket.
       #
       #   Acceptable values are:
-      #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
-      #     +authenticatedRead+ - Project team owners get OWNER access, and
+      #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
+      #     `authenticatedRead` - Project team owners get OWNER access, and
       #     allAuthenticatedUsers get READER access.
-      #   * +private+ - Project team owners get OWNER access.
-      #   * +project_private+, +projectPrivate+ - Project team members get
+      #   * `private` - Project team owners get OWNER access.
+      #   * `project_private`, `projectPrivate` - Project team members get
       #     access according to their roles.
-      #   * +public+, +public_read+, +publicRead+ - Project team owners get
+      #   * `public`, `public_read`, `publicRead` - Project team owners get
       #     OWNER access, and allUsers get READER access.
-      #   * +public_write+, +publicReadWrite+ - Project team owners get OWNER
+      #   * `public_write`, `publicReadWrite` - Project team owners get OWNER
       #     access, and allUsers get WRITER access.
       # @param [String] default_acl Apply a predefined set of default object
       #   access controls to this bucket.
       #
       #   Acceptable values are:
-      #   * +auth+, +auth_read+, +authenticated+, +authenticated_read+,
-      #     +authenticatedRead+ - File owner gets OWNER access, and
+      #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
+      #     `authenticatedRead` - File owner gets OWNER access, and
       #     allAuthenticatedUsers get READER access.
-      #   * +owner_full+, +bucketOwnerFullControl+ - File owner gets OWNER
+      #   * `owner_full`, `bucketOwnerFullControl` - File owner gets OWNER
       #     access, and project team owners get OWNER access.
-      #   * +owner_read+, +bucketOwnerRead+ - File owner gets OWNER access, and
+      #   * `owner_read`, `bucketOwnerRead` - File owner gets OWNER access, and
       #     project team owners get READER access.
-      #   * +private+ - File owner gets OWNER access.
-      #   * +project_private+, +projectPrivate+ - File owner gets OWNER access,
+      #   * `private` - File owner gets OWNER access.
+      #   * `project_private`, `projectPrivate` - File owner gets OWNER access,
       #     and project team members get access according to their roles.
-      #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
+      #   * `public`, `public_read`, `publicRead` - File owner gets OWNER
       #     access, and allUsers get READER access.
       # @param [String] cors The CORS rules for the bucket. Accepts an array of
       #   hashes containing the attributes specified for the [resource
@@ -230,9 +230,9 @@ module Gcloud
       #   cors](https://cloud.google.com/storage/docs/json_api/v1/buckets#cors).
       # @param [String] location The location of the bucket. Object data for
       #   objects in the bucket resides in physical storage within this region.
-      #   Possible values include +ASIA+, +EU+, and +US+.(See the [developer's
+      #   Possible values include `ASIA`, `EU`, and `US`. (See the [developer's
       #   guide](https://cloud.google.com/storage/docs/bucket-locations) for the
-      #   authoritative list. The default value is +US+.
+      #   authoritative list. The default value is `US`.
       # @param [String] logging_bucket The destination bucket for the bucket's
       #   logs. For more information, see [Access
       #   Logs](https://cloud.google.com/storage/docs/access-logs).
@@ -247,14 +247,14 @@ module Gcloud
       #   retried. Default is {Gcloud::Backoff.retries}.
       # @param [Symbol, String] storage_class Defines how objects in the bucket
       #   are stored and determines the SLA and the cost of storage. Values
-      #   include +:standard+, +:nearline+, and +:dra+ (Durable Reduced
+      #   include `:standard`, `:nearline`, and `:dra` (Durable Reduced
       #   Availability), as well as the strings returned by
       #   Bucket#storage_class. For more information, see [Storage
       #   Classes](https://cloud.google.com/storage/docs/storage-classes). The
-      #   default value is +:standard+.
+      #   default value is `:standard`.
       # @param [Boolean] versioning Whether [Object
       #   Versioning](https://cloud.google.com/storage/docs/object-versioning)
-      #   is to be enabled for the bucket. The default value is +false+.
+      #   is to be enabled for the bucket. The default value is `false`.
       # @param [String] website_main The index page returned from a static
       #   website served from the bucket when a site visitor requests the top
       #   level directory. For more information, see [How to Host a Static

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -183,8 +183,8 @@ module Gcloud
       # conditions. See {Gcloud::Backoff} to control this behavior, or
       # specify the wanted behavior in the call with the +:retries:+ option.
       #
-      # You can pass {website
-      # settings}[https://cloud.google.com/storage/docs/website-configuration]
+      # You can pass [website
+      # settings](https://cloud.google.com/storage/docs/website-configuration)
       # for the bucket, including a block that defines CORS rule. See
       # {Bucket::Cors} for details.
       #
@@ -225,46 +225,46 @@ module Gcloud
       #   * +public+, +public_read+, +publicRead+ - File owner gets OWNER
       #     access, and allUsers get READER access.
       # @param [String] cors The CORS rules for the bucket. Accepts an array of
-      #   hashes containing the attributes specified for the {resource
+      #   hashes containing the attributes specified for the [resource
       #   description of
-      #   cors}[https://cloud.google.com/storage/docs/json_api/v1/buckets#cors].
+      #   cors](https://cloud.google.com/storage/docs/json_api/v1/buckets#cors).
       # @param [String] location The location of the bucket. Object data for
       #   objects in the bucket resides in physical storage within this region.
-      #   Possible values include +ASIA+, +EU+, and +US+.(See the {developer's
-      #   guide}[https://cloud.google.com/storage/docs/bucket-locations] for the
+      #   Possible values include +ASIA+, +EU+, and +US+.(See the [developer's
+      #   guide](https://cloud.google.com/storage/docs/bucket-locations) for the
       #   authoritative list. The default value is +US+.
       # @param [String] logging_bucket The destination bucket for the bucket's
-      #   logs. For more information, see {Access
-      #   Logs}[https://cloud.google.com/storage/docs/access-logs].
+      #   logs. For more information, see [Access
+      #   Logs](https://cloud.google.com/storage/docs/access-logs).
       # @param [String] logging_prefix The prefix used to create log object
       #   names for the bucket. It can be at most 900 characters and must be a
-      #   {valid object
-      #   name}[https://cloud.google.com/storage/docs/bucket-naming#objectnames]
+      #   [valid object
+      #   name](https://cloud.google.com/storage/docs/bucket-naming#objectnames)
       #   . By default, the object prefix is the name of the bucket for which
-      #   the logs are enabled. For more information, see {Access
-      #   Logs}[https://cloud.google.com/storage/docs/access-logs].
+      #   the logs are enabled. For more information, see [Access
+      #   Logs](https://cloud.google.com/storage/docs/access-logs).
       # @param [Integer] retries The number of times the API call should be
       #   retried. Default is {Gcloud::Backoff.retries}.
       # @param [Symbol, String] storage_class Defines how objects in the bucket
       #   are stored and determines the SLA and the cost of storage. Values
       #   include +:standard+, +:nearline+, and +:dra+ (Durable Reduced
       #   Availability), as well as the strings returned by
-      #   Bucket#storage_class. For more information, see {Storage
-      #   Classes}[https://cloud.google.com/storage/docs/storage-classes]. The
+      #   Bucket#storage_class. For more information, see [Storage
+      #   Classes](https://cloud.google.com/storage/docs/storage-classes). The
       #   default value is +:standard+.
-      # @param [Boolean] versioning Whether {Object
-      #   Versioning}[https://cloud.google.com/storage/docs/object-versioning]
+      # @param [Boolean] versioning Whether [Object
+      #   Versioning](https://cloud.google.com/storage/docs/object-versioning)
       #   is to be enabled for the bucket. The default value is +false+.
       # @param [String] website_main The index page returned from a static
       #   website served from the bucket when a site visitor requests the top
-      #   level directory. For more information, see {How to Host a Static
+      #   level directory. For more information, see [How to Host a Static
       #   Website
-      #   }[https://cloud.google.com/storage/docs/website-configuration#step4].
+      #   ](https://cloud.google.com/storage/docs/website-configuration#step4).
       # @param [String] website_404 The page returned from a static website
       #   served from the bucket when a site visitor requests a resource that
-      #   does not exist. For more information, see {How to Host a Static
+      #   does not exist. For more information, see [How to Host a Static
       #   Website
-      #   }[https://cloud.google.com/storage/docs/website-configuration#step4].
+      #   ](https://cloud.google.com/storage/docs/website-configuration#step4).
       #
       # @return [Gcloud::Storage::Bucket]
       #

--- a/lib/gcloud/upload.rb
+++ b/lib/gcloud/upload.rb
@@ -19,7 +19,7 @@ require "gcloud"
 # Google Cloud Upload
 module Gcloud
   ##
-  # = Upload Settings
+  # # Upload Settings
   #
   # Upload allows users to configure how files are uploaded to the Google Cloud
   # Service APIs.

--- a/lib/gcloud/upload.rb
+++ b/lib/gcloud/upload.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 require "gcloud"
 
-#--
-# Google Cloud Upload
 module Gcloud
   ##
   # # Upload Settings

--- a/lib/gcloud/version.rb
+++ b/lib/gcloud/version.rb
@@ -1,4 +1,3 @@
-#--
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#--
-# Google Cloud Version
+
 module Gcloud
   VERSION = "0.6.1"
 end

--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -43,14 +43,18 @@ namespace :pages do
     tmp   = Pathname.new(Dir.home) + "tmp"
     docs  = tmp + "master-docs"
     pages = tmp + "master-pages"
+    jsondoc = tmp + "master-jsondoc"
     FileUtils.remove_dir docs if Dir.exists? docs
     FileUtils.remove_dir pages if Dir.exists? pages
+    FileUtils.remove_dir jsondoc if Dir.exists? jsondoc
     FileUtils.mkdir_p docs
     FileUtils.mkdir_p pages
+    FileUtils.mkdir_p jsondoc
 
-    Rake::Task["pages:yard"].invoke
+    Rake::Task["pages:jsondoc"].invoke
 
     puts `cp -R html/* #{docs}`
+    puts `cp jsondoc/gcloud.json #{jsondoc}/gcloud.json`
     # checkout the gh-pages branch
     git_repo = "git@github.com:GoogleCloudPlatform/gcloud-ruby.git"
     if ENV["GH_OAUTH_TOKEN"]
@@ -61,6 +65,8 @@ namespace :pages do
     Dir.chdir pages do
       # sync the docs
       puts `rsync -r --delete #{docs}/ docs/master/`
+      FileUtils.mkdir_p "versions"
+      puts `cp #{jsondoc}/gcloud.json versions/master.json`
       # commit changes
       puts `git add -A .`
       if ENV["GH_OAUTH_TOKEN"]

--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -247,4 +247,14 @@ namespace :pages do
       t.options << "--output-dir" << "html"
     end
   end
+
+  desc "Generates JSON output from gcloud-ruby .yardoc"
+  task :jsondoc => :yard do
+    require "gcloud/jsondoc"
+    registry = YARD::Registry.load! ".yardoc"
+    builder = Gcloud::Jsondoc.new registry
+    json = builder.docs.target!
+    FileUtils.mkdir_p "jsondoc"
+    File.write "jsondoc/gcloud.json", json
+  end
 end

--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -18,6 +18,8 @@ require "rdoc/task"
 require "fileutils"
 require "pathname"
 require "yaml"
+require "yard"
+require "yard/rake/yardoc_task"
 
 namespace :pages do
   desc "Updates the documentation on the gh-pages branch"
@@ -46,7 +48,7 @@ namespace :pages do
     FileUtils.mkdir_p docs
     FileUtils.mkdir_p pages
 
-    Rake::Task["pages:rdoc"].invoke
+    Rake::Task["pages:yard"].invoke
 
     puts `cp -R html/* #{docs}`
     # checkout the gh-pages branch
@@ -93,6 +95,11 @@ namespace :pages do
     FileUtils.mkdir_p repo
     FileUtils.mkdir_p pages
 
+    # Decide if we are using YARD or RDoc...
+    tag_version = Gem::Version.new tag.sub(/\Av/, "")
+    cutoff_version = Gem::Version.new "0.7.0"
+    use_rdoc = tag_version < cutoff_version
+
     git_repo = "git@github.com:GoogleCloudPlatform/gcloud-ruby.git"
     if ENV["GH_OAUTH_TOKEN"]
       git_repo = "https://#{ENV["GH_OAUTH_TOKEN"]}@github.com/#{ENV["GH_OWNER"]}/#{ENV["GH_PROJECT_NAME"]}"
@@ -105,7 +112,11 @@ namespace :pages do
       Bundler.with_clean_env do
         # create the docs
         puts `bundle install --path .bundle`
-        puts `bundle exec rake pages:rdoc`
+        if use_rdoc
+          puts `bundle exec rake pages:rdoc`
+        else
+          puts `bundle exec rake pages:yard`
+        end
       end
     end
 
@@ -153,29 +164,6 @@ namespace :pages do
     Rake::Task["pages:master"].invoke
   end
 
-  RDoc::Task.new do |rdoc|
-    begin
-      require "gcloud-rdoc"
-    rescue LoadError
-      puts "Cannot load gcloud-rdoc"
-    end
-
-    require "rubygems"
-    spec = Gem::Specification::load("gcloud.gemspec")
-
-    main = "README.md"
-    if main_index = spec.rdoc_options.index("--main")
-      main = spec.rdoc_options[main_index + 1]
-    end
-
-    rdoc.generator = "gcloud"
-    rdoc.title = "gcloud #{spec.version} Documentation"
-    rdoc.main = main
-    rdoc.rdoc_files.include spec.extra_rdoc_files,
-                            "lib/"
-    rdoc.options = spec.rdoc_options
-  end
-
   desc "Updates the documentation for a feature branch"
   task :feature, :push do |t, args|
     push = args[:push]
@@ -202,7 +190,9 @@ namespace :pages do
     FileUtils.remove_dir docs if Dir.exists? docs
     FileUtils.mkdir_p docs
 
-    Rake::Task["pages:rerdoc"].invoke
+    puts `rm -rf html`
+
+    Rake::Task["pages:yard"].invoke
 
     puts `cp -R html/* #{docs}`
 
@@ -218,5 +208,43 @@ namespace :pages do
     puts `git commit -m "Update documentation for #{branch}"`
     puts `git push #{push} gh-pages -f` if push
     puts `git checkout #{branch}`
+  end
+
+  RDoc::Task.new do |rdoc|
+    begin
+      require "gcloud-rdoc"
+    rescue LoadError
+      puts "Cannot load gcloud-rdoc"
+    end
+
+    require "rubygems"
+    spec = Gem::Specification::load("gcloud.gemspec")
+
+    main = "README.md"
+    if main_index = spec.rdoc_options.index("--main")
+      main = spec.rdoc_options[main_index + 1]
+    end
+
+    rdoc.generator = "gcloud"
+    rdoc.title = "gcloud #{spec.version} Documentation"
+    rdoc.main = main
+    rdoc.rdoc_files.include spec.extra_rdoc_files, "lib/"
+    rdoc.options = spec.rdoc_options
+  end
+
+  YARD::Rake::YardocTask.new do |t|
+    begin
+      require "yard-gcloud"
+    rescue LoadError
+      puts "Cannot load yard-gcloud"
+    end
+
+    if defined? YARD::Gcloud
+      t.options << "--template" << "gcloud"
+      t.options << "--markup" << "markdown"
+      t.options << "--markup-provider" << "kramdown"
+      t.options << "--readme" << "OVERVIEW.md"
+      t.options << "--output-dir" << "html"
+    end
   end
 end

--- a/rakelib/gh-pages.rake
+++ b/rakelib/gh-pages.rake
@@ -121,7 +121,7 @@ namespace :pages do
         if use_rdoc
           puts `bundle exec rake pages:rdoc`
         else
-          puts `bundle exec rake pages:yard`
+          puts `bundle exec rake pages:jsondoc`
         end
       end
     end
@@ -132,8 +132,10 @@ namespace :pages do
     Dir.chdir pages do
       # make the release dir if needed
       FileUtils.mkdir_p "docs/#{tag}/"
+      FileUtils.mkdir_p "versions"
       # sync the docs
       puts `rsync -r --delete #{repo}/html/ docs/#{tag}/`
+      puts `cp #{repo}/jsondoc/gcloud.json versions/#{tag}.json` unless use_rdoc
       # Update releases yaml
       releases = YAML.load_file "_data/releases.yaml"
       unless releases.select { |r| r["version"] == tag }.any?


### PR DESCRIPTION
Convert the code documentation to YARD syntax. Static documentation using yard-gcloud template in the yard-gcloud branch, and JSON documentation using gcloud-jsondoc in the gcloud-jsondoc branch.