### PR TITLE
Set YARD to use markdown

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,6 +1,7 @@
 --no-private
 --title=Gcloud
 --exclude lib/gcloud/proto/
+--markup markdown
 
 ./lib/**/*.rb
 -


### PR DESCRIPTION
This will allow sites such as rubydoc.info to display the docs correctly.