### PR TITLE
Improve mock expectations

### DIFF
--- a/test/gcloud/logging/metric_test.rb
+++ b/test/gcloud/logging/metric_test.rb
@@ -29,9 +29,17 @@ describe Gcloud::Logging::Metric, :mock_logging do
   it "can save itself" do
     new_metric_description = "New Metric Description"
     new_metric_filter = "logName:syslog AND severity>=WARN"
-
+    new_metric = Google::Logging::V2::LogMetric.new(
+      name: metric.name,
+      description: new_metric_description,
+      filter: new_metric_filter
+    )
+    update_req = Google::Logging::V2::UpdateLogMetricRequest.new(
+      metric_name: "projects/test/metrics/#{metric.name}",
+      metric: new_metric
+    )
     mock = Minitest::Mock.new
-    mock.expect :update_log_metric, metric_grpc, [Google::Logging::V2::UpdateLogMetricRequest]
+    mock.expect :update_log_metric, metric_grpc, [update_req]
     metric.service.metrics = mock
 
     metric.description = new_metric_description
@@ -46,8 +54,9 @@ describe Gcloud::Logging::Metric, :mock_logging do
   end
 
   it "can refresh itself" do
+    get_req = Google::Logging::V2::GetLogMetricRequest.new metric_name: "projects/test/metrics/#{metric.name}"
     mock = Minitest::Mock.new
-    mock.expect :get_log_metric, metric_grpc, [Google::Logging::V2::GetLogMetricRequest]
+    mock.expect :get_log_metric, metric_grpc, [get_req]
     metric.service.metrics = mock
 
     metric.refresh!
@@ -56,8 +65,9 @@ describe Gcloud::Logging::Metric, :mock_logging do
   end
 
   it "can delete itself" do
+    delete_req = Google::Logging::V2::DeleteLogMetricRequest.new metric_name: "projects/test/metrics/#{metric.name}"
     mock = Minitest::Mock.new
-    mock.expect :delete_log_metric, metric_grpc, [Google::Logging::V2::DeleteLogMetricRequest]
+    mock.expect :delete_log_metric, metric_grpc, [delete_req]
     metric.service.metrics = mock
 
     metric.delete

--- a/test/gcloud/logging/project/list_entries_test.rb
+++ b/test/gcloud/logging/project/list_entries_test.rb
@@ -53,15 +53,13 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries" do
     first_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project]
+    first_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], page_token: "next_page_token"
+    second_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2)),
-                [second_list_req]
+    mock.expect :list_log_entries, first_list_res, [first_list_req]
+    mock.expect :list_log_entries, second_list_res, [second_list_req]
     logging.service.logging = mock
 
     first_entries = logging.entries
@@ -81,15 +79,13 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries with next? and next" do
     first_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project]
+    first_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], page_token: "next_page_token"
+    second_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2)),
-                [second_list_req]
+    mock.expect :list_log_entries, first_list_res, [first_list_req]
+    mock.expect :list_log_entries, second_list_res, [second_list_req]
     logging.service.logging = mock
 
     first_entries = logging.entries
@@ -108,11 +104,10 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries with one project" do
     list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: ["project1"]
+    list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_entries, list_res, [list_req]
     logging.service.logging = mock
 
     entries = logging.entries projects: "project1"
@@ -127,11 +122,10 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries with multiple projects" do
     list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: ["project1", "project2", "project3"]
+    list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_entries, list_res, [list_req]
     logging.service.logging = mock
 
     entries = logging.entries projects: ["project1", "project2", "project3"]
@@ -148,11 +142,10 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
     adv_logs_filter = 'resource.type:"gce_"'
 
     list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], filter: adv_logs_filter
+    list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_entries, list_res, [list_req]
     logging.service.logging = mock
 
     entries = logging.entries filter: adv_logs_filter
@@ -167,11 +160,10 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries with order asc" do
     list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], order_by: "timestamp"
+    list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_entries, list_res, [list_req]
     logging.service.logging = mock
 
     entries = logging.entries order: "timestamp"
@@ -186,11 +178,10 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries with order desc" do
     list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], order_by: "timestamp desc"
+    list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_entries, list_res, [list_req]
     logging.service.logging = mock
 
     entries = logging.entries order: "timestamp desc"
@@ -205,11 +196,10 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries with max set" do
     list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], page_size: 3
+    list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_entries, list_res, [list_req]
     logging.service.logging = mock
 
     entries = logging.entries max: 3
@@ -224,11 +214,10 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
   it "paginates entries without max set" do
     list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project]
+    list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries,
-                Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_entries, list_res, [list_req]
     logging.service.logging = mock
 
     entries = logging.entries

--- a/test/gcloud/logging/project/metrics_test.rb
+++ b/test/gcloud/logging/project/metrics_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Gcloud::Logging::Project, :metrics, :mock_logging do
   it "lists metrics" do
     num_metrics = 3
+    list_req = [Google::Logging::V2::ListLogMetricsRequest]
+    list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics)),
-                [Google::Logging::V2::ListLogMetricsRequest]
+    mock.expect :list_log_metrics, list_res, list_req
     logging.service.metrics = mock
 
     metrics = logging.metrics
@@ -34,11 +34,11 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "lists metrics with find_metrics alias" do
     num_metrics = 3
+    list_req = [Google::Logging::V2::ListLogMetricsRequest]
+    list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics)),
-                [Google::Logging::V2::ListLogMetricsRequest]
+    mock.expect :list_log_metrics, list_res, list_req
     logging.service.metrics = mock
 
     metrics = logging.find_metrics
@@ -51,15 +51,13 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "paginates metrics" do
     first_list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path)
+    first_list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path, page_token: "next_page_token")
+    second_list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2)),
-                [second_list_req]
+    mock.expect :list_log_metrics, first_list_res, [first_list_req]
+    mock.expect :list_log_metrics, second_list_res, [second_list_req]
     logging.service.metrics = mock
 
     first_metrics = logging.metrics
@@ -79,15 +77,13 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "paginates metrics with next? and next" do
     first_list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path)
+    first_list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path, page_token: "next_page_token")
+    second_list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(2)),
-                [second_list_req]
+    mock.expect :list_log_metrics, first_list_res, [first_list_req]
+    mock.expect :list_log_metrics, second_list_res, [second_list_req]
     logging.service.metrics = mock
 
     first_metrics = logging.metrics
@@ -106,11 +102,10 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "paginates metrics with max set" do
     list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path, page_size: 3)
+    list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_metrics, list_res, [list_req]
     logging.service.metrics = mock
 
     metrics = logging.metrics max: 3
@@ -125,11 +120,10 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "paginates metrics without max set" do
     list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path)
+    list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics,
-                Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_log_metrics, list_res, [list_req]
     logging.service.metrics = mock
 
     metrics = logging.metrics
@@ -144,11 +138,11 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "creates a metric" do
     new_metric_name = "new-metric-#{Time.now.to_i}"
+    create_req = [Google::Logging::V2::CreateLogMetricRequest]
+    create_res = Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric,
-                Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name).to_json),
-                [Google::Logging::V2::CreateLogMetricRequest]
+    mock.expect :create_log_metric, create_res, create_req
     logging.service.metrics = mock
 
     metric = logging.create_metric new_metric_name
@@ -165,13 +159,13 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
     new_metric_name = "new-metric-#{Time.now.to_i}"
     new_metric_description = "New Metric (#{Time.now.to_i})"
     new_metric_filter = "logName:syslog AND severity>=WARN"
+    create_req = [Google::Logging::V2::CreateLogMetricRequest]
+    create_res = Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name,
+                                                                                    "description" => new_metric_description,
+                                                                                    "filter" => new_metric_filter).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric,
-                Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name,
-                                                                                   "description" => new_metric_description,
-                                                                                   "filter" => new_metric_filter).to_json),
-                [Google::Logging::V2::CreateLogMetricRequest]
+    mock.expect :create_log_metric, create_res, create_req
     logging.service.metrics = mock
 
     metric = logging.create_metric new_metric_name, description: new_metric_description,
@@ -186,11 +180,11 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "gets a metric" do
     metric_name = "existing-metric-#{Time.now.to_i}"
+    get_req = [Google::Logging::V2::GetLogMetricRequest]
+    get_res = Google::Logging::V2::LogMetric.decode_json(random_metric_hash.merge("name" => metric_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :get_log_metric,
-                Google::Logging::V2::LogMetric.decode_json(random_metric_hash.merge("name" => metric_name).to_json),
-                [Google::Logging::V2::GetLogMetricRequest]
+    mock.expect :get_log_metric, get_res, get_req
     logging.service.metrics = mock
 
     metric = logging.metric metric_name

--- a/test/gcloud/logging/project/metrics_test.rb
+++ b/test/gcloud/logging/project/metrics_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Gcloud::Logging::Project, :metrics, :mock_logging do
   it "lists metrics" do
     num_metrics = 3
-    list_req = [Google::Logging::V2::ListLogMetricsRequest]
+    list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path)
     list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, list_req
+    mock.expect :list_log_metrics, list_res, [list_req]
     logging.service.metrics = mock
 
     metrics = logging.metrics
@@ -34,11 +34,11 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "lists metrics with find_metrics alias" do
     num_metrics = 3
-    list_req = [Google::Logging::V2::ListLogMetricsRequest]
+    list_req = Google::Logging::V2::ListLogMetricsRequest.new(project_name: project_path)
     list_res = Google::Logging::V2::ListLogMetricsResponse.decode_json(list_metrics_json(num_metrics))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, list_req
+    mock.expect :list_log_metrics, list_res, [list_req]
     logging.service.metrics = mock
 
     metrics = logging.find_metrics
@@ -138,11 +138,15 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "creates a metric" do
     new_metric_name = "new-metric-#{Time.now.to_i}"
-    create_req = [Google::Logging::V2::CreateLogMetricRequest]
+    new_metric = Google::Logging::V2::LogMetric.new name: new_metric_name
+    create_req = Google::Logging::V2::CreateLogMetricRequest.new(
+      project_name: "projects/test",
+      metric: new_metric
+    )
     create_res = Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric, create_res, create_req
+    mock.expect :create_log_metric, create_res, [create_req]
     logging.service.metrics = mock
 
     metric = logging.create_metric new_metric_name
@@ -159,13 +163,21 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
     new_metric_name = "new-metric-#{Time.now.to_i}"
     new_metric_description = "New Metric (#{Time.now.to_i})"
     new_metric_filter = "logName:syslog AND severity>=WARN"
-    create_req = [Google::Logging::V2::CreateLogMetricRequest]
+    new_metric = Google::Logging::V2::LogMetric.new(
+      name: new_metric_name,
+      description: new_metric_description,
+      filter: new_metric_filter
+    )
+    create_req = Google::Logging::V2::CreateLogMetricRequest.new(
+      project_name: "projects/test",
+      metric: new_metric
+    )
     create_res = Google::Logging::V2::LogMetric.decode_json(empty_metric_hash.merge("name" => new_metric_name,
                                                                                     "description" => new_metric_description,
                                                                                     "filter" => new_metric_filter).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric, create_res, create_req
+    mock.expect :create_log_metric, create_res, [create_req]
     logging.service.metrics = mock
 
     metric = logging.create_metric new_metric_name, description: new_metric_description,
@@ -180,11 +192,11 @@ describe Gcloud::Logging::Project, :metrics, :mock_logging do
 
   it "gets a metric" do
     metric_name = "existing-metric-#{Time.now.to_i}"
-    get_req = [Google::Logging::V2::GetLogMetricRequest]
+    get_req = Google::Logging::V2::GetLogMetricRequest.new metric_name: "projects/test/metrics/#{metric_name}"
     get_res = Google::Logging::V2::LogMetric.decode_json(random_metric_hash.merge("name" => metric_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :get_log_metric, get_res, get_req
+    mock.expect :get_log_metric, get_res, [get_req]
     logging.service.metrics = mock
 
     metric = logging.metric metric_name

--- a/test/gcloud/logging/project/resource_descriptors_test.rb
+++ b/test/gcloud/logging/project/resource_descriptors_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
   it "lists resource descriptors" do
     num_descriptors = 3
-    list_req = [Google::Logging::V2::ListMonitoredResourceDescriptorsRequest]
+    list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new
     list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, list_req
+    mock.expect :list_monitored_resource_descriptors, list_res, [list_req]
     logging.service.logging = mock
 
     resource_descriptors = logging.resource_descriptors
@@ -34,11 +34,11 @@ describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
 
   it "lists resource descriptors with find_resource_descriptors alias" do
     num_descriptors = 3
-    list_req = [Google::Logging::V2::ListMonitoredResourceDescriptorsRequest]
+    list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new
     list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, list_req
+    mock.expect :list_monitored_resource_descriptors, list_res, [list_req]
     logging.service.logging = mock
 
     resource_descriptors = logging.find_resource_descriptors

--- a/test/gcloud/logging/project/resource_descriptors_test.rb
+++ b/test/gcloud/logging/project/resource_descriptors_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
   it "lists resource descriptors" do
     num_descriptors = 3
+    list_req = [Google::Logging::V2::ListMonitoredResourceDescriptorsRequest]
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors)),
-                [Google::Logging::V2::ListMonitoredResourceDescriptorsRequest]
+    mock.expect :list_monitored_resource_descriptors, list_res, list_req
     logging.service.logging = mock
 
     resource_descriptors = logging.resource_descriptors
@@ -34,11 +34,11 @@ describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
 
   it "lists resource descriptors with find_resource_descriptors alias" do
     num_descriptors = 3
+    list_req = [Google::Logging::V2::ListMonitoredResourceDescriptorsRequest]
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(num_descriptors)),
-                [Google::Logging::V2::ListMonitoredResourceDescriptorsRequest]
+    mock.expect :list_monitored_resource_descriptors, list_res, list_req
     logging.service.logging = mock
 
     resource_descriptors = logging.find_resource_descriptors
@@ -51,15 +51,13 @@ describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
 
   it "paginates resource descriptors" do
     first_list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new(page_token: "next_page_token")
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2)),
-                [second_list_req]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [first_list_req]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [second_list_req]
     logging.service.logging = mock
 
     first_descriptors = logging.resource_descriptors
@@ -79,15 +77,13 @@ describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
 
   it "paginates resource descriptors with next? and next" do
     first_list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new
+    first_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new(page_token: "next_page_token")
+    second_list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(2)),
-                [second_list_req]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, [first_list_req]
+    mock.expect :list_monitored_resource_descriptors, second_list_res, [second_list_req]
     logging.service.logging = mock
 
     first_descriptors = logging.resource_descriptors
@@ -106,11 +102,10 @@ describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
 
   it "paginates resource descriptors with max set" do
     list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new(page_size: 3)
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_monitored_resource_descriptors, list_res, [list_req]
     logging.service.logging = mock
 
     resource_descriptors = logging.resource_descriptors max: 3
@@ -125,11 +120,10 @@ describe Gcloud::Logging::Project, :resource_descriptors, :mock_logging do
 
   it "paginates resource descriptors without max set" do
     list_req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new
+    list_res = Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors,
-                Google::Logging::V2::ListMonitoredResourceDescriptorsResponse.decode_json(list_resource_descriptors_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_monitored_resource_descriptors, list_res, [list_req]
     logging.service.logging = mock
 
     resource_descriptors = logging.resource_descriptors

--- a/test/gcloud/logging/project/sinks_test.rb
+++ b/test/gcloud/logging/project/sinks_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Gcloud::Logging::Project, :sinks, :mock_logging do
   it "lists sinks" do
     num_sinks = 3
-    list_req = [Google::Logging::V2::ListSinksRequest]
+    list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path)
     list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, list_req
+    mock.expect :list_sinks, list_res, [list_req]
     logging.service.sinks = mock
 
     sinks = logging.sinks
@@ -34,11 +34,11 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "lists sinks with find_sinks alias" do
     num_sinks = 3
-    list_req = [Google::Logging::V2::ListSinksRequest]
+    list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path)
     list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, list_req
+    mock.expect :list_sinks, list_res, [list_req]
     logging.service.sinks = mock
 
     sinks = logging.find_sinks
@@ -138,11 +138,15 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "creates a sink" do
     new_sink_name = "new-sink-#{Time.now.to_i}"
-    create_req = [Google::Logging::V2::CreateSinkRequest]
+    new_sink = Google::Logging::V2::LogSink.new name: new_sink_name
+    create_req = Google::Logging::V2::CreateSinkRequest.new(
+      project_name: "projects/test",
+      sink: new_sink
+    )
     create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge("name" => new_sink_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink, create_res, create_req
+    mock.expect :create_sink, create_res, [create_req]
     logging.service.sinks = mock
 
     sink = logging.create_sink new_sink_name
@@ -160,7 +164,16 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
     new_sink_name = "new-sink-#{Time.now.to_i}"
     new_sink_destination = "storage.googleapis.com/new-sinks"
     new_sink_filter = "logName:syslog AND severity>=WARN"
-    create_req = [Google::Logging::V2::CreateSinkRequest]
+    new_sink = Google::Logging::V2::LogSink.new(
+      name: new_sink_name,
+      destination: new_sink_destination,
+      filter: new_sink_filter,
+      output_version_format: :V2
+    )
+    create_req = Google::Logging::V2::CreateSinkRequest.new(
+      project_name: "projects/test",
+      sink: new_sink
+    )
     create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge(
                                                           "name" => new_sink_name,
                                                           "destination" => new_sink_destination,
@@ -168,7 +181,7 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
                                                           "output_version_format" => "V2").to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink, create_res, create_req
+    mock.expect :create_sink, create_res, [create_req]
     logging.service.sinks = mock
 
     sink = logging.create_sink new_sink_name, destination: new_sink_destination,
@@ -185,11 +198,11 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "gets a sink" do
     sink_name = "existing-sink-#{Time.now.to_i}"
-    get_req = [Google::Logging::V2::GetSinkRequest]
+    get_req = Google::Logging::V2::GetSinkRequest.new(sink_name: "projects/test/sinks/#{sink_name}")
     get_res = Google::Logging::V2::LogSink.decode_json(random_sink_hash.merge("name" => sink_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :get_sink, get_res, get_req
+    mock.expect :get_sink, get_res, [get_req]
     logging.service.sinks = mock
 
     sink = logging.sink sink_name

--- a/test/gcloud/logging/project/sinks_test.rb
+++ b/test/gcloud/logging/project/sinks_test.rb
@@ -17,11 +17,11 @@ require "helper"
 describe Gcloud::Logging::Project, :sinks, :mock_logging do
   it "lists sinks" do
     num_sinks = 3
+    list_req = [Google::Logging::V2::ListSinksRequest]
+    list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks)),
-                [Google::Logging::V2::ListSinksRequest]
+    mock.expect :list_sinks, list_res, list_req
     logging.service.sinks = mock
 
     sinks = logging.sinks
@@ -34,11 +34,11 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "lists sinks with find_sinks alias" do
     num_sinks = 3
+    list_req = [Google::Logging::V2::ListSinksRequest]
+    list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(num_sinks)),
-                [Google::Logging::V2::ListSinksRequest]
+    mock.expect :list_sinks, list_res, list_req
     logging.service.sinks = mock
 
     sinks = logging.find_sinks
@@ -51,15 +51,13 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "paginates sinks" do
     first_list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path)
+    first_list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path, page_token: "next_page_token")
+    second_list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2)),
-                [second_list_req]
+    mock.expect :list_sinks, first_list_res, [first_list_req]
+    mock.expect :list_sinks, second_list_res, [second_list_req]
     logging.service.sinks = mock
 
     first_sinks = logging.sinks
@@ -79,15 +77,13 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "paginates sinks with next? and next" do
     first_list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path)
+    first_list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path, page_token: "next_page_token")
+    second_list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token")),
-                [first_list_req]
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2)),
-                [second_list_req]
+    mock.expect :list_sinks, first_list_res, [first_list_req]
+    mock.expect :list_sinks, second_list_res, [second_list_req]
     logging.service.sinks = mock
 
     first_sinks = logging.sinks
@@ -106,11 +102,10 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "paginates sinks with max set" do
     list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path, page_size: 3)
+    list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_sinks, list_res, [list_req]
     logging.service.sinks = mock
 
     sinks = logging.sinks max: 3
@@ -125,11 +120,10 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "paginates sinks without max set" do
     list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path)
+    list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks,
-                Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token")),
-                [list_req]
+    mock.expect :list_sinks, list_res, [list_req]
     logging.service.sinks = mock
 
     sinks = logging.sinks
@@ -144,11 +138,11 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "creates a sink" do
     new_sink_name = "new-sink-#{Time.now.to_i}"
+    create_req = [Google::Logging::V2::CreateSinkRequest]
+    create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge("name" => new_sink_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink,
-                Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge("name" => new_sink_name).to_json),
-                [Google::Logging::V2::CreateSinkRequest]
+    mock.expect :create_sink, create_res, create_req
     logging.service.sinks = mock
 
     sink = logging.create_sink new_sink_name
@@ -166,15 +160,15 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
     new_sink_name = "new-sink-#{Time.now.to_i}"
     new_sink_destination = "storage.googleapis.com/new-sinks"
     new_sink_filter = "logName:syslog AND severity>=WARN"
+    create_req = [Google::Logging::V2::CreateSinkRequest]
+    create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge(
+                                                          "name" => new_sink_name,
+                                                          "destination" => new_sink_destination,
+                                                          "filter" => new_sink_filter,
+                                                          "output_version_format" => "V2").to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink,
-                Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge(
-                  "name"                  => new_sink_name,
-                  "destination"           => new_sink_destination,
-                  "filter"                => new_sink_filter,
-                  "output_version_format" => "V2").to_json),
-                [Google::Logging::V2::CreateSinkRequest]
+    mock.expect :create_sink, create_res, create_req
     logging.service.sinks = mock
 
     sink = logging.create_sink new_sink_name, destination: new_sink_destination,
@@ -191,12 +185,11 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "gets a sink" do
     sink_name = "existing-sink-#{Time.now.to_i}"
+    get_req = [Google::Logging::V2::GetSinkRequest]
+    get_res = Google::Logging::V2::LogSink.decode_json(random_sink_hash.merge("name" => sink_name).to_json)
 
     mock = Minitest::Mock.new
-    mock.expect :get_sink,
-                Google::Logging::V2::LogSink.decode_json(random_sink_hash.merge(
-                  "name" => sink_name).to_json),
-                [Google::Logging::V2::GetSinkRequest]
+    mock.expect :get_sink, get_res, get_req
     logging.service.sinks = mock
 
     sink = logging.sink sink_name

--- a/test/gcloud/logging/sink_test.rb
+++ b/test/gcloud/logging/sink_test.rb
@@ -45,9 +45,18 @@ describe Gcloud::Logging::Sink, :mock_logging do
   it "can save itself" do
     new_sink_destination = "storage.googleapis.com/new-sink-bucket"
     new_sink_filter = "logName:syslog AND severity>=WARN"
-
+    new_sink = Google::Logging::V2::LogSink.new(
+      name: sink.name,
+      destination: new_sink_destination,
+      filter: new_sink_filter,
+      output_version_format: :V1
+    )
+    update_req = Google::Logging::V2::UpdateSinkRequest.new(
+      sink_name: "projects/test/sinks/#{sink.name}",
+      sink: new_sink
+    )
     mock = Minitest::Mock.new
-    mock.expect :update_sink, sink_grpc, [Google::Logging::V2::UpdateSinkRequest]
+    mock.expect :update_sink, sink_grpc, [update_req]
     sink.service.sinks = mock
 
     sink.destination = new_sink_destination
@@ -64,8 +73,9 @@ describe Gcloud::Logging::Sink, :mock_logging do
   end
 
   it "can refresh itself" do
+    get_req = Google::Logging::V2::GetSinkRequest.new sink_name: "projects/test/sinks/#{sink.name}"
     mock = Minitest::Mock.new
-    mock.expect :get_sink, sink_grpc, [Google::Logging::V2::GetSinkRequest]
+    mock.expect :get_sink, sink_grpc, [get_req]
     sink.service.sinks = mock
 
     sink.refresh!
@@ -74,8 +84,9 @@ describe Gcloud::Logging::Sink, :mock_logging do
   end
 
   it "can delete itself" do
+    delete_req = Google::Logging::V2::DeleteSinkRequest.new sink_name: "projects/test/sinks/#{sink.name}"
     mock = Minitest::Mock.new
-    mock.expect :delete_sink, sink_grpc, [Google::Logging::V2::DeleteSinkRequest]
+    mock.expect :delete_sink, sink_grpc, [delete_req]
     sink.service.sinks = mock
 
     sink.delete


### PR DESCRIPTION
Partway through his conversion of Logging to gRPC, @blowmage started fully specifying expectations for mocks of the grpc services. This PR will do the same for the earlier tests that didn't get fully specified. It also refactors `mock#expect`calls to a single line.