### PR TITLE
Fix BigQuery handling empty data

### DIFF
--- a/lib/gcloud/bigquery/data.rb
+++ b/lib/gcloud/bigquery/data.rb
@@ -94,8 +94,8 @@ module Gcloud
       # Disabled rubocop because this implementation will not last.
 
       def self.format_rows rows, fields
-        headers = fields.map { |f| f["name"] }
-        field_types = fields.map { |f| f["type"] }
+        headers = Array(fields).map { |f| f["name"] }
+        field_types = Array(fields).map { |f| f["type"] }
 
         Array(rows).map do |row|
           values = row["f"].map { |f| f["v"] }

--- a/lib/gcloud/bigquery/query_data.rb
+++ b/lib/gcloud/bigquery/query_data.rb
@@ -107,8 +107,12 @@ module Gcloud
       ##
       # @private New Data from a response object.
       def self.from_gapi gapi, connection
-        formatted_rows = format_rows gapi["rows"],
-                                     gapi["schema"]["fields"]
+        if gapi["schema"].nil?
+          formatted_rows = []
+        else
+          formatted_rows = format_rows gapi["rows"],
+                                       gapi["schema"]["fields"]
+        end
 
         data = new formatted_rows
         data.gapi = gapi

--- a/test/gcloud/bigquery/data_test.rb
+++ b/test/gcloud/bigquery/data_test.rb
@@ -104,6 +104,17 @@ describe Gcloud::Bigquery::Data, :mock_bigquery do
     data.total.must_equal 3
   end
 
+  it "handles missing rows and fields" do
+    mock_connection.get "/bigquery/v2/projects/#{project}/datasets/#{dataset_id}/tables/#{table_id}/data" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       nil_table_data_json]
+    end
+
+    nil_data = table.data
+    nil_data.class.must_equal Gcloud::Bigquery::Data
+    nil_data.count.must_equal 0
+  end
+
   it "paginates data" do
     mock_connection.get "/bigquery/v2/projects/#{project}/datasets/#{dataset_id}/tables/#{table_id}/data" do |env|
       env.params.wont_include "pageToken"
@@ -253,5 +264,11 @@ describe Gcloud::Bigquery::Data, :mock_bigquery do
       "pageToken" => "token1234567890",
       "totalRows" => 3
     }
+  end
+
+  def nil_table_data_json
+    h = table_data_hash
+    h.delete "rows"
+    h.to_json
   end
 end

--- a/test/gcloud/bigquery/query_data_test.rb
+++ b/test/gcloud/bigquery/query_data_test.rb
@@ -111,4 +111,34 @@ describe Gcloud::Bigquery::QueryData, :mock_bigquery do
     job = query_data.job
     job.must_equal "I AM A STUBBED JOB"
   end
+
+  it "handles missing rows and fields" do
+    nil_query_data = Gcloud::Bigquery::QueryData.from_gapi nil_query_data_hash,
+                                                           bigquery.connection
+
+    nil_query_data.class.must_equal Gcloud::Bigquery::QueryData
+    nil_query_data.count.must_equal 0
+  end
+
+  it "handles empty rows and fields" do
+    empty_query_data = Gcloud::Bigquery::QueryData.from_gapi empty_query_data_hash,
+                                                             bigquery.connection
+
+    empty_query_data.class.must_equal Gcloud::Bigquery::QueryData
+    empty_query_data.count.must_equal 0
+  end
+
+  def nil_query_data_hash
+    h = query_data_hash
+    h.delete "rows"
+    h.delete "schema"
+    h
+  end
+
+  def empty_query_data_hash
+    h = query_data_hash
+    h["rows"] = []
+    h["schema"]["fields"] = []
+    h
+  end
 end


### PR DESCRIPTION
I have duplicated the `NoMethodError: undefined method `[]' for nil:NilClass` error in the tests when building Data and QueryData objects where the schema is missing. I also added tests to cover missing rows of data as well. The code now handles these situations without raising.

This should fix #530.