### PR TITLE
Add missing YARD tags to methods that yield

### DIFF
--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -203,6 +203,9 @@ module Gcloud
       # @see https://cloud.google.com/bigquery/access-control BigQuery Access
       #   Control
       #
+      # @yield [access] a block for setting rules
+      # @yieldparam [Dataset::Access] access the object accepting rules
+      #
       # @example
       #   require "gcloud"
       #
@@ -322,6 +325,8 @@ module Gcloud
       #   this hash, see the [Tables resource
       #   ](https://cloud.google.com/bigquery/docs/reference/v2/tables#resource)
       #   .
+      # @yield [schema] a block for setting the schema
+      # @yieldparam [Table::Schema] schema the object accepting the schema
       #
       # @return [Gcloud::Bigquery::Table]
       #

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -265,6 +265,8 @@ module Gcloud
       #   [BigQuery Access
       #   Control](https://cloud.google.com/bigquery/access-control) for more
       #   information.
+      # @yield [access] a block for setting rules
+      # @yieldparam [Dataset::Access] access the object accepting rules
       #
       # @return [Gcloud::Bigquery::Dataset]
       #

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -305,6 +305,8 @@ module Gcloud
       #   `false`, the fields will be added to the existing schema. When a table
       #   already contains data, schema changes must be additive. Thus, the
       #   default value is `false`.
+      # @yield [schema] a block for setting the schema
+      # @yieldparam [Table::Schema] schema the object accepting the schema
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/bigquery/table/schema.rb
+++ b/lib/gcloud/bigquery/table/schema.rb
@@ -167,6 +167,9 @@ module Gcloud
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @yield [nested_schema] a block for setting the nested schema
+        # @yieldparam [Table::Schema] nested_schema the object accepting the
+        #   nested schema
         #
         # @example
         #   require "gcloud"

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -233,6 +233,9 @@ module Gcloud
       ##
       # Creates a Datastore Transaction.
       #
+      # @yield [tx] a block yielding a new transaction
+      # @yieldparam [Transaction] tx the transaction object
+      #
       # @example Runs the given block in a database transaction:
       #   require "gcloud"
       #
@@ -337,6 +340,8 @@ module Gcloud
       #   value. This is optional.
       # @param [Integer, String, nil] id_or_name The Key's `id` or `name` value
       #   if a `kind` was provided in the first parameter.
+      # @yield [entity] a block yielding a new entity
+      # @yieldparam [Entity] entity the newly created entity object
       #
       # @return [Gcloud::Datastore::Entity]
       #

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -222,6 +222,14 @@ module Gcloud
       # `"b"` should be indexed (meaning that `"a"`' should be excluded), you
       # should pass the array: `[true, false]`.
       #
+      # @param [String] name the property name
+      # @param [Boolean, Array<Boolean>, nil] flag whether the value or values
+      #   should be excluded from indexing
+      # @yield [value] a block yielding each value of the property
+      # @yieldparam [Object] value a value of the property
+      # @yieldreturn [Boolean] `true` if the value should be excluded from
+      #   indexing
+      #
       # @see https://cloud.google.com/datastore/docs/concepts/indexes#Datastore_Unindexed_properties
       #   Unindexed properties
       #

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -465,6 +465,8 @@ module Gcloud
       #   serial number.
       # @param [Integer, lambda, Proc] soa_serial A value (or a lambda or Proc
       #   returning a value) for the new SOA record serial number.
+      # @yield [tx] a block yielding a new transaction
+      # @yieldparam [Zone::Transaction] tx the transaction object
       #
       # @return [Gcloud::Dns::Change]
       #
@@ -674,6 +676,8 @@ module Gcloud
       # @param [Integer+, lambda, Proc] soa_serial A value (or a lambda or Proc
       #   returning a value) for the new SOA record serial number. See {#update}
       #   for details.
+      # @yield [record] a block yielding each matching record
+      # @yieldparam [Record] record the record to be modified
       #
       # @return [Gcloud::Dns::Change]
       #

--- a/lib/gcloud/dns/zone/transaction.rb
+++ b/lib/gcloud/dns/zone/transaction.rb
@@ -149,6 +149,8 @@ module Gcloud
         # @param [String] type The identifier of a [supported record
         #   type](https://cloud.google.com/dns/what-is-cloud-dns).
         #   For example: `A`, `AAAA`, `CNAME`, `MX`, or `TXT`.
+        # @yield [record] a block yielding each matching record
+        # @yieldparam [Record] record the record to be modified
         #
         # @example
         #   require "gcloud"

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -242,6 +242,8 @@ module Gcloud
       # @param [Hash] attributes Optional attributes for the message.
       # @option attributes [Boolean] :autocreate Flag to control whether the
       #   provided topic will be created if it does not exist.
+      # @yield [batch] a block for publishing multiple messages in one request
+      # @yieldparam [Topic::Batch] batch the batch object
       #
       # @return [Message, Array<Message>] Returns the published message when
       #   called without a block, or an array of messages when called with a

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -289,6 +289,8 @@ module Gcloud
       # @param [Number] delay The number of seconds to pause between requests
       #   when the Google Cloud service has no messages to return. The default
       #   value is `1`.
+      # @yield [msg] a block for processing new messages
+      # @yieldparam [ReceivedMessage] msg the newly received message
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -262,6 +262,8 @@ module Gcloud
       #
       # @param [String] data The message data.
       # @param [Hash] attributes Optional attributes for the message.
+      # @yield [batch] a block for publishing multiple messages in one request
+      # @yieldparam [Topic::Batch] batch the batch object
       #
       # @return [Message, Array<Message>] Returns the published message when
       #   called without a block, or an array of messages when called with a

--- a/lib/gcloud/resource_manager/project.rb
+++ b/lib/gcloud/resource_manager/project.rb
@@ -115,6 +115,9 @@ module Gcloud
       # No more than 256 labels can be associated with a given resource.
       # (`Hash`)
       #
+      # @yield [labels] a block for setting labels
+      # @yieldparam [Hash] labels the hash accepting labels
+      #
       # @example Labels are read-only and cannot be changed:
       #   require "gcloud"
       #
@@ -233,6 +236,10 @@ module Gcloud
 
       ##
       # Updates the project in a single API call. See {Project::Updater}
+      #
+      # @yield [project] a block yielding a project delegate
+      # @yieldparam [Project::Updater] project the delegate object for updating
+      #   the project
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -96,6 +96,9 @@ module Gcloud
       # @see https://cloud.google.com/storage/docs/cross-origin Cross-Origin
       #   Resource Sharing (CORS)
       #
+      # @yield [cors] a block for setting CORS rules
+      # @yieldparam [Bucket::Cors] cors the object accepting CORS rules
+      #
       # @example Retrieving the bucket's CORS rules.
       #   require "gcloud"
       #
@@ -279,6 +282,8 @@ module Gcloud
       # {#website_main=}, and {#website_404=}. In addition, the #cors
       # configuration accessible in the block is completely mutable and will be
       # included in the request. (See {Bucket::Cors})
+      #
+      # @yield [bucket] a block yielding a delegate object for updating the file
       #
       # @example
       #   require "gcloud"

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -252,6 +252,8 @@ module Gcloud
       # {#content_type=}, and {#metadata=}. The {#metadata} hash accessible in
       # the block is completely mutable and will be included in the request.
       #
+      # @yield [file] a block yielding a delegate object for updating the file
+      #
       # @example
       #   require "gcloud"
       #

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -265,6 +265,8 @@ module Gcloud
       #   does not exist. For more information, see [How to Host a Static
       #   Website
       #   ](https://cloud.google.com/storage/docs/website-configuration#step4).
+      # @yield [cors] a block for setting CORS rules
+      # @yieldparam [Bucket::Cors] cors the object accepting CORS rules
       #
       # @return [Gcloud::Storage::Bucket]
       #


### PR DESCRIPTION
These tags are used to add yield and yield params to the JSON docs.