### PR TITLE
Add Logging Entries

### DIFF
--- a/lib/gcloud/logging/entry.rb
+++ b/lib/gcloud/logging/entry.rb
@@ -1,0 +1,232 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud/logging/resource"
+require "gcloud/logging/entry/http_request"
+require "gcloud/logging/entry/operation"
+require "gcloud/logging/entry/list"
+
+module Gcloud
+  module Logging
+    ##
+    # # Entry
+    #
+    # An individual entry in a log.
+    #
+    # @example
+    #   require "gcloud"
+    #
+    #   gcloud = Gcloud.new
+    #   logging = gcloud.logging
+    #   entry = logging.entries.first
+    #
+    class Entry
+      ##
+      # Create an empty Entry object.
+      def initialize
+        @labels = {}
+        @resource = Resource.new
+        @http_request = HttpRequest.new
+        @operation = Operation.new
+      end
+
+      ##
+      # The resource name of the log to which this log entry belongs. The format
+      # of the name is `projects/<project-id>/logs/<log-id>`. e.g.
+      # `projects/my-projectid/logs/syslog` and
+      # `projects/1234567890/logs/library.googleapis.com%2Fbook_log`
+      #
+      # The log ID part of resource name must be less than 512 characters long
+      # and can only include the following characters: upper and lower case
+      # alphanumeric characters: `[A-Za-z0-9]`; and punctuation characters:
+      # forward-slash (`/`), underscore (`_`), hyphen (`-`), and period (`.`).
+      # Forward-slash (`/`) characters in the log ID must be URL-encoded.
+      attr_accessor :log_name
+
+      ##
+      # The monitored resource associated with this log entry. Example: a log
+      # entry that reports a database error would be associated with the
+      # monitored resource designating the particular database that reported the
+      # error.
+      attr_reader :resource
+
+      ##
+      # The time the event described by the log entry occurred. If omitted,
+      # Cloud Logging will use the time the log entry is written.
+      attr_accessor :timestamp
+
+      ##
+      # The severity of the log entry. The default value is `DEFAULT`.
+      attr_accessor :severity
+
+      ##
+      # Helper method to determine if the severity is `DEFAULT`
+      def default?
+        severity == "DEFAULT"
+      end
+
+      ##
+      # Helper method to determine if the severity is `DEBUG`
+      def debug?
+        severity == "DEBUG"
+      end
+
+      ##
+      # Helper method to determine if the severity is `INFO`
+      def info?
+        severity == "INFO"
+      end
+
+      ##
+      # Helper method to determine if the severity is `NOTICE`
+      def notice?
+        severity == "NOTICE"
+      end
+
+      ##
+      # Helper method to determine if the severity is `WARNING`
+      def warning?
+        severity == "WARNING"
+      end
+
+      ##
+      # Helper method to determine if the severity is `ERROR`
+      def error?
+        severity == "ERROR"
+      end
+
+      ##
+      # Helper method to determine if the severity is `CRITICAL`
+      def critical?
+        severity == "CRITICAL"
+      end
+
+      ##
+      # Helper method to determine if the severity is `ALERT`
+      def alert?
+        severity == "ALERT"
+      end
+
+      ##
+      # Helper method to determine if the severity is `EMERGENCY`
+      def emergency?
+        severity == "EMERGENCY"
+      end
+
+      ##
+      # A unique ID for the log entry. If you provide this field, the logging
+      # service considers other log entries in the same log with the same ID as
+      # duplicates which can be removed. If omitted, Cloud Logging will generate
+      # a unique ID for this log entry.
+      attr_accessor :insert_id
+
+      ##
+      # A set of user-defined data that provides additional information about
+      # the log entry.
+      attr_accessor :labels
+
+      ##
+      # The log entry payload, represented as either a string, a hash (JSON), or
+      # a hash (protocol buffer).
+      attr_accessor :payload
+
+      ##
+      # Information about the HTTP request associated with this log entry, if
+      # applicable.
+      attr_reader :http_request
+
+      ##
+      # Information about an operation associated with the log entry, if
+      # applicable.
+      attr_reader :operation
+
+      ##
+      # @private Exports the Entry to a Google API Client object.
+      def to_gapi
+        ret = {
+          "logName" => log_name,
+          "timestamp" => formatted_timestamp,
+          "severity" => severity,
+          "insertId" => insert_id,
+          "labels" => labels
+        }.delete_if { |_, v| v.nil? }
+        ret.merge! payload_gapi
+        ret.merge!({ "resource" => resource.to_gapi,
+                     "httpRequest" => http_request.to_gapi,
+                     "operation" => operation.to_gapi
+                   }.delete_if { |_, v| v.empty? })
+      end
+
+      ##
+      # @private Formats the timestamp for the API.
+      def formatted_timestamp
+        return timestamp.utc.strftime("%FT%TZ") if timestamp.respond_to? :utc
+        timestamp
+      end
+
+      ##
+      # @private Formats the payload for the API.
+      def payload_gapi
+        if payload.respond_to? :to_proto
+          { "protoPayload" => payload.to_proto }
+        elsif payload.respond_to? :to_hash
+          { "jsonPayload" => payload.to_hash }
+        else
+          { "textPayload" => payload.to_s }
+        end
+      end
+
+      ##
+      # @private Determines if the Entry has any data.
+      def empty?
+        to_gapi.empty?
+      end
+
+      ##
+      # @private New Entry from a Google API Client object.
+      def self.from_gapi gapi
+        gapi ||= {}
+        entry = new.tap do |e|
+          e.log_name = gapi["logName"]
+          e.timestamp = Time.parse(gapi["timestamp"]) if gapi["timestamp"]
+          e.severity = gapi["severity"]
+          e.insert_id = gapi["insertId"]
+          e.labels = hashify(gapi["labels"])
+          e.payload = extract_payload(gapi)
+        end
+        entry.instance_eval do
+          @resource = Resource.from_gapi gapi["resource"]
+          @http_request = HttpRequest.from_gapi gapi["httpRequest"]
+          @operation = Operation.from_gapi gapi["operation"]
+        end
+        entry
+      end
+
+      ##
+      # @private Convert to a hash, used for labels.
+      def self.hashify h
+        h = h.to_hash if h.respond_to? :to_hash
+        h = h.to_h    if h.respond_to? :to_h
+        h
+      end
+
+      ##
+      # @private Extract payload data from Google API Client object.
+      def self.extract_payload gapi
+        gapi["protoPayload"] || gapi["jsonPayload"] || gapi["textPayload"]
+      end
+    end
+  end
+end

--- a/lib/gcloud/logging/entry/http_request.rb
+++ b/lib/gcloud/logging/entry/http_request.rb
@@ -1,0 +1,127 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud/logging/resource/list"
+
+module Gcloud
+  module Logging
+    class Entry
+      ##
+      # # Http Request
+      #
+      # HTTP request data associated with a log entry.
+      #
+      class HttpRequest
+        ##
+        # @private Create an empty HttpRequest object.
+        def initialize
+        end
+
+        ##
+        # The request method. Examples: "GET", "HEAD", "PUT", "POST".
+        attr_accessor :method
+
+        ##
+        # The scheme (http, https), the host name, the path and the query
+        # portion of the URL that was requested. Example:
+        # "http://example.com/some/info?color=red".
+        attr_accessor :url
+
+        ##
+        # The size of the HTTP request message in bytes, including the request
+        # headers and the request body.
+        attr_accessor :size
+
+        ##
+        # The response code indicating the status of response. Examples: 200,
+        # 404.
+        attr_accessor :status
+
+        ##
+        # The size of the HTTP response message sent back to the client, in
+        # bytes, including the response headers and the response body.
+        attr_accessor :response_size
+
+        ##
+        # The user agent sent by the client. Example: "Mozilla/4.0 (compatible;
+        # MSIE 6.0; Windows 98; Q312461; .NET CLR 1.0.3705)".
+        attr_accessor :user_agent
+
+        ##
+        # The IP address (IPv4 or IPv6) of the client that issued the HTTP
+        # request. Examples: "192.168.1.1", "FE80::0202:B3FF:FE1E:8329".
+        attr_accessor :remote_ip
+
+        ##
+        # The referer URL of the request, as defined in [HTTP/1.1 Header Field
+        # Definitions](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
+        attr_accessor :referer
+
+        ##
+        # Whether or not an entity was served from cache (with or without
+        # validation).
+        attr_accessor :cache_hit
+
+        ##
+        # Whether or not the response was validated with the origin server
+        # before being served from cache. This field is only meaningful if
+        # cache_hit is `true`.
+        attr_accessor :validated
+
+        ##
+        # @private Exports the HttpRequest to a Google API Client object.
+        def to_gapi
+          {
+            "requestMethod" => method,
+            "requestUrl" => url,
+            "requestSize" => size,
+            "status" => status,
+            "responseSize" => response_size,
+            "userAgent" => user_agent,
+            "remoteIp" => remote_ip,
+            "referer" => referer,
+            "cacheHit" => cache_hit,
+            "validatedWithOriginServer" => validated
+          }.delete_if { |_, v| v.nil? }
+        end
+
+        ##
+        # @private Determines if the HttpRequest has any data.
+        def empty?
+          to_gapi.empty?
+        end
+
+        ##
+        # @private New HttpRequest from a Google API Client object.
+        def self.from_gapi gapi
+          gapi ||= {}
+          gapi = gapi.to_hash if gapi.respond_to? :to_hash
+          new.tap do |h|
+            h.method        = gapi["requestMethod"]
+            h.url           = gapi["requestUrl"]
+            h.size          = gapi["requestSize"]
+            h.status        = gapi["status"]
+            h.response_size = gapi["responseSize"]
+            h.user_agent    = gapi["userAgent"]
+            h.remote_ip     = gapi["remoteIp"]
+            h.referer       = gapi["referer"]
+            h.cache_hit     = gapi["cacheHit"]
+            h.validated     = gapi["validatedWithOriginServer"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/logging/entry/list.rb
+++ b/lib/gcloud/logging/entry/list.rb
@@ -1,0 +1,77 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "delegate"
+
+module Gcloud
+  module Logging
+    class Entry
+      ##
+      # Entry::List is a special case Array with additional values.
+      class List < DelegateClass(::Array)
+        ##
+        # If not empty, indicates that there are more records that match
+        # the request and this value should be passed to continue.
+        attr_accessor :token
+
+        ##
+        # Create a new Entry::List with an array of Entry instances.
+        def initialize arr = []
+          super arr
+        end
+
+        ##
+        # Whether there a next page of entries.
+        def next?
+          !token.nil?
+        end
+
+        ##
+        # Retrieve the next page of entries.
+        def next
+          return nil unless next?
+          ensure_connection!
+          resp = @connection.list_entries token: token
+          if resp.success?
+            self.class.from_response resp, @connection
+          else
+            fail ApiError.from_response(resp)
+          end
+        end
+
+        ##
+        # @private New Entry::List from a response object.
+        def self.from_response resp, conn
+          entries = new(Array(resp.data["entries"]).map do |gapi_object|
+            Entry.from_gapi gapi_object
+          end)
+          entries.instance_eval do
+            @token = resp.data["nextPageToken"]
+            @connection = conn
+          end
+          entries
+        end
+
+        protected
+
+        ##
+        # Raise an error unless an active connection is available.
+        def ensure_connection!
+          fail "Must have active connection" unless @connection
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/logging/entry/operation.rb
+++ b/lib/gcloud/logging/entry/operation.rb
@@ -1,0 +1,85 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud/logging/resource/list"
+
+module Gcloud
+  module Logging
+    class Entry
+      ##
+      # # Operation
+      #
+      # Additional information about a potentially long-running operation with
+      # which a log entry is associated.
+      #
+      class Operation
+        ##
+        # @private Create an empty Operation object.
+        def initialize
+        end
+
+        ##
+        # An arbitrary operation identifier. Log entries with the same
+        # identifier are assumed to be part of the same operation.
+        attr_accessor :id
+
+        ##
+        # An arbitrary producer identifier. The combination of id and producer
+        # must be globally unique. Examples for producer:
+        # `"MyDivision.MyBigCompany.com"`,
+        # `"github.com/MyProject/MyApplication"`.
+        attr_accessor :producer
+
+        ##
+        # Set this to `true` if this is the first log entry in the operation.
+        attr_accessor :first
+
+        ##
+        # Set this to `true` if this is the last log entry in the operation.
+        attr_accessor :last
+
+        ##
+        # @private Exports the Operation to a Google API Client object.
+        def to_gapi
+          {
+            "id" => id,
+            "producer" => producer,
+            "first" => first,
+            "last" => last
+          }.delete_if { |_, v| v.nil? }
+        end
+
+        ##
+        # @private Determines if the Operation has any data.
+        def empty?
+          to_gapi.empty?
+        end
+
+        ##
+        # @private New Operation from a Google API Client object.
+        def self.from_gapi gapi
+          gapi ||= {}
+          gapi = gapi.to_hash if gapi.respond_to? :to_hash
+          new.tap do |o|
+            o.id       = gapi["id"]
+            o.producer = gapi["producer"]
+            o.first    = gapi["first"]
+            o.last     = gapi["last"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/logging/metric.rb
+++ b/lib/gcloud/logging/metric.rb
@@ -40,7 +40,7 @@ module Gcloud
       attr_accessor :gapi
 
       ##
-      # @private Create an empty File object.
+      # @private Create an empty Metric object.
       def initialize
         @connection = nil
         @gapi = {}

--- a/lib/gcloud/logging/resource.rb
+++ b/lib/gcloud/logging/resource.rb
@@ -31,49 +31,59 @@ module Gcloud
     #
     class Resource
       ##
-      # @private The Google API Client object.
-      attr_accessor :gapi
-
-      ##
-      # @private Create an empty File object.
+      # Create an empty Resource object.
       def initialize
-        @connection = nil
-        @gapi = {}
+        @labels = []
       end
 
       ##
       # The monitored resource type.
-      def type
-        @gapi["type"]
-      end
+      attr_accessor :type
 
       ##
       # A concise name for the monitored resource type, which is displayed in
       # user interfaces.
-      def name
-        @gapi["displayName"]
-      end
+      attr_accessor :name
 
       ##
       # A detailed description of the monitored resource type, which is used in
       # documentation.
-      def description
-        @gapi["description"]
-      end
+      attr_accessor :description
 
       ##
       # A set of labels that can be used to describe instances of this monitored
       # resource type.
-      def labels
-        # TODO: Make a proper Label class to represent this structure...
-        Array @gapi["labels"]
+      attr_accessor :labels
+
+      ##
+      # @private Exports the Resource to a Google API Client object.
+      def to_gapi
+        ret = {
+          "type" => type,
+          "displayName" => name,
+          "description" => description,
+          "labels" => labels
+        }.delete_if { |_, v| v.nil? }
+        ret.delete "labels" if labels.empty?
+        ret
+      end
+
+      ##
+      # @private Determines if the Resource has any data.
+      def empty?
+        to_gapi.empty?
       end
 
       ##
       # @private New Resource from a Google API Client object.
       def self.from_gapi gapi
-        new.tap do |f|
-          f.gapi = gapi
+        gapi ||= {}
+        gapi = gapi.to_hash if gapi.respond_to? :to_hash
+        new.tap do |r|
+          r.type        = gapi["type"]
+          r.name        = gapi["displayName"]
+          r.description = gapi["description"]
+          r.labels      = Array(gapi["labels"])
         end
       end
     end

--- a/lib/gcloud/logging/sink.rb
+++ b/lib/gcloud/logging/sink.rb
@@ -44,7 +44,7 @@ module Gcloud
       attr_accessor :gapi
 
       ##
-      # @private Create an empty File object.
+      # @private Create an empty Sink object.
       def initialize
         @connection = nil
         @gapi = {}

--- a/test/gcloud/logging/entry/http_request_test.rb
+++ b/test/gcloud/logging/entry/http_request_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Entry::HttpRequest, :mock_logging do
+  let(:http_request) { Gcloud::Logging::Entry::HttpRequest.from_gapi random_http_request_hash }
+
+  it "has attributes" do
+    http_request.method.must_equal "GET"
+    http_request.url.must_equal "http://test.local/foo?bar=baz"
+    http_request.size.must_equal "123"
+    http_request.status.must_equal 200
+    http_request.response_size.must_equal "456"
+    http_request.user_agent.must_equal "gcloud-ruby/1.0.0"
+    http_request.remote_ip.must_equal "127.0.0.1"
+    http_request.referer.must_equal "http://test.local/referer"
+    http_request.cache_hit.must_equal false
+    http_request.validated.must_equal false
+  end
+end

--- a/test/gcloud/logging/entry/operation_test.rb
+++ b/test/gcloud/logging/entry/operation_test.rb
@@ -1,0 +1,26 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Entry::Operation, :mock_logging do
+  let(:operation) { Gcloud::Logging::Entry::Operation.from_gapi random_operation_hash }
+
+  it "has attributes" do
+    operation.id.must_equal "xyz789"
+    operation.producer.must_equal "MyApp.MyClass#my_method"
+    operation.first.must_equal false
+    operation.last.must_equal false
+  end
+end

--- a/test/gcloud/logging/entry/severity_test.rb
+++ b/test/gcloud/logging/entry/severity_test.rb
@@ -1,0 +1,136 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Entry, :severity, :mock_logging do
+  let(:entry) { Gcloud::Logging::Entry.from_gapi random_entry_hash }
+
+  it "has the correct helpers for DEFAULT" do
+    entry.severity = "DEFAULT"
+    entry.must_be :default?
+    entry.wont_be :debug?
+    entry.wont_be :info?
+    entry.wont_be :notice?
+    entry.wont_be :warning?
+    entry.wont_be :error?
+    entry.wont_be :critical?
+    entry.wont_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for DEBUG" do
+    entry.severity = "DEBUG"
+    entry.wont_be :default?
+    entry.must_be :debug?
+    entry.wont_be :info?
+    entry.wont_be :notice?
+    entry.wont_be :warning?
+    entry.wont_be :error?
+    entry.wont_be :critical?
+    entry.wont_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for INFO" do
+    entry.severity = "INFO"
+    entry.wont_be :default?
+    entry.wont_be :debug?
+    entry.must_be :info?
+    entry.wont_be :notice?
+    entry.wont_be :warning?
+    entry.wont_be :error?
+    entry.wont_be :critical?
+    entry.wont_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for NOTICE" do
+    entry.severity = "NOTICE"
+    entry.wont_be :default?
+    entry.wont_be :debug?
+    entry.wont_be :info?
+    entry.must_be :notice?
+    entry.wont_be :warning?
+    entry.wont_be :error?
+    entry.wont_be :critical?
+    entry.wont_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for WARNING" do
+    entry.severity = "WARNING"
+    entry.wont_be :default?
+    entry.wont_be :debug?
+    entry.wont_be :info?
+    entry.wont_be :notice?
+    entry.must_be :warning?
+    entry.wont_be :error?
+    entry.wont_be :critical?
+    entry.wont_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for ERROR" do
+    entry.severity = "ERROR"
+    entry.wont_be :default?
+    entry.wont_be :debug?
+    entry.wont_be :info?
+    entry.wont_be :notice?
+    entry.wont_be :warning?
+    entry.must_be :error?
+    entry.wont_be :critical?
+    entry.wont_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for CRITICAL" do
+    entry.severity = "CRITICAL"
+    entry.wont_be :default?
+    entry.wont_be :debug?
+    entry.wont_be :info?
+    entry.wont_be :notice?
+    entry.wont_be :warning?
+    entry.wont_be :error?
+    entry.must_be :critical?
+    entry.wont_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for ALERT" do
+    entry.severity = "ALERT"
+    entry.wont_be :default?
+    entry.wont_be :debug?
+    entry.wont_be :info?
+    entry.wont_be :notice?
+    entry.wont_be :warning?
+    entry.wont_be :error?
+    entry.wont_be :critical?
+    entry.must_be :alert?
+    entry.wont_be :emergency?
+  end
+
+  it "has the correct helpers for EMERGENCY" do
+    entry.severity = "EMERGENCY"
+    entry.wont_be :default?
+    entry.wont_be :debug?
+    entry.wont_be :info?
+    entry.wont_be :notice?
+    entry.wont_be :warning?
+    entry.wont_be :error?
+    entry.wont_be :critical?
+    entry.wont_be :alert?
+    entry.must_be :emergency?
+  end
+end

--- a/test/gcloud/logging/entry/to_gapi_test.rb
+++ b/test/gcloud/logging/entry/to_gapi_test.rb
@@ -1,0 +1,88 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Entry, :to_gapi, :mock_logging do
+  let(:entry) { Gcloud::Logging::Entry.new }
+
+  it "returns the correct data" do
+    entry.log_name = "projects/test/logs/testlog"
+
+    entry.resource.type =        "webapp_server"
+    entry.resource.name =        "Web Application Server"
+    entry.resource.description = "This service runs the web app"
+    entry.resource.labels =      [{ "env"         => "test",
+                                    "valueType"   => "STRING",
+                                    "description" => "The server is running in test" }]
+
+    entry.severity = "ERROR"
+    entry.timestamp = Time.parse("2016-01-02T03:04:05Z")
+    entry.insert_id = "insert123"
+    entry.labels = { env: :test }
+    entry.labels["fizz"] = "buzz"
+    entry.payload = "payload"
+
+    entry.http_request.method = "POST"
+    entry.http_request.url = "http://test.local/fizz?buzz"
+    entry.http_request.size = "456"
+    entry.http_request.status = 201
+    entry.http_request.response_size = "345"
+    entry.http_request.user_agent = "gcloud-ruby/1.0.0"
+    entry.http_request.remote_ip = "127.0.0.1"
+    entry.http_request.referer = "http://test.local/referer"
+    entry.http_request.cache_hit = true
+    entry.http_request.validated = false
+
+    entry.operation.id = "abc123"
+    entry.operation.producer = "NewApp.NewClass#new_method"
+    entry.operation.first = true
+    entry.operation.last = false
+
+    gapi = entry.to_gapi
+
+    gapi["logName"].must_equal "projects/test/logs/testlog"
+
+    gapi["resource"]["type"].must_equal        "webapp_server"
+    gapi["resource"]["displayName"].must_equal "Web Application Server"
+    gapi["resource"]["description"].must_equal "This service runs the web app"
+    gapi["resource"]["labels"].must_equal      [{ "env"         => "test",
+                                                  "valueType"   => "STRING",
+                                                  "description" => "The server is running in test" }]
+
+    gapi["severity"].must_equal "ERROR"
+    gapi["timestamp"].must_equal "2016-01-02T03:04:05Z"
+    gapi["insertId"].must_equal "insert123"
+    gapi["labels"].must_equal(env: :test, "fizz" => "buzz")
+    gapi["textPayload"].must_equal "payload"
+    gapi["jsonPayload"].must_be :nil?
+    gapi["protoPayload"].must_be :nil?
+
+    gapi["httpRequest"]["requestMethod"].must_equal "POST"
+    gapi["httpRequest"]["requestUrl"].must_equal "http://test.local/fizz?buzz"
+    gapi["httpRequest"]["requestSize"].must_equal "456"
+    gapi["httpRequest"]["status"].must_equal 201
+    gapi["httpRequest"]["responseSize"].must_equal "345"
+    gapi["httpRequest"]["userAgent"].must_equal "gcloud-ruby/1.0.0"
+    gapi["httpRequest"]["remoteIp"].must_equal "127.0.0.1"
+    gapi["httpRequest"]["referer"].must_equal "http://test.local/referer"
+    gapi["httpRequest"]["cacheHit"].must_equal true
+    gapi["httpRequest"]["validatedWithOriginServer"].must_equal false
+
+    gapi["operation"]["id"].must_equal "abc123"
+    gapi["operation"]["producer"].must_equal "NewApp.NewClass#new_method"
+    gapi["operation"]["first"].must_equal true
+    gapi["operation"]["last"].must_equal false
+  end
+end

--- a/test/gcloud/logging/entry_test.rb
+++ b/test/gcloud/logging/entry_test.rb
@@ -1,0 +1,136 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Entry, :mock_logging do
+  let(:entry) { Gcloud::Logging::Entry.from_gapi entry_hash }
+  let(:entry_hash) { random_entry_hash }
+
+  it "knows its attributes" do
+    entry.log_name.must_equal             entry_hash["logName"]
+    entry.resource.must_be_kind_of        Gcloud::Logging::Resource
+    entry.timestamp.must_equal            Time.parse(entry_hash["timestamp"])
+    entry.severity.must_equal             entry_hash["severity"]
+    entry.insert_id.must_equal            entry_hash["insertId"]
+    entry.labels.must_be_kind_of          Hash
+    entry.labels["env"].must_equal        "production"
+    entry.labels["foo"].must_equal        "bar"
+    entry.payload.must_equal              "payload"
+    entry.http_request.must_be_kind_of    Gcloud::Logging::Entry::HttpRequest
+    entry.operation.must_be_kind_of       Gcloud::Logging::Entry::Operation
+  end
+
+  it "timestamp gives the correct time when a timestamp is present" do
+    custom_timestamp = "2016-01-02T03:04:05.06Z"
+    entry = Gcloud::Logging::Entry.from_gapi "timestamp" => custom_timestamp
+    entry.timestamp.wont_be :nil?
+    entry.timestamp.must_equal Time.parse(custom_timestamp)
+  end
+
+  it "timestamp gives nil when no timestamp is present" do
+    entry.timestamp = nil
+    entry.timestamp.must_be :nil?
+  end
+
+  it "labels will return a Hash even when missing from the Google API object" do
+    entry = Gcloud::Logging::Entry.from_gapi "labels" => nil
+    entry.labels.must_be_kind_of Hash
+  end
+
+  it "can have a JSON payload" do
+    entry.payload = { "pay" => "load" }
+    entry.payload.must_be_kind_of Hash
+    entry.payload["pay"].must_equal "load"
+  end
+
+  it "can have a ProtoBuf payload" do
+    proto = OpenStruct.new to_proto: { "id" => 1234, "@type" => "types.example.com/standard/id" }
+    entry.payload = proto
+    gapi = entry.to_gapi
+    gapi["protoPayload"].must_be_kind_of Hash
+    gapi["protoPayload"]["id"].must_equal 1234
+    gapi["protoPayload"]["@type"].must_equal "types.example.com/standard/id"
+  end
+
+  it "has the correct resource attributes" do
+    entry.resource.type.must_equal        entry_hash["resource"]["type"]
+    entry.resource.name.must_equal        entry_hash["resource"]["displayName"]
+    entry.resource.description.must_equal entry_hash["resource"]["description"]
+    entry.resource.labels.must_equal      entry_hash["resource"]["labels"]
+  end
+
+  it "has a resource even if the Google API object doesn't have it" do
+    custom_entry_hash = random_entry_hash
+    custom_entry_hash.delete "resource"
+    custom_entry = Gcloud::Logging::Entry.from_gapi custom_entry_hash
+
+    custom_entry.resource.must_be_kind_of Gcloud::Logging::Resource
+    custom_entry.resource.type.must_be :nil?
+    custom_entry.resource.name.must_be :nil?
+    custom_entry.resource.description.must_be :nil?
+    custom_entry.resource.labels.must_be_kind_of Array
+    custom_entry.resource.labels.must_be :empty?
+  end
+
+  it "has the correct http_request attributes" do
+    entry.http_request.method.must_equal "GET"
+    entry.http_request.url.must_equal "http://test.local/foo?bar=baz"
+    entry.http_request.size.must_equal "123"
+    entry.http_request.status.must_equal 200
+    entry.http_request.response_size.must_equal "456"
+    entry.http_request.user_agent.must_equal "gcloud-ruby/1.0.0"
+    entry.http_request.remote_ip.must_equal "127.0.0.1"
+    entry.http_request.referer.must_equal "http://test.local/referer"
+    entry.http_request.cache_hit.must_equal false
+    entry.http_request.validated.must_equal false
+  end
+
+  it "has an http_request even if the Google API object doesn't have it" do
+    custom_entry_hash = random_entry_hash
+    custom_entry_hash.delete "httpRequest"
+    custom_entry = Gcloud::Logging::Entry.from_gapi custom_entry_hash
+
+    custom_entry.http_request.must_be_kind_of Gcloud::Logging::Entry::HttpRequest
+    custom_entry.http_request.method.must_be :nil?
+    custom_entry.http_request.url.must_be :nil?
+    custom_entry.http_request.size.must_be :nil?
+    custom_entry.http_request.status.must_be :nil?
+    custom_entry.http_request.response_size.must_be :nil?
+    custom_entry.http_request.user_agent.must_be :nil?
+    custom_entry.http_request.remote_ip.must_be :nil?
+    custom_entry.http_request.referer.must_be :nil?
+    custom_entry.http_request.cache_hit.must_be :nil?
+    custom_entry.http_request.validated.must_be :nil?
+  end
+
+  it "has the correct operation attributes" do
+    entry.operation.id.must_equal "xyz789"
+    entry.operation.producer.must_equal "MyApp.MyClass#my_method"
+    entry.operation.first.must_equal false
+    entry.operation.last.must_equal false
+  end
+
+  it "has an operation even if the Google API object doesn't have it" do
+    custom_entry_hash = random_entry_hash
+    custom_entry_hash.delete "operation"
+    custom_entry = Gcloud::Logging::Entry.from_gapi custom_entry_hash
+
+    custom_entry.operation.must_be_kind_of Gcloud::Logging::Entry::Operation
+    custom_entry.operation.id.must_be :nil?
+    custom_entry.operation.producer.must_be :nil?
+    custom_entry.operation.first.must_be :nil?
+    custom_entry.operation.last.must_be :nil?
+  end
+end

--- a/test/gcloud/logging/project/list_entries_test.rb
+++ b/test/gcloud/logging/project/list_entries_test.rb
@@ -1,0 +1,261 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Project, :list_entries, :mock_logging do
+  it "lists entries" do
+    num_entries = 3
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(num_entries)]
+    end
+
+    entries = logging.entries
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.size.must_equal num_entries
+  end
+
+  it "lists entries with find_entries alias" do
+    num_entries = 3
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(num_entries)]
+    end
+
+    entries = logging.find_entries
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.size.must_equal num_entries
+  end
+
+  it "paginates entries" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_equal "next_page_token"
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(2)]
+    end
+
+    first_entries = logging.entries
+    first_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    first_entries.count.must_equal 3
+    first_entries.token.wont_be :nil?
+    first_entries.token.must_equal "next_page_token"
+
+    second_entries = logging.entries token: first_entries.token
+    second_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    second_entries.count.must_equal 2
+    second_entries.token.must_be :nil?
+  end
+
+  it "paginates entries with next? and next" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_equal "next_page_token"
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(2)]
+    end
+
+    first_entries = logging.entries
+    first_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    first_entries.count.must_equal 3
+    first_entries.next?.must_equal true #must_be :next?
+
+    second_entries = first_entries.next
+    second_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    second_entries.count.must_equal 2
+    second_entries.next?.must_equal false #wont_be :next?
+  end
+
+  it "paginates entries with one project" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal ["project1"]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+
+    entries = logging.entries projects: "project1"
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  it "paginates entries with multiple projects" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal ["project1", "project2", "project3"]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+
+    entries = logging.entries projects: ["project1", "project2", "project3"]
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  it "paginates entries with a filter" do
+    adv_logs_filter = 'resource.type:"gce_"'
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_equal adv_logs_filter
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+
+    entries = logging.entries filter: adv_logs_filter
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  it "paginates entries with order asc" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_equal "timestamp"
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+
+    entries = logging.entries order: "timestamp"
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  it "paginates entries with order desc" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_equal "timestamp desc"
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+
+    entries = logging.entries order: "timestamp desc"
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  it "paginates entries with max set" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_equal 3
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+
+    entries = logging.entries max: 3
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  it "paginates entries without max set" do
+    mock_connection.post "/v2beta1/entries:list" do |env|
+      list_json = JSON.parse env.body
+      list_json["projectIds"].must_equal [project]
+      list_json["filter"].must_be :nil?
+      list_json["orderBy"].must_be :nil?
+      list_json["pageToken"].must_be :nil?
+      list_json["maxResults"].must_be :nil?
+      [200, {"Content-Type"=>"application/json"},
+       list_entries_json(3, "next_page_token")]
+    end
+
+    entries = logging.entries
+    entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    entries.count.must_equal 3
+    entries.token.wont_be :nil?
+    entries.token.must_equal "next_page_token"
+  end
+
+  def list_entries_json count = 2, token = nil
+    {
+      entries: count.times.map { random_entry_hash },
+      nextPageToken: token
+    }.delete_if { |_, v| v.nil? }.to_json
+  end
+end

--- a/test/gcloud/logging/project/write_entries_test.rb
+++ b/test/gcloud/logging/project/write_entries_test.rb
@@ -1,0 +1,108 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Project, :write_entries, :mock_logging do
+  it "writes a single entry" do
+    entry = logging.entry.tap do |e|
+      e.log_name = "testlog"
+    end
+
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_be :nil?
+      entries_json["resource"].must_be :nil?
+      entries_json["labels"].must_be :nil?
+      entries_json["entries"].must_equal [entry.to_gapi]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logging.write_entries entry
+  end
+
+  it "writes multiple entries" do
+    entry1 = logging.entry.tap do |e|
+      e.log_name = "testlog"
+    end
+    entry2 = logging.entry.tap do |e|
+      e.log_name = "otherlog"
+    end
+
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_be :nil?
+      entries_json["resource"].must_be :nil?
+      entries_json["labels"].must_be :nil?
+      entries_json["entries"].must_equal [entry1.to_gapi, entry2.to_gapi]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logging.write_entries [entry1, entry2]
+  end
+
+  it "writes entries with log_name" do
+    entry = logging.entry.tap do |e|
+      e.timestamp = Time.now
+    end
+
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/test/logs/testlog"
+      entries_json["resource"].must_be :nil?
+      entries_json["labels"].must_be :nil?
+      entries_json["entries"].must_equal [entry.to_gapi]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logging.write_entries entry, log_name: "testlog"
+  end
+
+  it "writes entries with resource" do
+    entry = logging.entry.tap do |e|
+      e.timestamp = Time.now
+    end
+    resource = Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "web_app_server"
+    end
+
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_be :nil?
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_be :nil?
+      entries_json["entries"].must_equal [entry.to_gapi]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logging.write_entries entry, resource: resource
+  end
+
+  it "writes entries with labels" do
+    entry = logging.entry.tap do |e|
+      e.timestamp = Time.now
+    end
+
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_be :nil?
+      entries_json["resource"].must_be :nil?
+      entries_json["labels"].must_equal("env" => "production")
+      entries_json["entries"].must_equal [entry.to_gapi]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logging.write_entries entry, labels: {env: :production}
+  end
+end

--- a/test/gcloud/logging/project_test.rb
+++ b/test/gcloud/logging/project_test.rb
@@ -20,6 +20,10 @@ describe Gcloud::Logging::Project, :mock_logging do
     logging.project.must_equal project
   end
 
+  it "creates an empty entry" do
+    logging.entry.must_be_kind_of Gcloud::Logging::Entry
+  end
+
   it "deletes a log" do
     log_name = "syslog"
 

--- a/test/gcloud/logging/resource_test.rb
+++ b/test/gcloud/logging/resource_test.rb
@@ -19,9 +19,15 @@ describe Gcloud::Logging::Resource, :mock_logging do
   let(:resource_hash) { random_resource_hash }
 
   it "knows its attributes" do
-    resource.type.must_equal        resource_hash["type"]
-    resource.name.must_equal        resource_hash["displayName"]
-    resource.description.must_equal resource_hash["description"]
-    resource.labels.must_equal      resource_hash["labels"]
+    resource.type.must_equal        "cloudsql_database"
+    resource.name.must_equal        "Cloud SQL Database"
+    resource.description.must_equal "This resource is a Cloud SQL Database"
+    resource.labels.must_equal      [{ "key"         => "prod",
+                                       "valueType"   => "STRING",
+                                       "description" => "The resources are considered in production" }]
+  end
+
+  it "can export to a gapi object" do
+    resource.to_gapi.must_equal resource_hash
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -879,6 +879,47 @@ class MockLogging < Minitest::Spec
     addl.include? :mock_logging
   end
 
+  def random_entry_hash
+    {
+      "logName"   => "projects/my-projectid/logs/syslog",
+      "resource"  => random_resource_hash,
+      "timestamp" => "2014-10-02T15:01:23.045123456Z",
+      "severity"  => "DEFAULT",
+      "insertId"  => "abc123",
+      "labels" => {
+        "env" => "production",
+        "foo" => "bar"
+      },
+      "textPayload" => "payload",
+      "httpRequest" => random_http_request_hash,
+      "operation" => random_operation_hash
+    }
+  end
+
+  def random_http_request_hash
+    {
+      "requestMethod" => "GET",
+      "requestUrl" => "http://test.local/foo?bar=baz",
+      "requestSize" => "123",
+      "status" => 200,
+      "responseSize" => "456",
+      "userAgent" => "gcloud-ruby/1.0.0",
+      "remoteIp" => "127.0.0.1",
+      "referer" => "http://test.local/referer",
+      "cacheHit" => false,
+      "validatedWithOriginServer" => false
+    }
+  end
+
+  def random_operation_hash
+    {
+      "id" => "xyz789",
+      "producer" => "MyApp.MyClass#my_method",
+      "first" => false,
+      "last" => false
+    }
+  end
+
   def random_resource_hash
     {
       "type"        => "cloudsql_database",


### PR DESCRIPTION
Add listing and writing entries.

Entry, Resource, HttpRequest, and Operation are implemented as simple classes, with only attributes being on the public API. They hold no connection to the logging service. Entry has a large surface area, and there are little affordances in the API to make populating it any easier. This will be addressed in future pull requests.

[closes #492, #493, #498, #499, #500, #501, #502]