### PR TITLE
Fix @example tags

### DIFF
--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -436,7 +436,6 @@ module Gcloud
       #   jobs = bigquery.jobs
       #
       # @example Retrieve only running jobs using the `:filter` option:
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -445,7 +444,6 @@ module Gcloud
       #   running_jobs = bigquery.jobs filter: "running"
       #
       # @example With pagination: (See {Job::List#token})
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -682,7 +682,6 @@ module Gcloud
       #   load_job = table.load "gs://my-bucket/file-name.csv"
       #
       # @example Pass a gcloud storage file instance:
-      #
       #   require "gcloud"
       #   require "gcloud/storage"
       #
@@ -720,6 +719,7 @@ module Gcloud
       # of Faraday at or above 0.9.2, is a workaround for [this gzip
       # issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
       #
+      # @example
       #   require "gcloud"
       #
       #   # Use httpclient to avoid broken pipe errors with large uploads

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -446,7 +446,6 @@ module Gcloud
       #   end
       #
       # @example With pagination: (See {Subscription::List#token})
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -122,7 +122,6 @@ module Gcloud
       #   puts sub.name # => "my-topic-sub"
       #
       # @example The name is optional, and will be generated if not given:
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -133,7 +132,6 @@ module Gcloud
       #   puts sub.name # => "generated-sub-name"
       #
       # @example Wait 2 minutes for acknowledgement and push all to an endpoint:
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -225,7 +223,6 @@ module Gcloud
       #   end
       #
       # @example With pagination: (See {Subscription::List#token})
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -277,7 +274,6 @@ module Gcloud
       #   msg = topic.publish "new-message"
       #
       # @example Additionally, a message can be published with attributes:
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -25,6 +25,7 @@ module Gcloud
     #
     # Provides methods for creating, retrieving, and updating projects.
     #
+    # @example
     #   require "gcloud"
     #
     #   gcloud = Gcloud.new

--- a/lib/gcloud/resource_manager/project/updater.rb
+++ b/lib/gcloud/resource_manager/project/updater.rb
@@ -25,6 +25,7 @@ module Gcloud
       # This object is used by Project#update when passed a block. These methods
       # are used to update the project data in a single API call.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -215,7 +215,6 @@ module Gcloud
       #   document.rank #=> nil
       #
       # @example To check if an index already contains a document:
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -255,7 +254,6 @@ module Gcloud
       #   end
       #
       # @example With pagination: (See {Gcloud::Search::Document::List})
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -480,7 +478,6 @@ module Gcloud
       #   end
       #
       # @example With pagination: (See {Gcloud::Search::Result::List})
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -507,7 +504,6 @@ module Gcloud
       #   documents = index.search query # API call
       #
       # @example With the `fields` option:
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
@@ -519,7 +515,6 @@ module Gcloud
       #                          fields: ["name", "total_price", "highlight"]
       #
       # @example Just as in documents, data is accessible via {Fields} methods:
-      #
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -584,6 +584,7 @@ module Gcloud
       # for [this gzip
       # issue](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/367).
       #
+      # @example
       #   require "gcloud"
       #
       #   # Use httpclient to avoid broken pipe errors with large uploads

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -453,6 +453,7 @@ module Gcloud
       #
       # Represents a Bucket's Default Access Control List.
       #
+      # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new


### PR DESCRIPTION
Despite previous efforts, I found yet more examples without `@example` tags, or with a trailing blank line after the tag. But I'm pretty sure this PR fixes all examples.