### PR TITLE
Add missing @example to docs

### DIFF
--- a/lib/gcloud/backoff.rb
+++ b/lib/gcloud/backoff.rb
@@ -23,9 +23,11 @@ module Gcloud
   # retry will be delayed one second, the second retry will be delayed
   # two seconds, and so on.
   #
+  # @example
   #   require "gcloud/backoff"
   #
   #   Gcloud::Backoff.retries = 5 # Set a maximum of five retries per call
+  #
   class Backoff
     class << self
       ##

--- a/lib/gcloud/upload.rb
+++ b/lib/gcloud/upload.rb
@@ -22,10 +22,12 @@ module Gcloud
   # Upload allows users to configure how files are uploaded to the Google Cloud
   # Service APIs.
   #
+  # @example
   #   require "gcloud/upload"
   #
   #   # Set the default threshold to 10 MiB.
   #   Gcloud::Upload.resumable_threshold = 10_000_000
+  #
   module Upload
     ##
     # Retrieve resumable threshold.


### PR DESCRIPTION
Fixes a couple of code examples to which we missed adding YARD's `@example` tag. Thanks to @callmehiphop for informing us about this issue today.