### PR TITLE
Fix Entity#update_exclude_indexes!

### DIFF
--- a/acceptance/datastore/datastore_test.rb
+++ b/acceptance/datastore/datastore_test.rb
@@ -56,6 +56,11 @@ describe "Datastore", :datastore do
 
     it "should save/find/delete with a key name" do
       post.key = Gcloud::Datastore::Key.new "Post", "post1"
+      post.exclude_from_indexes! "author", true
+      # Verify the index excludes are set properly
+      post.exclude_from_indexes?("title").must_equal false
+      post.exclude_from_indexes?("author").must_equal true
+
       dataset.save post
 
       refresh = dataset.find post.key
@@ -63,6 +68,9 @@ describe "Datastore", :datastore do
       refresh.key.id.must_equal          post.key.id
       refresh.key.name.must_equal        post.key.name
       refresh.properties.to_h.must_equal post.properties.to_h
+      # Verify the index excludes are retrieved properly
+      refresh.exclude_from_indexes?("title").must_equal false
+      refresh.exclude_from_indexes?("author").must_equal true
 
       dataset.delete post
       refresh = dataset.find post.key

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -319,9 +319,9 @@ module Gcloud
       def update_exclude_indexes! entity
         @_exclude_indexes = {}
         Array(entity.property).each do |property|
-          @_exclude_indexes[property.name] = property.value.indexed
+          @_exclude_indexes[property.name] = !property.value.indexed
           unless property.value.list_value.nil?
-            exclude = Array(property.value.list_value).map(&:indexed)
+            exclude = Array(property.value.list_value).map{|v| !v.indexed}
             @_exclude_indexes[property.name] = exclude
           end
         end

--- a/test/gcloud/datastore/entity_exclude_test.rb
+++ b/test/gcloud/datastore/entity_exclude_test.rb
@@ -25,6 +25,37 @@ describe Gcloud::Datastore::Entity, :exclude_from_indexes do
     end
   end
 
+  it "converts indexed value to not excluded from a protocol buffer object" do
+    proto = Gcloud::Datastore::Proto::Entity.new
+    proto.key = Gcloud::Datastore::Proto::Key.new
+    proto.key.path_element = [Gcloud::Datastore::Proto::Key::PathElement.new]
+    proto.key.path_element.first.kind = "User"
+    proto.key.path_element.first.id = 123456
+    proto.property = [Gcloud::Datastore::Proto::Property.new]
+    proto.property[0].name = "name"
+    proto.property[0].value = Gcloud::Datastore::Proto.to_proto_value "User McNumber"
+    proto.property[0].value.indexed = true # default
+
+    entity_from_proto = Gcloud::Datastore::Entity.from_proto proto
+    entity_from_proto.exclude_from_indexes?("name").must_equal false
+  end
+
+  it "converts indexed list to not excluded from a protocol buffer object" do
+    proto = Gcloud::Datastore::Proto::Entity.new
+    proto.key = Gcloud::Datastore::Proto::Key.new
+    proto.key.path_element = [Gcloud::Datastore::Proto::Key::PathElement.new]
+    proto.key.path_element.first.kind = "User"
+    proto.key.path_element.first.id = 123456
+    proto.property = [Gcloud::Datastore::Proto::Property.new]
+    proto.property[0].name = "tags"
+    proto.property[0].value = Gcloud::Datastore::Proto.to_proto_value ["ruby", "code"]
+    proto.property[0].value.list_value.first.indexed = true # default
+    proto.property[0].value.list_value.last.indexed = true # default
+
+    entity_from_proto = Gcloud::Datastore::Entity.from_proto proto
+    entity_from_proto.exclude_from_indexes?("tags").must_equal [false, false]
+  end
+
   it "doesn't exclude from indexes by default" do
     refute entity.exclude_from_indexes?("name")
     refute entity.exclude_from_indexes?("email")


### PR DESCRIPTION
This PR adds breaking unit and acceptance tests for the correct conversion of `indexed` properties to `Entity#exclude_from_indexes?`. It fixes the broken tests by flipping the boolean value of `indexed`, both for individual values and list values.

Thank you @bmclean for reporting this issue and indicating how to fix it in #537.

[closes #537]