### PR TITLE
Fix NameError Bigquery::Dataset::Access#validate_special_group

### DIFF
--- a/lib/gcloud/bigquery/dataset/access.rb
+++ b/lib/gcloud/bigquery/dataset/access.rb
@@ -438,7 +438,7 @@ module Gcloud
         def validate_special_group value
           good_value = GROUPS[value.to_s]
           return good_value unless good_value.nil?
-          scope
+          value
         end
 
         # @private


### PR DESCRIPTION
I found undefined local variable `scope` in [bigquery/dataset/access.rb#L441](https://github.com/GoogleCloudPlatform/gcloud-ruby/blob/master/lib/gcloud/bigquery/dataset/access.rb#L441)