### PR TITLE
Cap rubocop at last version (0.35)

### DIFF
--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      "minitest-rg", "~> 5.2"
   gem.add_development_dependency      "autotest-suffix", "~> 1.1"
   gem.add_development_dependency      "rdoc", "~> 4.0"
-  gem.add_development_dependency      "rubocop", "~> 0.27"
+  gem.add_development_dependency      "rubocop", "<= 0.35.1"
   gem.add_development_dependency      "httpclient", "~> 2.5"
   gem.add_development_dependency      "simplecov", "~> 0.9"
   gem.add_development_dependency      "coveralls", "~> 0.7"


### PR DESCRIPTION
Capping rubocop at last release (0.35) due to trouble with
0.36 release and older Ruby versions.