### PR TITLE
Yard gcloud

### DIFF
--- a/templates/gcloud/class/html/index.erb
+++ b/templates/gcloud/class/html/index.erb
@@ -143,7 +143,7 @@
 
                     <%= htmlify method.docstring %>
 
-                    <% if method.has_tag?(:see) %>
+                    <% if method.has_tag? :see %>
                       <p class="tag_title">See Also:</p>
                       <ul class="see">
                         <% method.tags(:see).each do |tag| %>
@@ -152,13 +152,13 @@
                       </ul>
                     <% end %>
 
-                    <% if (tags = method.tags(:param)).count > 0 %>
+                    <% if method.has_tag? :param %>
                       <h3 id="method-i-<%= method.name %>-label-Parameters">
                         Parameters
                         <span><a href="#method-i-<%= method.name %>-label-Parameters">¶</a> <a href="#top">↑</a></span>
                       </h3>
                       <dl class="rdoc-list note-list">
-                        <% tags.each do |tag| %>
+                        <% method.tags(:param).each do |tag| %>
                           <dt>
                             <code><%= h tag.name %></code>
                           </dt>
@@ -187,12 +187,12 @@
                       </p>
                     <% end %>
 
-                    <% if (tags = method.tags(:example)).count > 0 %>
+                    <% if method.has_tag? :example %>
                       <h3 id="method-i-<%= method.name %>-label-Examples">
-                        Example<%= "s" if tags.count > 1 %>
+                        Example<%= "s" if method.tags(:example).count > 1 %>
                         <span><a href="#method-i-<%= method.name %>-label-Examples">¶</a> <a href="#top">↑</a></span>
                       </h3>
-                      <% tags.each do |tag| %>
+                      <% method.tags(:example).each do |tag| %>
                         <% unless tag.name.empty? %>
                           <p class="example_title"><%= htmlify_line(tag.name) %></p>
                         <% end %>

--- a/templates/gcloud/class/html/index.erb
+++ b/templates/gcloud/class/html/index.erb
@@ -126,9 +126,9 @@
                   <%= htmlify method.docstring %>
 
                   <% if (tags = method.tags(:param)).count > 0 %>
-                    <h3 id="method-i-subscribe-label-Parameters">
+                    <h3 id="method-i-<%= method.name %>-label-Parameters">
                       Parameters
-                      <span><a href="#method-i-subscribe-label-Parameters">¶</a> <a href="#top">↑</a></span>
+                      <span><a href="#method-i-<%= method.name %>-label-Parameters">¶</a> <a href="#top">↑</a></span>
                     </h3>
                     <dl class="rdoc-list note-list">
                       <% tags.each do |tag| %>
@@ -148,9 +148,9 @@
                   <% end %>
 
                   <% if (tag = method.tag(:return)) %>
-                    <h3 id="method-i-subscription-label-Returns">
+                    <h3 id="method-i-<%= method.name %>-label-Returns">
                       Returns
-                      <span><a href="#method-i-subscription-label-Returns">¶</a> <a href="#top">↑</a></span>
+                      <span><a href="#method-i-<%= method.name %>-label-Returns">¶</a> <a href="#top">↑</a></span>
                     </h3>
                     <p>
                       <%= format_types(tag.types) %>
@@ -158,6 +158,19 @@
                         <%= htmlify_line(tag.text) %>
                       <% end %>
                     </p>
+                  <% end %>
+
+                  <% if (tags = method.tags(:example)).count > 0 %>
+                    <h3 id="method-i-<%= method.name %>-label-Examples">
+                      Example<%= "s" if tags.count > 1 %>
+                      <span><a href="#method-i-<%= method.name %>-label-Examples">¶</a> <a href="#top">↑</a></span>
+                    </h3>
+                    <% tags.each do |tag| %>
+                      <% unless tag.name.empty? %>
+                        <p class="example_title"><%= htmlify_line(tag.name) %></p>
+                      <% end %>
+                      <pre class="code"><code><%= html_syntax_highlight(tag.text, :ruby) %></code></pre>
+                    <% end %>
                   <% end %>
 
                 </div>

--- a/templates/gcloud/class/html/index.erb
+++ b/templates/gcloud/class/html/index.erb
@@ -147,6 +147,19 @@
                     </dl>
                   <% end %>
 
+                  <% if (tag = method.tag(:return)) %>
+                    <h3 id="method-i-subscription-label-Returns">
+                      Returns
+                      <span><a href="#method-i-subscription-label-Returns">¶</a> <a href="#top">↑</a></span>
+                    </h3>
+                    <p>
+                      <%= format_types(tag.types) %>
+                      <% if tag.text && !tag.text.empty? %>
+                        <%= htmlify_line(tag.text) %>
+                      <% end %>
+                    </p>
+                  <% end %>
+
                 </div>
               </div>
             <% end %>

--- a/templates/gcloud/class/html/index.erb
+++ b/templates/gcloud/class/html/index.erb
@@ -143,6 +143,15 @@
 
                     <%= htmlify method.docstring %>
 
+                    <% if method.has_tag?(:see) %>
+                      <p class="tag_title">See Also:</p>
+                      <ul class="see">
+                        <% method.tags(:see).each do |tag| %>
+                          <li><%= linkify(tag.name, tag.text) %></li>
+                        <% end %>
+                      </ul>
+                    <% end %>
+
                     <% if (tags = method.tags(:param)).count > 0 %>
                       <h3 id="method-i-<%= method.name %>-label-Parameters">
                         Parameters

--- a/templates/gcloud/class/html/index.erb
+++ b/templates/gcloud/class/html/index.erb
@@ -111,70 +111,95 @@
 
           <div class="methods">
             <% methods.each do |method| %>
-              <div class="method">
-                <a name="<%= anchor_for method %>"></a>
-                <h4>
-                  <code><%= method.name %><%= format_args(method) %></code>
-                  <span>
-                    <a href="#<%= anchor_for method %>">&para;</a>
-                    <a href="#top">&uarr;</a>
-                  </span>
-                </h4>
-
-                <div class="method-description">
-
-                  <%= htmlify method.docstring %>
-
-                  <% if (tags = method.tags(:param)).count > 0 %>
-                    <h3 id="method-i-<%= method.name %>-label-Parameters">
-                      Parameters
-                      <span><a href="#method-i-<%= method.name %>-label-Parameters">¶</a> <a href="#top">↑</a></span>
-                    </h3>
-                    <dl class="rdoc-list note-list">
-                      <% tags.each do |tag| %>
-                        <dt>
-                          <code><%= h tag.name %></code>
-                        </dt>
-                        <dd>
-                          <p>
-                            <% if tag.text && !tag.text.empty? %>
-                              <%= htmlify_line(tag.text) %>
-                            <% end %>
-                            <%= format_types(tag.types) %>
-                          </p>
-                        </dd>
-                      <% end %>
-                    </dl>
+              <% if method.is_alias? %>
+                <div class="method">
+                  <a name="<%= anchor_for method %>"></a>
+                  <h4>
+                    <code><%= method.name %><%= format_args(method) %></code>
+                    <span>
+                      <a href="#<%= anchor_for method %>">&para;</a>
+                      <a href="#top">&uarr;</a>
+                    </span>
+                  </h4>
+                  <% if my_alias_method = alias_for(method) %>
+                    <div class="aliases">
+                      Alias for:
+                      <a href="#<%= anchor_for my_alias_method %>"><%= my_alias_method.name %></a>
+                    </div>
                   <% end %>
-
-                  <% if (tag = method.tag(:return)) %>
-                    <h3 id="method-i-<%= method.name %>-label-Returns">
-                      Returns
-                      <span><a href="#method-i-<%= method.name %>-label-Returns">¶</a> <a href="#top">↑</a></span>
-                    </h3>
-                    <p>
-                      <%= format_types(tag.types) %>
-                      <% if tag.text && !tag.text.empty? %>
-                        <%= htmlify_line(tag.text) %>
-                      <% end %>
-                    </p>
-                  <% end %>
-
-                  <% if (tags = method.tags(:example)).count > 0 %>
-                    <h3 id="method-i-<%= method.name %>-label-Examples">
-                      Example<%= "s" if tags.count > 1 %>
-                      <span><a href="#method-i-<%= method.name %>-label-Examples">¶</a> <a href="#top">↑</a></span>
-                    </h3>
-                    <% tags.each do |tag| %>
-                      <% unless tag.name.empty? %>
-                        <p class="example_title"><%= htmlify_line(tag.name) %></p>
-                      <% end %>
-                      <pre class="code"><code><%= html_syntax_highlight(tag.text, :ruby) %></code></pre>
-                    <% end %>
-                  <% end %>
-
                 </div>
-              </div>
+              <% else %>
+                <div class="method">
+                  <a name="<%= anchor_for method %>"></a>
+                  <h4>
+                    <code><%= method.name %><%= format_args(method) %></code>
+                    <span>
+                      <a href="#<%= anchor_for method %>">&para;</a>
+                      <a href="#top">&uarr;</a>
+                    </span>
+                  </h4>
+
+                  <div class="method-description">
+
+                    <%= htmlify method.docstring %>
+
+                    <% if (tags = method.tags(:param)).count > 0 %>
+                      <h3 id="method-i-<%= method.name %>-label-Parameters">
+                        Parameters
+                        <span><a href="#method-i-<%= method.name %>-label-Parameters">¶</a> <a href="#top">↑</a></span>
+                      </h3>
+                      <dl class="rdoc-list note-list">
+                        <% tags.each do |tag| %>
+                          <dt>
+                            <code><%= h tag.name %></code>
+                          </dt>
+                          <dd>
+                            <p>
+                              <% if tag.text && !tag.text.empty? %>
+                                <%= htmlify_line(tag.text) %>
+                              <% end %>
+                              <%= format_types(tag.types) %>
+                            </p>
+                          </dd>
+                        <% end %>
+                      </dl>
+                    <% end %>
+
+                    <% if (tag = method.tag(:return)) %>
+                      <h3 id="method-i-<%= method.name %>-label-Returns">
+                        Returns
+                        <span><a href="#method-i-<%= method.name %>-label-Returns">¶</a> <a href="#top">↑</a></span>
+                      </h3>
+                      <p>
+                        <%= format_types(tag.types) %>
+                        <% if tag.text && !tag.text.empty? %>
+                          <%= htmlify_line(tag.text) %>
+                        <% end %>
+                      </p>
+                    <% end %>
+
+                    <% if (tags = method.tags(:example)).count > 0 %>
+                      <h3 id="method-i-<%= method.name %>-label-Examples">
+                        Example<%= "s" if tags.count > 1 %>
+                        <span><a href="#method-i-<%= method.name %>-label-Examples">¶</a> <a href="#top">↑</a></span>
+                      </h3>
+                      <% tags.each do |tag| %>
+                        <% unless tag.name.empty? %>
+                          <p class="example_title"><%= htmlify_line(tag.name) %></p>
+                        <% end %>
+                        <pre class="code"><code><%= html_syntax_highlight(tag.text, :ruby) %></code></pre>
+                      <% end %>
+                    <% end %>
+
+                  </div>
+                  <% if method.aliases.size > 0 %>
+                    <div class="aliases">
+                      Also aliased as:
+                      <%= method.aliases.map {|o| "<a href='##{anchor_for(o)}'>" + h(o.name.to_s) + "</a>" }.join(", ") %>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
             <% end %>
           </div>
         <% end %>

--- a/templates/gcloud/class/html/index.erb
+++ b/templates/gcloud/class/html/index.erb
@@ -113,7 +113,6 @@
             <% methods.each do |method| %>
               <div class="method">
                 <a name="<%= anchor_for method %>"></a>
-
                 <h4>
                   <code><%= method.name %><%= format_args(method) %></code>
                   <span>
@@ -123,7 +122,31 @@
                 </h4>
 
                 <div class="method-description">
+
                   <%= htmlify method.docstring %>
+
+                  <% if (tags = method.tags(:param)).count > 0 %>
+                    <h3 id="method-i-subscribe-label-Parameters">
+                      Parameters
+                      <span><a href="#method-i-subscribe-label-Parameters">¶</a> <a href="#top">↑</a></span>
+                    </h3>
+                    <dl class="rdoc-list note-list">
+                      <% tags.each do |tag| %>
+                        <dt>
+                          <code><%= h tag.name %></code>
+                        </dt>
+                        <dd>
+                          <p>
+                            <% if tag.text && !tag.text.empty? %>
+                              <%= htmlify_line(tag.text) %>
+                            <% end %>
+                            <%= format_types(tag.types) %>
+                          </p>
+                        </dd>
+                      <% end %>
+                    </dl>
+                  <% end %>
+
                 </div>
               </div>
             <% end %>

--- a/templates/gcloud/class/html/setup.rb
+++ b/templates/gcloud/class/html/setup.rb
@@ -34,3 +34,8 @@ def methods_in_groups groups, methods
     yield("#{scope.to_s.capitalize} Methods", items) unless items.empty?
   end
 end
+
+def alias_for method
+  my_alias = method.namespace.aliases[method]
+  method.namespace.meths.find {|m| m.name == my_alias }
+end


### PR DESCRIPTION
This PR makes the documentation output of the YARD template equivalent in terms of content to the existing Rdoc template. Styling is slightly different in some places, such as type listings, which have a smaller font.

[closes #520]