### PR TITLE
Add Logger Implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,8 @@ Style/EmptyLines:
   Enabled: false
 Style/EmptyElse:
   Enabled: false
+Style/CyclomaticComplexity:
+  Max: 10
 Metrics/AbcSize:
   Max: 25
 Metrics/MethodLength:

--- a/lib/gcloud/logging/logger.rb
+++ b/lib/gcloud/logging/logger.rb
@@ -37,7 +37,7 @@ module Gcloud
       attr_reader :labels
 
       ##
-      # @private Creates a new Connection instance.
+      # @private Creates a new Logger instance.
       def initialize logging, log_name, resource, labels = nil
         @logging = logging
         @log_name = log_name

--- a/lib/gcloud/logging/logger.rb
+++ b/lib/gcloud/logging/logger.rb
@@ -1,0 +1,216 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Gcloud
+  module Logging
+    ##
+    # # Logger
+    #
+    # A (mostly) API compatible logger for ruby's Logger.
+    class Logger
+      ##
+      # @private The logging object.
+      attr_accessor :logging
+
+      ##
+      # @private The Google Cloud log_name to write the log entry with.
+      attr_reader :log_name
+
+      ##
+      # @private The Google Cloud resource to write the log entry with.
+      attr_reader :resource
+
+      ##
+      # @private The Google Cloud labels to write the log entry with.
+      attr_reader :labels
+
+      ##
+      # @private Creates a new Connection instance.
+      def initialize logging, log_name, resource, labels = nil
+        @logging = logging
+        @log_name = log_name
+        @resource = resource
+        @labels = labels
+        @level = 0 # DEBUG is the default behavior
+      end
+
+      ##
+      # Log a DEBUG message.
+      def debug message = nil, &block
+        if block_given?
+          add 0, nil, message, &block
+        else
+          add 0, message, nil, &block
+        end
+      end
+
+      ##
+      # Log an INFO message.
+      def info message = nil, &block
+        if block_given?
+          add 1, nil, message, &block
+        else
+          add 1, message, nil, &block
+        end
+      end
+
+      ##
+      # Log a WARN message.
+      def warn message = nil, &block
+        if block_given?
+          add 2, nil, message, &block
+        else
+          add 2, message, nil, &block
+        end
+      end
+
+      ##
+      # Log an ERROR message.
+      def error message = nil, &block
+        if block_given?
+          add 3, nil, message, &block
+        else
+          add 3, message, nil, &block
+        end
+      end
+
+      ##
+      # Log a FATAL message.
+      def fatal message = nil, &block
+        if block_given?
+          add 4, nil, message, &block
+        else
+          add 4, message, nil, &block
+        end
+      end
+
+      ##
+      # Log an UNKNOWN message. This will be printed no matter what the logger's
+      # level is.
+      def unknown message = nil, &block
+        if block_given?
+          add 5, nil, message, &block
+        else
+          add 5, message, nil, &block
+        end
+      end
+
+      ##
+      # Log a message if the given severity is high enough. This is the generic
+      # logging method. Users will be more inclined to use {#debug}, {#info},
+      # {#warn}, {#error}, and {#fatal}.
+      def add severity, message = nil, progname = nil
+        severity = derive_severity(severity) || 5 # 5 is UNKNOWN/DEFAULT
+        return true if severity < @level
+
+        if message.nil?
+          if block_given?
+            message = yield
+          else
+            message = progname
+            # progname = nil # TODO: Figure out what to do with the progname
+          end
+        end
+
+        write_entry severity, message
+      end
+      alias_method :log, :add
+
+      ##
+      # Returns true if the current severity level allows for sending DEBUG
+      # messages.
+      def debug?
+        @level <= 0
+      end
+
+      ##
+      # Returns true if the current severity level allows for sending INFO
+      # messages.
+      def info?
+        @level <= 1
+      end
+
+      ##
+      # Returns true if the current severity level allows for sending WARN
+      # messages.
+      def warn?
+        @level <= 2
+      end
+
+      ##
+      # Returns true if the current severity level allows for sending ERROR
+      # messages.
+      def error?
+        @level <= 3
+      end
+
+      ##
+      # Returns true if the current severity level allows for sending FATAL
+      # messages.
+      def fatal?
+        @level <= 4
+      end
+
+      ##
+      # Set logging severity threshold.
+      def level= severity
+        new_level = derive_severity severity
+        fail ArgumentError, "invalid log level: #{severity}" if new_level.nil?
+        @level = new_level
+      end
+      alias_method :sev_threshold=, :level=
+
+      protected
+
+      ##
+      # @private Write a log entry to Google Cloud Logging service.
+      def write_entry severity, message
+        entry = logging.entry.tap do |e|
+          e.severity = gcloud_severity(severity)
+          e.payload = message
+        end
+
+        logging.write_entries entry, log_name: log_name,
+                                     resource: resource,
+                                     labels: labels
+      end
+
+      ##
+      # @private Get the logger level number from severity value object.
+      def derive_severity severity
+        return severity if severity.is_a? Integer
+
+        downcase_severity = severity.to_s.downcase
+        case downcase_severity
+        when "debug".freeze then 0
+        when "info".freeze then 1
+        when "warn".freeze then 2
+        when "error".freeze then 3
+        when "fatal".freeze then 4
+        when "unknown".freeze then 5
+        else nil
+        end
+      end
+
+      ##
+      # @private Get Google Cloud deverity from logger level number.
+      def gcloud_severity severity_int
+        %w(DEBUG INFO WARNING ERROR CRITICAL DEFAULT)[severity_int]
+      rescue
+        "DEFAULT"
+      end
+    end
+  end
+end

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -201,11 +201,9 @@ module Gcloud
       end
 
       ##
-      # Lists log entries. Use this method to retrieve log entries from Cloud
-      # Logging.
+      # Creates a logger object that is API compatible with ruby's standard
+      # library Logger.
       #
-      # @param [Gcloud::Logging::Entry, Array] entries One or more entry objects
-      #   to write. The log entries must have values for all required fields.
       # @param [String] log_name A log resource name to be associated with the
       #   written log entries.
       # @param [Gcloud::Logging::Resource] resource The monitored resource to be

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -201,6 +201,38 @@ module Gcloud
       end
 
       ##
+      # Lists log entries. Use this method to retrieve log entries from Cloud
+      # Logging.
+      #
+      # @param [Gcloud::Logging::Entry, Array] entries One or more entry objects
+      #   to write. The log entries must have values for all required fields.
+      # @param [String] log_name A log resource name to be associated with the
+      #   written log entries.
+      # @param [Gcloud::Logging::Resource] resource The monitored resource to be
+      #   associated with written log entries.
+      # @param [Hash] labels A set of user-defined data to be associated with
+      #   written log entries.
+      #
+      # @return [Gcloud::Logging::Logger] Logger object that can be used in
+      #   place of a ruby standard library logger object.
+      #
+      # @example
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   logging = gcloud.logging
+      #
+      #   resource = logging.resource "gae_app",
+      #                               module_id: "1",
+      #                               version_id: "20150925t173233"
+      #
+      #   logger = logging.logger "syslog", resource, env: :production
+      #
+      def logger log_name, resource, labels = {}
+        Logger.new self, log_name, resource, labels
+      end
+
+      ##
       # Deletes a log and all its log entries. The log will reappear if it
       # receives new entries.
       #

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -21,6 +21,7 @@ require "gcloud/logging/entry"
 require "gcloud/logging/resource_descriptor"
 require "gcloud/logging/sink"
 require "gcloud/logging/metric"
+require "gcloud/logging/logger"
 
 module Gcloud
   module Logging

--- a/test/gcloud/logging/logger/add_test.rb
+++ b/test/gcloud/logging/logger/add_test.rb
@@ -1,0 +1,275 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :add, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  describe :debug do
+    it "creates a log entry using :debug" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("DEBUG", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add :debug, "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using 'debug'" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("DEBUG", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add "debug", "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using Logger::DEBUG" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("DEBUG", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add ::Logger::DEBUG, "Danger Will Robinson!"
+    end
+  end
+
+  describe :info do
+    it "creates a log entry using :info" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("INFO", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add :info, "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using 'info'" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("INFO", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add "info", "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using Logger::INFO" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("INFO", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add ::Logger::INFO, "Danger Will Robinson!"
+    end
+  end
+
+  describe :warn do
+    it "creates a log entry using :warn" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("WARNING", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add :warn, "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using 'warn'" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("WARNING", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add "warn", "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using Logger::WARN" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("WARNING", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add ::Logger::WARN, "Danger Will Robinson!"
+    end
+  end
+
+  describe :error do
+    it "creates a log entry using :error" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add :error, "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using 'error'" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add "error", "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using Logger::ERROR" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add ::Logger::ERROR, "Danger Will Robinson!"
+    end
+  end
+
+  describe :fatal do
+    it "creates a log entry using :fatal" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add :fatal, "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using 'fatal'" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add "fatal", "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using Logger::FATAL" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add ::Logger::FATAL, "Danger Will Robinson!"
+    end
+  end
+
+  describe :unknown do
+    it "creates a log entry using :unknown" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add :unknown, "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using 'unknown'" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add "unknown", "Danger Will Robinson!"
+    end
+
+    it "creates a log entry using Logger::UNKNOWN" do
+      mock_connection.post "/v2beta1/entries:write" do |env|
+        entries_json = JSON.parse env.body
+        entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+        entries_json["resource"].must_equal resource.to_gapi
+        entries_json["labels"].must_equal labels
+        entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+        [200, {"Content-Type"=>"application/json"}, ""]
+      end
+
+      logger.add ::Logger::UNKNOWN, "Danger Will Robinson!"
+    end
+  end
+end

--- a/test/gcloud/logging/logger/debug_test.rb
+++ b/test/gcloud/logging/logger/debug_test.rb
@@ -1,0 +1,111 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :debug, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  before do
+    logger.level = ::Logger::DEBUG
+  end
+
+  it "creates a log entry with #debug" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEBUG", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.debug "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #info" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("INFO", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.info "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #warn" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("WARNING", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.warn "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #error" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.error "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #fatal" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.fatal "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #unknown" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.unknown "Danger Will Robinson!"
+  end
+end

--- a/test/gcloud/logging/logger/error_test.rb
+++ b/test/gcloud/logging/logger/error_test.rb
@@ -1,0 +1,84 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :error, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  before do
+    logger.level = ::Logger::ERROR
+  end
+
+  it "does not create a log entry with #debug" do
+    logger.debug "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #info" do
+    logger.info "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #warn" do
+    logger.warn "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #error" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.error "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #fatal" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.fatal "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #unknown" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.unknown "Danger Will Robinson!"
+  end
+end

--- a/test/gcloud/logging/logger/fatal_test.rb
+++ b/test/gcloud/logging/logger/fatal_test.rb
@@ -1,0 +1,75 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :fatal, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  before do
+    logger.level = ::Logger::FATAL
+  end
+
+  it "does not create a log entry with #debug" do
+    logger.debug "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #info" do
+    logger.info "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #warn" do
+    logger.warn "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #error" do
+    logger.error "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #fatal" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.fatal "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #unknown" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.unknown "Danger Will Robinson!"
+  end
+end

--- a/test/gcloud/logging/logger/info_test.rb
+++ b/test/gcloud/logging/logger/info_test.rb
@@ -1,0 +1,102 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :info, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  before do
+    logger.level = ::Logger::INFO
+  end
+
+  it "does not create a log entry with #debug" do
+    logger.debug "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #info" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("INFO", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.info "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #warn" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("WARNING", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.warn "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #error" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.error "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #fatal" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.fatal "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #unknown" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.unknown "Danger Will Robinson!"
+  end
+end

--- a/test/gcloud/logging/logger/unknown_test.rb
+++ b/test/gcloud/logging/logger/unknown_test.rb
@@ -1,0 +1,66 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :unknown, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  before do
+    logger.level = ::Logger::UNKNOWN
+  end
+
+  it "does not create a log entry with #debug" do
+    logger.debug "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #info" do
+    logger.info "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #warn" do
+    logger.warn "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #error" do
+    logger.error "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #fatal" do
+    logger.fatal "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #unknown" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.unknown "Danger Will Robinson!"
+  end
+end

--- a/test/gcloud/logging/logger/warn_test.rb
+++ b/test/gcloud/logging/logger/warn_test.rb
@@ -1,0 +1,93 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :warn, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  before do
+    logger.level = ::Logger::WARN
+  end
+
+  it "does not create a log entry with #debug" do
+    logger.debug "Danger Will Robinson!"
+  end
+
+  it "does not create a log entry with #info" do
+    logger.info "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #warn" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("WARNING", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.warn "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #error" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.error "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #fatal" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.fatal "Danger Will Robinson!"
+  end
+
+  it "creates a log entry with #unknown" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.unknown "Danger Will Robinson!"
+  end
+end

--- a/test/gcloud/logging/logger_test.rb
+++ b/test/gcloud/logging/logger_test.rb
@@ -1,0 +1,107 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "logger"
+
+describe Gcloud::Logging::Logger, :mock_logging do
+  let(:log_name) { "web_app_log" }
+  let(:resource) do
+    Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "gce_instance"
+      r.labels["zone"] = "global"
+      r.labels["instance_id"] = "abc123"
+    end
+  end
+  let(:labels) { { "env" => "production" } }
+  let(:logger) { Gcloud::Logging::Logger.new logging, log_name, resource, labels }
+
+  it "creates a DEBUG log entry with #debug" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEBUG", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.debug "Danger Will Robinson!"
+  end
+
+  it "creates an INFO log entry with #info" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("INFO", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.info "Danger Will Robinson!"
+  end
+
+  it "creates a WARNING log entry with #warn" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("WARNING", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.warn "Danger Will Robinson!"
+  end
+
+  it "creates a ERROR log entry with #error" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("ERROR", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.error "Danger Will Robinson!"
+  end
+
+  it "creates a CRITICAL log entry with #fatal" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("CRITICAL", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.fatal "Danger Will Robinson!"
+  end
+
+  it "creates a DEFAULT log entry with #unknown" do
+    mock_connection.post "/v2beta1/entries:write" do |env|
+      entries_json = JSON.parse env.body
+      entries_json["logName"].must_equal "projects/#{project}/logs/#{log_name}"
+      entries_json["resource"].must_equal resource.to_gapi
+      entries_json["labels"].must_equal labels
+      entries_json["entries"].must_equal [entry_gapi("DEFAULT", "Danger Will Robinson!")]
+      [200, {"Content-Type"=>"application/json"}, ""]
+    end
+
+    logger.unknown "Danger Will Robinson!"
+  end
+end

--- a/test/gcloud/logging/project/logger_test.rb
+++ b/test/gcloud/logging/project/logger_test.rb
@@ -1,0 +1,44 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Logging::Project, :logger, :mock_logging do
+  it "creates a ruby logger object" do
+    log_name = "web_app_log"
+    resource = Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "web_app_server"
+    end
+    labels = { "env" => "production" }
+
+    logger = logging.logger log_name, resource, labels
+    logger.must_be_kind_of Gcloud::Logging::Logger
+    logger.log_name.must_equal log_name
+    logger.resource.must_equal resource
+    logger.labels.must_equal labels
+  end
+
+  it "creates a ruby logger object without labels" do
+    log_name = "web_app_log"
+    resource = Gcloud::Logging::Resource.new.tap do |r|
+      r.type = "web_app_server"
+    end
+
+    logger = logging.logger log_name, resource
+    logger.must_be_kind_of Gcloud::Logging::Logger
+    logger.log_name.must_equal log_name
+    logger.resource.must_equal resource
+    logger.labels.must_be :empty?
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -879,6 +879,13 @@ class MockLogging < Minitest::Spec
     addl.include? :mock_logging
   end
 
+  def entry_gapi severity, payload
+    logging.entry.tap do |e|
+      e.severity = severity
+      e.payload = payload
+    end.to_gapi
+  end
+
   def random_entry_hash
     {
       "logName"   => "projects/my-projectid/logs/syslog",


### PR DESCRIPTION
Add Logger implementation that is API compatible with ruby's standard library Logger.

```ruby
require "gcloud"

gcloud = Gcloud.new
logging = gcloud.logging

resource = logging.resource "gae_app",
                            module_id: "1",
                            version_id: "20150925t173233"

logger = logging.logger "syslog", resource, env: :production
```

This will close #505.