### PR TITLE
Update jsondoc to generate multiple JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ pkg/*
 # directories left by gh-pages
 _site/*
 html/*
+
+# build output
+json

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem "rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "gcloud/jsondoc"
+require "pathname"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -14,6 +15,14 @@ desc "Generates JSON output from gcloud-ruby .yardoc"
 task :gcloud do
   registry = YARD::Registry.load! "../gcloud-ruby/.yardoc"
   builder = Gcloud::Jsondoc.new registry
-  json = builder.docs.target!
-  File.open("docs/examples/gcloud-docs.json", 'w'){|f| f.write json}
+  FileUtils.mkdir_p "json"
+  builder.docs.each do |doc|
+    json = doc.jbuilder.target!
+    json_path = "json/master/"
+    json_path += doc.filepath
+    dirname = Pathname.new(json_path).dirname
+    puts json_path
+    FileUtils.mkdir_p(dirname)
+    File.write json_path, json
+  end
 end

--- a/gcloud-jsondoc.gemspec
+++ b/gcloud-jsondoc.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'yard', "~> 0.8"
-  s.add_dependency 'redcarpet', "~> 3.3"
+  s.add_dependency 'kramdown', "~> 1.9"
+  s.add_dependency "rouge", "~> 1.10"
   s.add_dependency 'jbuilder', "~> 2.3"
 
   s.add_development_dependency "minitest"

--- a/lib/gcloud/jsondoc.rb
+++ b/lib/gcloud/jsondoc.rb
@@ -70,8 +70,8 @@ module Gcloud
           json.description md(object.docstring.to_s, true)
           json.source object.files.first.join("#L")
           json.resources object.docstring.tags(:see) do |t|
-            json.href t.name
             json.title md(t.text)
+            json.link t.name
           end
           json.examples object.docstring.tags(:example) do |t|
             json.caption md(t.name)

--- a/lib/gcloud/jsondoc.rb
+++ b/lib/gcloud/jsondoc.rb
@@ -178,11 +178,16 @@ module Gcloud
         html = Kramdown::Document.new(s.to_s, input: "GFM", hard_wrap: false,
                                        syntax_highlighter: "rouge",
                                        syntax_highlighter_opts: {css_class: "ruby"}).to_html.strip
+        html = remove_line_breaks(html)
         html = unwrap_paragraph(html) unless multi_paragraph
         if html
           html = resolve_links(html)
         end
         html
+      end
+
+      def remove_line_breaks html
+        html.gsub("\n", " ")
       end
 
       def unwrap_paragraph html

--- a/lib/gcloud/jsondoc.rb
+++ b/lib/gcloud/jsondoc.rb
@@ -37,12 +37,36 @@ module Gcloud
 
 
     class CodeObject
+
+      include YARD::Templates::Helpers::HtmlHelper
+
       attr_reader :name, :jbuilder, :code
 
       def initialize code
         @code = code
         @name = @code.name.to_s.downcase
         build
+      end
+
+      # API expected by HtmlHelper
+      def object
+        code
+      end
+
+      # API expected by HtmlHelper; overrides BaseHelper#linkify (not included)
+      def linkify(name, title)
+        code_obj = YARD::Registry.resolve code.namespace, name, true
+        path = if code_obj.nil?
+                 name
+               else
+                 parts = code_obj.path.split "::"
+                 parts.shift if parts.first == "Gcloud"
+                 parts.map(&:downcase).join("/")
+               end
+        link = "<a data-custom-type=\"#{path}\">#{title || name}</a>"
+        puts "linkify: #{name}, code_obj: #{code_obj.inspect}"
+        puts link
+        link
       end
 
       def filepath
@@ -155,6 +179,9 @@ module Gcloud
                                        syntax_highlighter: "rouge",
                                        syntax_highlighter_opts: {css_class: "ruby"}).to_html.strip
         html = unwrap_paragraph(html) unless multi_paragraph
+        if html
+          html = resolve_links(html)
+        end
         html
       end
 

--- a/lib/gcloud/jsondoc.rb
+++ b/lib/gcloud/jsondoc.rb
@@ -1,10 +1,11 @@
 require "gcloud/jsondoc/version"
 require "yard"
-require "redcarpet"
+require "kramdown"
 require "jbuilder"
 
 module Gcloud
   class Jsondoc
+
     attr_reader :input, :docs, :registry
 
     ##
@@ -14,128 +15,185 @@ module Gcloud
     #   the source code objects
     def initialize registry
       @registry = registry
+      @docs = []
       build
     end
 
     def build
       modules = @registry.all(:module)
-      @docs = Jbuilder.new do |json|
-        json.services modules do |service|
-          json.id service.name.to_s.downcase
-          metadata json, service
-          methods json, service
-          classes = service.children.select { |c| c.type == :class && c.namespace.name == service.name }
-          json.pages classes do |klass|
-            json.id klass.name.to_s.downcase
-            metadata json, klass
-            methods json, klass
+      modules.each do |code|
+        @docs << CodeObject.new(code)
+        children = code.children.select { |c| c.type == :class && c.namespace.name == code.name }
+        children.each do |child|
+          @docs << CodeObject.new(child)
+          grandchildren = child.children.select { |c| c.type == :class && c.namespace.name == child.name }
+          grandchildren.each do |child|
+            @docs << ChildCodeObject.new(child)
           end
         end
       end
       @registry.clear
     end
 
-    protected
 
-    def metadata json, object
-      json.metadata do
-        json.name object.name.to_s
-        json.description md(object.docstring.to_s, true)
-        json.source object.files.first.join("#L")
-        json.resources object.docstring.tags(:see) do |t|
-          json.href t.name
-          json.title md(t.text)
+    class CodeObject
+      attr_reader :name, :jbuilder, :code
+
+      def initialize code
+        @code = code
+        @name = @code.name.to_s.downcase
+        build
+      end
+
+      def filepath
+        downcase_namespace = @code.namespace.name.to_s.downcase
+        if downcase_namespace == "root"
+          "#{@name}.json"
+        else
+          "#{downcase_namespace}/#{@name}.json"
         end
-        json.examples object.docstring.tags(:example) do |t|
-          json.caption md(t.name)
-          json.code t.text
+      end
+
+      def build
+        @jbuilder = Jbuilder.new do |json|
+          json.id code.name.to_s.downcase
+          metadata json, code
+          methods json, code
         end
+      end
+
+      protected
+
+      def metadata json, object
+        json.metadata do
+          json.name object.name.to_s
+          json.description md(object.docstring.to_s, true)
+          json.source object.files.first.join("#L")
+          json.resources object.docstring.tags(:see) do |t|
+            json.href t.name
+            json.title md(t.text)
+          end
+          json.examples object.docstring.tags(:example) do |t|
+            json.caption md(t.name)
+            json.code t.text
+          end
+        end
+      end
+
+      def methods json, object
+        methods = object.children.select { |c| c.type == :method && !c.is_alias? && !c.has_tag?(:private) } # TODO: handle aliases
+        json.methods methods do |method|
+          metadata json, method
+          options = method.docstring.tags(:option)
+          # merge options into parent params
+          params = method.docstring.tags(:param).inject([]) do |memo, param_tag|
+            memo << param_tag
+            options_tags = options.select { |t| t.name == param_tag.name }
+            memo += options_tags unless options_tags.empty?
+            memo
+          end
+          if block = method.docstring.tag(:yield)
+            block_params = method.docstring.tags :yieldparam
+            block_params.unshift block
+            params += block_params
+          end
+          json.params params do |param|
+            param json, method, param
+          end
+          json.exceptions method.docstring.tags(:raise) do |t|
+            json.type t.type
+            json.description md(t.text)
+          end
+          json.returns method.docstring.tags(:return) do |t|
+            json.types t.types
+            json.description md(t.text)
+          end
+        end
+      end
+
+      def param json, method, param
+
+        if param.tag_name == "option"
+          # #<YARD::Tags::OptionTag:0x007fc78102ad78 @tag_name="option", @text=nil, @name="opts", @types=nil, @pair=#<YARD::Tags::DefaultTag:0x007fc78102bd40 @tag_name="option", @text="The subject", @name=":subject", @types=["String"], @defaults=nil>, @object=#<yardoc method MyModule::MyClass#example_instance_method>>
+          json.name (param.name + param.pair.name).sub(":", ".")
+          param = param.pair
+        elsif param.tag_name == "yield"
+          json.name "yield"
+        elsif param.tag_name == "yieldparam"
+          json.name "yield.#{param.name}"
+        else
+          json.name param.name
+        end
+
+        if param.tag_name == "yield"
+          json.types ["block"]
+        else
+          json.types param.types
+        end
+        json.description md(param.text)
+
+        if param.tag_name == "option" || param.tag_name == "yield"
+          json.optional true
+        elsif param.tag_name == "yieldparam"
+          json.optional false
+        else
+          # extract default value from MethodObject#parameters ⇒ Array<Array(String, String)>
+          # keyword argument parameter names contain trailing ":" in MethodObject#parameters, but not in Tag
+          method_param_pair = method.parameters.find { |p| p[0].sub(/:\z/, "") == param.name.to_s }
+          fail "no entry found for @param: '#{param.name}' in MethodObject#parameters: #{method.inspect}" unless method_param_pair
+          default_value = method_param_pair[1]
+          json.optional !default_value.nil?
+        end
+
+        json.default default_value if default_value
+        json.nullable(default_value == "nil" || (!param.types.nil? && param.types.include?("nil")))
+        # json.defaults param.defaults TODO: add default value to spec and impl
+      end
+
+      def md s, multi_paragraph = false
+        html = Kramdown::Document.new(s.to_s, input: "GFM", hard_wrap: false,
+                                       syntax_highlighter: "rouge",
+                                       syntax_highlighter_opts: {css_class: "ruby"}).to_html.strip
+        html = unwrap_paragraph(html) unless multi_paragraph
+        html
+      end
+
+      def unwrap_paragraph html
+        match = Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(html)
+        match[1] if match
       end
     end
 
-    def methods json, object
-      methods = object.children.select { |c| c.type == :method && !c.is_alias? && !c.has_tag?(:private) } # TODO: handle aliases
-      json.methods methods do |method|
-        metadata json, method
-        options = method.docstring.tags(:option)
-        # merge options into parent params
-        params = method.docstring.tags(:param).inject([]) do |memo, param_tag|
-          memo << param_tag
-          options_tags = options.select { |t| t.name == param_tag.name }
-          memo += options_tags unless options_tags.empty?
-          memo
-        end
-        if block = method.docstring.tag(:yield)
-          block_params = method.docstring.tags :yieldparam
-          block_params.unshift block
-          params += block_params
-        end
-        json.params params do |param|
-          param json, method, param
-        end
-        json.exceptions method.docstring.tags(:raise) do |t|
-          json.type t.type
-          json.description md(t.text)
-        end
-        json.returns method.docstring.tags(:return) do |t|
-          json.types t.types
-          json.description md(t.text)
-        end
-      end
-    end
 
-    def param json, method, param
 
-      if param.tag_name == "option"
-        # #<YARD::Tags::OptionTag:0x007fc78102ad78 @tag_name="option", @text=nil, @name="opts", @types=nil, @pair=#<YARD::Tags::DefaultTag:0x007fc78102bd40 @tag_name="option", @text="The subject", @name=":subject", @types=["String"], @defaults=nil>, @object=#<yardoc method MyModule::MyClass#example_instance_method>>
-        json.name (param.name + param.pair.name).sub(":", ".")
-        param = param.pair
-      elsif param.tag_name == "yield"
-        json.name "yield"
-      elsif param.tag_name == "yieldparam"
-        json.name "yield.#{param.name}"
-      else
-        json.name param.name
+    class ChildCodeObject < CodeObject
+
+      def filepath    # bigquery/table-list.json
+        "#{@code.namespace.namespace.name.to_s.downcase}/#{@code.namespace.name.to_s.downcase}-#{@name}.json"
       end
 
-      if param.tag_name == "yield"
-        json.types ["block"]
-      else
-        json.types param.types
+      def build
+        @jbuilder = Jbuilder.new do |json|
+          json.id "#{code.namespace.name.to_s.downcase}-#{code.name.to_s.downcase}"
+          metadata json, code
+          methods json, code
+        end
       end
-      json.description md(param.text)
-
-      if param.tag_name == "option" || param.tag_name == "yield"
-        json.optional true
-      elsif param.tag_name == "yieldparam"
-        json.optional false
-      else
-        # extract default value from MethodObject#parameters ⇒ Array<Array(String, String)>
-        # keyword argument parameter names contain trailing ":" in MethodObject#parameters, but not in Tag
-        method_param_pair = method.parameters.find { |p| p[0].sub(/:\z/, "") == param.name.to_s }
-        fail "no entry found for @param: '#{param.name}' in MethodObject#parameters: #{method.inspect}" unless method_param_pair
-        default_value = method_param_pair[1]
-        json.optional !default_value.nil?
+      def metadata json, object
+        json.metadata do
+          json.name "#{object.namespace.name}::#{object.name}"
+          json.description md(object.docstring.to_s, true)
+          json.source object.files.first.join("#L")
+          json.resources object.docstring.tags(:see) do |t|
+            json.href t.name
+            json.title md(t.text)
+          end
+          json.examples object.docstring.tags(:example) do |t|
+            json.caption md(t.name)
+            json.code t.text
+          end
+        end
       end
-
-      json.default default_value if default_value
-      json.nullable(default_value == "nil" || (!param.types.nil? && param.types.include?("nil")))
-      # json.defaults param.defaults TODO: add default value to spec and impl
-    end
-
-    def md s, multi_paragraph = false
-      html = markdown.render(s.to_s).strip.gsub("\n", " ")
-      html = unwrap_paragraph(html) unless multi_paragraph
-      html
-    end
-
-    def unwrap_paragraph html
-      match = Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(html)
-      match[1] if match
-    end
-
-    def markdown
-      @markdown ||= Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)
     end
   end
 end

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -1,147 +1,59 @@
 require 'test_helper'
 
-describe Gcloud::Jsondoc, :docs do
+describe Gcloud::Jsondoc, :class do
 
 
   before do
     registry = YARD::Registry.load(["test/fixtures/**/*.rb"], true)
     @builder = Gcloud::Jsondoc.new registry
-    @docs = @builder.docs[0].jbuilder.attributes!
+    @docs = @builder.docs[2].jbuilder.attributes! # docs[0] in module_test.rb
   end
 
   it "must have attributes at root" do
-    @docs.size.must_equal 4
+    @docs.size.must_equal 3
     @docs.keys[0].must_equal "id"
     @docs.keys[1].must_equal "metadata"
     @docs.keys[2].must_equal "methods"
   end
 
-  describe "when given a module" do
-    it "must have an id" do
-      @docs["id"].must_equal "mymodule"
-    end
+  describe "when given a class" do
 
-    it "must have service metadata" do
+    it "must have metadata" do
       metadata = @docs["metadata"]
-      metadata["name"].must_equal "MyModule"
-      metadata["description"].must_equal "<p>The outermost module in the test fixtures.</p>  <p>This is a Ruby <a href=\"http://docs.ruby-lang.org/en/2.2.0/Module.html\">module</a>.</p>"
-      metadata["source"].must_equal "test/fixtures/my_module.rb#L8"
-    end
-
-    it "can have methods" do
-      methods = @docs["methods"]
-      methods.size.must_equal 1
-    end
-  end
-
-  describe "when a module has a method" do
-
-    it "must have metadata" do
-      metadata = @docs["methods"][0]["metadata"]
-      metadata["name"].must_equal "example_method"
-      metadata["description"].must_equal "<p>Creates a new object for testing this library, as explained in <a href=\"https://en.wikipedia.org/wiki/Software_testing\">this article on testing</a>.</p>  <p>Each call creates a new instance.</p>"
-      metadata["source"].must_equal "test/fixtures/my_module.rb#L38"
-    end
-
-    it "must have metadata examples" do
-      metadata = @docs["methods"][0]["metadata"]
-      metadata["examples"].size.must_equal 1
-      metadata["examples"][0]["caption"].must_equal "You can pass options."
-      metadata["examples"][0]["code"].must_equal "return_object = Mymodule.storage \"my name\", opt_in: true do |config|\n  config.more = \"more\"\nend"
-    end
-
-    it "must have metadata resources" do
-      metadata = @docs["methods"][0]["metadata"]
-      metadata["resources"].size.must_equal 1
-      metadata["resources"][0]["href"].must_equal "http://ntp.org/documentation.html"
-      metadata["resources"][0]["title"].must_equal "NTP Documentation"
-    end
-
-    it "must have params" do
-      params = @docs["methods"][0]["params"]
-      params.size.must_equal 3
-      params[0]["name"].must_equal "personal_name"
-      params[0]["types"].must_equal ["String"]
-      params[0]["description"].must_equal "The name, which can be any name as defined by <a href=\"https://en.wikipedia.org/wiki/Personal_name\">this article on names</a>"
-      params[0]["optional"].must_equal false
-      params[0]["default"].must_be :nil?
-      params[0]["nullable"].must_equal false
-
-      params[1]["name"].must_equal "email"
-      params[1]["types"].must_equal ["String", "Array<String>", "nil"]
-      params[1]["description"].must_equal "The person&#39;s email or emails."
-      params[1]["optional"].must_equal true
-      params[1]["default"].must_equal "nil"
-      params[1]["nullable"].must_equal true
-
-      params[2]["name"].must_equal "opt_in"
-      params[2]["types"].must_equal ["Boolean", "nil"]
-      params[2]["description"].must_equal "Whether to subscribe to <em>all</em> mailing lists."
-      params[2]["optional"].must_equal true
-      params[2]["default"].must_equal "false"
-      params[2]["nullable"].must_equal true
-    end
-
-    it "must have exceptions" do
-      exceptions = @docs["methods"][0]["exceptions"]
-      exceptions.size.must_equal 1
-      exceptions[0]["type"].must_equal "ArgumentError"
-      exceptions[0]["description"].must_equal "if the name is not a name as defined by <a href=\"https://en.wikipedia.org/wiki/Personal_name\">this article</a>"
-    end
-
-    it "must have returns" do
-      returns = @docs["methods"][0]["returns"]
-      returns.size.must_equal 1
-      returns[0]["types"].must_equal ["MyModule::ReturnClass"]
-      returns[0]["description"].must_equal "an empty object instance"
-    end
-  end
-
-  describe "when given a module class" do
-    it "must have a pages entry" do
-      pages = @docs["pages"]
-      pages.size.must_equal 3
-      pages[0]["id"].must_equal "returnclass"
-      pages[1]["id"].must_equal "myclass"
-      pages[2]["id"].must_equal "myconfig" # TODO: don't include in pages
-    end
-
-    it "must have metadata" do
-      metadata = @docs["pages"][1]["metadata"]
       metadata["name"].must_equal "MyClass"
       metadata["description"].must_equal "<p>You can use MyClass for almost anything.</p>"
       metadata["source"].must_equal "test/fixtures/my_module/my_class.rb#L4"
     end
 
     it "can have methods" do
-      methods = @docs["pages"][1]["methods"]
+      methods = @docs["methods"]
       methods.size.must_equal 1
     end
 
     describe "when a class has a method" do
       it "must have metadata" do
-        metadata = @docs["pages"][1]["methods"][0]["metadata"]
+        metadata = @docs["methods"][0]["metadata"]
         metadata["name"].must_equal "example_instance_method"
         metadata["description"].must_equal "<p>Accepts many arguments for testing this library. Also accepts a block if a block is given.</p>  <p>Do not call this method until you have read all of its documentation.</p>"
         metadata["source"].must_equal "test/fixtures/my_module/my_class.rb#L50"
       end
 
       it "must have metadata examples" do
-        metadata = @docs["pages"][1]["methods"][0]["metadata"]
+        metadata = @docs["methods"][0]["metadata"]
         metadata["examples"].size.must_equal 2
         metadata["examples"][0]["caption"].must_equal "You can pass a block."
         metadata["examples"][0]["code"].must_equal "my_class = MyClass.new\nmy_class.example_instance_method times: 5 do |my_config|\n  my_config.limit = 5\n  true\nend"
       end
 
       it "must have metadata resources" do
-        metadata = @docs["pages"][1]["methods"][0]["metadata"]
+        metadata = @docs["methods"][0]["metadata"]
         metadata["resources"].size.must_equal 1
-        metadata["resources"][0]["href"].must_equal "http://ruby-doc.org/core-2.2.0/Proc.html"
+        metadata["resources"][0]["link"].must_equal "http://ruby-doc.org/core-2.2.0/Proc.html"
         metadata["resources"][0]["title"].must_equal "Proc objects are blocks of code that have been bound to a set of local variables."
       end
 
       it "can have params with options hash and keyword args" do
-        params = @docs["pages"][1]["methods"][0]["params"]
+        params = @docs["methods"][0]["params"]
         params.size.must_equal 8
 
         params[0]["name"].must_equal "policy"

--- a/test/jsondoc_test.rb
+++ b/test/jsondoc_test.rb
@@ -6,30 +6,30 @@ describe Gcloud::Jsondoc, :docs do
   before do
     registry = YARD::Registry.load(["test/fixtures/**/*.rb"], true)
     @builder = Gcloud::Jsondoc.new registry
-    @docs = @builder.docs.attributes!
+    @docs = @builder.docs[0].jbuilder.attributes!
   end
 
-  it "must have services array at root" do
-    @docs.size.must_equal 1
-    @docs.keys[0].must_equal "services"
+  it "must have attributes at root" do
+    @docs.size.must_equal 4
+    @docs.keys[0].must_equal "id"
+    @docs.keys[1].must_equal "metadata"
+    @docs.keys[2].must_equal "methods"
   end
 
   describe "when given a module" do
-    it "must have a service" do
-      services = @docs["services"]
-      services.size.must_equal 1
-      services[0]["id"].must_equal "mymodule"
+    it "must have an id" do
+      @docs["id"].must_equal "mymodule"
     end
 
     it "must have service metadata" do
-      metadata = @docs["services"][0]["metadata"]
+      metadata = @docs["metadata"]
       metadata["name"].must_equal "MyModule"
       metadata["description"].must_equal "<p>The outermost module in the test fixtures.</p>  <p>This is a Ruby <a href=\"http://docs.ruby-lang.org/en/2.2.0/Module.html\">module</a>.</p>"
       metadata["source"].must_equal "test/fixtures/my_module.rb#L8"
     end
 
     it "can have methods" do
-      methods = @docs["services"][0]["methods"]
+      methods = @docs["methods"]
       methods.size.must_equal 1
     end
   end
@@ -37,28 +37,28 @@ describe Gcloud::Jsondoc, :docs do
   describe "when a module has a method" do
 
     it "must have metadata" do
-      metadata = @docs["services"][0]["methods"][0]["metadata"]
+      metadata = @docs["methods"][0]["metadata"]
       metadata["name"].must_equal "example_method"
       metadata["description"].must_equal "<p>Creates a new object for testing this library, as explained in <a href=\"https://en.wikipedia.org/wiki/Software_testing\">this article on testing</a>.</p>  <p>Each call creates a new instance.</p>"
       metadata["source"].must_equal "test/fixtures/my_module.rb#L38"
     end
 
     it "must have metadata examples" do
-      metadata = @docs["services"][0]["methods"][0]["metadata"]
+      metadata = @docs["methods"][0]["metadata"]
       metadata["examples"].size.must_equal 1
       metadata["examples"][0]["caption"].must_equal "You can pass options."
       metadata["examples"][0]["code"].must_equal "return_object = Mymodule.storage \"my name\", opt_in: true do |config|\n  config.more = \"more\"\nend"
     end
 
     it "must have metadata resources" do
-      metadata = @docs["services"][0]["methods"][0]["metadata"]
+      metadata = @docs["methods"][0]["metadata"]
       metadata["resources"].size.must_equal 1
       metadata["resources"][0]["href"].must_equal "http://ntp.org/documentation.html"
       metadata["resources"][0]["title"].must_equal "NTP Documentation"
     end
 
     it "must have params" do
-      params = @docs["services"][0]["methods"][0]["params"]
+      params = @docs["methods"][0]["params"]
       params.size.must_equal 3
       params[0]["name"].must_equal "personal_name"
       params[0]["types"].must_equal ["String"]
@@ -83,14 +83,14 @@ describe Gcloud::Jsondoc, :docs do
     end
 
     it "must have exceptions" do
-      exceptions = @docs["services"][0]["methods"][0]["exceptions"]
+      exceptions = @docs["methods"][0]["exceptions"]
       exceptions.size.must_equal 1
       exceptions[0]["type"].must_equal "ArgumentError"
       exceptions[0]["description"].must_equal "if the name is not a name as defined by <a href=\"https://en.wikipedia.org/wiki/Personal_name\">this article</a>"
     end
 
     it "must have returns" do
-      returns = @docs["services"][0]["methods"][0]["returns"]
+      returns = @docs["methods"][0]["returns"]
       returns.size.must_equal 1
       returns[0]["types"].must_equal ["MyModule::ReturnClass"]
       returns[0]["description"].must_equal "an empty object instance"
@@ -99,7 +99,7 @@ describe Gcloud::Jsondoc, :docs do
 
   describe "when given a module class" do
     it "must have a pages entry" do
-      pages = @docs["services"][0]["pages"]
+      pages = @docs["pages"]
       pages.size.must_equal 3
       pages[0]["id"].must_equal "returnclass"
       pages[1]["id"].must_equal "myclass"
@@ -107,41 +107,41 @@ describe Gcloud::Jsondoc, :docs do
     end
 
     it "must have metadata" do
-      metadata = @docs["services"][0]["pages"][1]["metadata"]
+      metadata = @docs["pages"][1]["metadata"]
       metadata["name"].must_equal "MyClass"
       metadata["description"].must_equal "<p>You can use MyClass for almost anything.</p>"
       metadata["source"].must_equal "test/fixtures/my_module/my_class.rb#L4"
     end
 
     it "can have methods" do
-      methods = @docs["services"][0]["pages"][1]["methods"]
+      methods = @docs["pages"][1]["methods"]
       methods.size.must_equal 1
     end
 
     describe "when a class has a method" do
       it "must have metadata" do
-        metadata = @docs["services"][0]["pages"][1]["methods"][0]["metadata"]
+        metadata = @docs["pages"][1]["methods"][0]["metadata"]
         metadata["name"].must_equal "example_instance_method"
         metadata["description"].must_equal "<p>Accepts many arguments for testing this library. Also accepts a block if a block is given.</p>  <p>Do not call this method until you have read all of its documentation.</p>"
         metadata["source"].must_equal "test/fixtures/my_module/my_class.rb#L50"
       end
 
       it "must have metadata examples" do
-        metadata = @docs["services"][0]["pages"][1]["methods"][0]["metadata"]
+        metadata = @docs["pages"][1]["methods"][0]["metadata"]
         metadata["examples"].size.must_equal 2
         metadata["examples"][0]["caption"].must_equal "You can pass a block."
         metadata["examples"][0]["code"].must_equal "my_class = MyClass.new\nmy_class.example_instance_method times: 5 do |my_config|\n  my_config.limit = 5\n  true\nend"
       end
 
       it "must have metadata resources" do
-        metadata = @docs["services"][0]["pages"][1]["methods"][0]["metadata"]
+        metadata = @docs["pages"][1]["methods"][0]["metadata"]
         metadata["resources"].size.must_equal 1
         metadata["resources"][0]["href"].must_equal "http://ruby-doc.org/core-2.2.0/Proc.html"
         metadata["resources"][0]["title"].must_equal "Proc objects are blocks of code that have been bound to a set of local variables."
       end
 
       it "can have params with options hash and keyword args" do
-        params = @docs["services"][0]["pages"][1]["methods"][0]["params"]
+        params = @docs["pages"][1]["methods"][0]["params"]
         params.size.must_equal 8
 
         params[0]["name"].must_equal "policy"

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+describe Gcloud::Jsondoc, :module do
+
+
+  before do
+    registry = YARD::Registry.load(["test/fixtures/**/*.rb"], true)
+    @builder = Gcloud::Jsondoc.new registry
+    @docs = @builder.docs[0].jbuilder.attributes! # docs[2] in class_test.rb
+  end
+
+  it "must have attributes at root" do
+    @docs.size.must_equal 3
+    @docs.keys[0].must_equal "id"
+    @docs.keys[1].must_equal "metadata"
+    @docs.keys[2].must_equal "methods"
+  end
+
+  describe "when given a module" do
+    it "must have an id" do
+      @docs["id"].must_equal "mymodule"
+    end
+
+    it "must have service metadata" do
+      metadata = @docs["metadata"]
+      metadata["name"].must_equal "MyModule"
+      metadata["description"].must_equal "<p>The outermost module in the test fixtures.</p>  <p>This is a Ruby <a href=\"http://docs.ruby-lang.org/en/2.2.0/Module.html\">module</a>.</p>"
+      metadata["source"].must_equal "test/fixtures/my_module.rb#L8"
+    end
+
+    it "can have methods" do
+      methods = @docs["methods"]
+      methods.size.must_equal 1
+    end
+  end
+
+  describe "when a module has a method" do
+
+    it "must have metadata" do
+      metadata = @docs["methods"][0]["metadata"]
+      metadata["name"].must_equal "example_method"
+      metadata["description"].must_equal "<p>Creates a new object for testing this library, as explained in <a href=\"https://en.wikipedia.org/wiki/Software_testing\">this article on testing</a>.</p>  <p>Each call creates a new instance.</p>"
+      metadata["source"].must_equal "test/fixtures/my_module.rb#L38"
+    end
+
+    it "must have metadata examples" do
+      metadata = @docs["methods"][0]["metadata"]
+      metadata["examples"].size.must_equal 1
+      metadata["examples"][0]["caption"].must_equal "You can pass options."
+      metadata["examples"][0]["code"].must_equal "return_object = Mymodule.storage \"my name\", opt_in: true do |config|\n  config.more = \"more\"\nend"
+    end
+
+    it "must have metadata resources" do
+      metadata = @docs["methods"][0]["metadata"]
+      metadata["resources"].size.must_equal 1
+      metadata["resources"][0]["link"].must_equal "http://ntp.org/documentation.html"
+      metadata["resources"][0]["title"].must_equal "NTP Documentation"
+    end
+
+    it "must have params" do
+      params = @docs["methods"][0]["params"]
+      params.size.must_equal 3
+      params[0]["name"].must_equal "personal_name"
+      params[0]["types"].must_equal ["String"]
+      params[0]["description"].must_equal "The name, which can be any name as defined by <a href=\"https://en.wikipedia.org/wiki/Personal_name\">this article on names</a>"
+      params[0]["optional"].must_equal false
+      params[0]["default"].must_be :nil?
+      params[0]["nullable"].must_equal false
+
+      params[1]["name"].must_equal "email"
+      params[1]["types"].must_equal ["String", "Array<String>", "nil"]
+      params[1]["description"].must_equal "The person’s email or emails."
+      params[1]["optional"].must_equal true
+      params[1]["default"].must_equal "nil"
+      params[1]["nullable"].must_equal true
+
+      params[2]["name"].must_equal "opt_in"
+      params[2]["types"].must_equal ["Boolean", "nil"]
+      params[2]["description"].must_equal "Whether to subscribe to <em>all</em> mailing lists."
+      params[2]["optional"].must_equal true
+      params[2]["default"].must_equal "false"
+      params[2]["nullable"].must_equal true
+    end
+
+    it "must have exceptions" do
+      exceptions = @docs["methods"][0]["exceptions"]
+      exceptions.size.must_equal 1
+      exceptions[0]["type"].must_equal "ArgumentError"
+      exceptions[0]["description"].must_equal "if the name is not a name as defined by <a href=\"https://en.wikipedia.org/wiki/Personal_name\">this article</a>"
+    end
+
+    it "must have returns" do
+      returns = @docs["methods"][0]["returns"]
+      returns.size.must_equal 1
+      returns[0]["types"].must_equal ["MyModule::ReturnClass"]
+      returns[0]["description"].must_equal "an empty object instance"
+    end
+  end
+end


### PR DESCRIPTION
This PR makes output of the jsondoc tool on the `gcloud-jsondoc` branch compatible with the current gcloud-common site JSON. It also changes its markdown library from Redcarpet to Kramdown, to keep up with the times and for consistency with the current YARD-generated docs.