### PR TITLE
Update .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,8 +26,14 @@ Style/EmptyLines:
 Style/EmptyElse:
   Enabled: false
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
 Metrics/MethodLength:
   Max: 15
 Metrics/ParameterLists:
+  Enabled: false
+Style/RescueModifier:
+  Enabled: false
+Style/ClassVars:
+  Enabled: false
+Style/TrivialAccessors:
   Enabled: false

--- a/lib/gcloud/credentials.rb
+++ b/lib/gcloud/credentials.rb
@@ -58,9 +58,6 @@ module Gcloud
       @client.fetch_access_token!
     end
 
-    # rubocop:disable all
-    # Disabled rubocop because this is intentionally complex.
-
     ##
     # Returns the default credentials.
     #
@@ -86,8 +83,6 @@ module Gcloud
       client = Google::Auth.get_application_default scope
       new client
     end
-
-    # rubocop:enable all
 
     protected
 

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -118,9 +118,7 @@ module Gcloud
         @fields[name]
       end
 
-      # rubocop:disable Style/TrivialAccessors
-      # Disable rubocop because we want .fields to be listed with the other
-      # methods on the class.
+      # Trivial accessor because we want .fields to be listed with methods.
 
       ##
       # The fields in the document. Each field has a name (String) and a list of
@@ -128,8 +126,6 @@ module Gcloud
       def fields
         @fields
       end
-
-      # rubocop:enable Style/TrivialAccessors
 
       ##
       # Add a new value. If the field name does not exist it will be added. If

--- a/lib/gcloud/search/result.rb
+++ b/lib/gcloud/search/result.rb
@@ -72,9 +72,7 @@ module Gcloud
         @fields[name]
       end
 
-      # rubocop:disable Style/TrivialAccessors
-      # Disable rubocop because we want .fields to be listed with the other
-      # methods on the class.
+      # Trivial accessor because we want .fields to be listed with methods.
 
       ##
       # The fields in the search result. Each field has a name (String) and a
@@ -82,8 +80,6 @@ module Gcloud
       def fields
         @fields
       end
-
-      # rubocop:enable Style/TrivialAccessors
 
       ##
       # Calls block once for each field, passing the field name and values pair

--- a/lib/gcloud/upload.rb
+++ b/lib/gcloud/upload.rb
@@ -40,10 +40,7 @@ module Gcloud
     ##
     # Sets a new resumable threshold value.
     def self.resumable_threshold= new_resumable_threshold
-      # rubocop:disable Style/ClassVars
-      # Disabled rubocop because this is the best option.
       @@resumable_threshold = new_resumable_threshold.to_i
-      # rubocop:enable Style/ClassVars
     end
 
     # Set the default threshold to 5 MiB.


### PR DESCRIPTION
This PR contains the only low-hanging fruit I could find for #408. I believe these changes to rubocop's configuration make a lot of sense: The disabled style checks are unlikely to ever catch accidental bad style; they just catch constructs that we deliberately and thoughtfully choose to use as a last resort. 

Disable three style cops and increase Abc by 5. Remove disable comments.

[closes #408]