### PR TITLE
Logging List#all

### DIFF
--- a/lib/gcloud/logging/entry/list.rb
+++ b/lib/gcloud/logging/entry/list.rb
@@ -51,6 +51,32 @@ module Gcloud
         end
 
         ##
+        # Retrieves all log entries by repeatedly loading {#next} until
+        # {#next?} returns false. Returns the list instance for method chaining.
+        #
+        # This method may make several API calls until all log entries are
+        # retrieved. Be sure to use as narrow a search criteria as possible.
+        # Please use with caution.
+        #
+        # @example
+        #   require "gcloud"
+        #
+        #   gcloud = Gcloud.new
+        #   logging = gcloud.logging
+        #   hour_ago = (Time.now - 60*60).utc.strftime('%FT%TZ')
+        #   recent_errors = "timestamp >= \"#{hour_ago}\" severity >= ERROR"
+        #   entries = logging.entries(filter: recent_errors).all
+        #
+        def all
+          while next?
+            next_records = self.next
+            push(*next_records)
+            self.token = next_records.token
+          end
+          self
+        end
+
+        ##
         # @private New Entry::List from a
         # Google::Logging::V2::ListLogEntryResponse object.
         def self.from_grpc grpc_list, service, projects: nil, filter: nil,

--- a/lib/gcloud/logging/entry/list.rb
+++ b/lib/gcloud/logging/entry/list.rb
@@ -43,7 +43,8 @@ module Gcloud
         def next
           return nil unless next?
           ensure_service!
-          grpc = @service.list_entries token: token
+          grpc = @service.list_entries token: token, projects: @projects,
+                                       filter: @filter, order: @order, max: @max
           self.class.from_grpc grpc, @service
         rescue GRPC::BadStatus => e
           raise Error.from_error(e)
@@ -52,7 +53,8 @@ module Gcloud
         ##
         # @private New Entry::List from a
         # Google::Logging::V2::ListLogEntryResponse object.
-        def self.from_grpc grpc_list, service
+        def self.from_grpc grpc_list, service, projects: nil, filter: nil,
+                           order: nil, max: nil
           entries = new(Array(grpc_list.entries).map do |grpc_entry|
             Entry.from_grpc grpc_entry
           end)
@@ -60,6 +62,10 @@ module Gcloud
             @token = grpc_list.next_page_token
             @token = nil if @token == ""
             @service = service
+            @projects = projects
+            @filter = filter
+            @order = order
+            @max = max
           end
           entries
         end

--- a/lib/gcloud/logging/metric/list.rb
+++ b/lib/gcloud/logging/metric/list.rb
@@ -50,7 +50,7 @@ module Gcloud
         end
 
         ##
-        # Retrieves all sinks by repeatedly loading {#next?} until {#next?}
+        # Retrieves all metrics by repeatedly loading {#next?} until {#next?}
         # returns false. Returns the list instance for method chaining.
         #
         # @example

--- a/lib/gcloud/logging/metric/list.rb
+++ b/lib/gcloud/logging/metric/list.rb
@@ -50,6 +50,26 @@ module Gcloud
         end
 
         ##
+        # Retrieves all sinks by repeatedly loading {#next?} until {#next?}
+        # returns false. Returns the list instance for method chaining.
+        #
+        # @example
+        #   require "gcloud"
+        #
+        #   gcloud = Gcloud.new
+        #   logging = gcloud.logging
+        #   all_metrics = logging.metrics.all # Load all pages of metrics
+        #
+        def all
+          while next?
+            next_records = self.next
+            push(*next_records)
+            self.token = next_records.token
+          end
+          self
+        end
+
+        ##
         # @private New Metric::List from a
         # Google::Logging::V2::ListLogMetricsResponse object.
         def self.from_grpc grpc_list, service

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -124,7 +124,8 @@ module Gcloud
         ensure_service!
         list_grpc = service.list_entries projects: projects, filter: filter,
                                          order: order, token: token, max: max
-        Entry::List.from_grpc list_grpc, service
+        Entry::List.from_grpc list_grpc, service, projects: projects, max: max,
+                                                  filter: filter, order: order
       rescue GRPC::BadStatus => e
         raise Error.from_error(e)
       end

--- a/lib/gcloud/logging/sink/list.rb
+++ b/lib/gcloud/logging/sink/list.rb
@@ -50,6 +50,26 @@ module Gcloud
         end
 
         ##
+        # Retrieves all sinks by repeatedly loading {#next?} until {#next?}
+        # returns false. Returns the list instance for method chaining.
+        #
+        # @example
+        #   require "gcloud"
+        #
+        #   gcloud = Gcloud.new
+        #   logging = gcloud.logging
+        #   all_sinks = logging.sinks.all # Load all pages of sinks
+        #
+        def all
+          while next?
+            next_records = self.next
+            push(*next_records)
+            self.token = next_records.token
+          end
+          self
+        end
+
+        ##
         # @private New Sink::List from a Google::Logging::V2::ListSinksResponse
         # object.
         def self.from_grpc grpc_list, service

--- a/test/gcloud/logging/project/list_entries_test.rb
+++ b/test/gcloud/logging/project/list_entries_test.rb
@@ -77,7 +77,47 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
     second_entries.token.must_be :nil?
   end
 
-  it "paginates entries with next? and next" do
+  it "paginates entries with criteria" do
+    first_list_req = Google::Logging::V2::ListLogEntriesRequest.new(
+      project_ids: ["project1", "project2", "project3"],
+      filter: 'resource.type:"gce_"',
+      order_by: "timestamp"
+    )
+    first_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
+    second_list_req = Google::Logging::V2::ListLogEntriesRequest.new(
+      project_ids: ["project1", "project2", "project3"],
+      filter: 'resource.type:"gce_"',
+      order_by: "timestamp",
+      page_token: "next_page_token"
+    )
+    second_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_log_entries, first_list_res, [first_list_req]
+    mock.expect :list_log_entries, second_list_res, [second_list_req]
+    logging.service.mocked_logging = mock
+
+    first_entries = logging.entries projects: ["project1", "project2", "project3"],
+                                    filter: 'resource.type:"gce_"',
+                                    order: "timestamp"
+    second_entries = logging.entries projects: ["project1", "project2", "project3"],
+                                     filter: 'resource.type:"gce_"',
+                                     order: "timestamp",
+                                     token: first_entries.token
+
+    mock.verify
+
+    first_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    first_entries.count.must_equal 3
+    first_entries.token.wont_be :nil?
+    first_entries.token.must_equal "next_page_token"
+
+    second_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    second_entries.count.must_equal 2
+    second_entries.token.must_be :nil?
+  end
+
+  it "paginates entries using next? and next" do
     first_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project]
     first_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
     second_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], page_token: "next_page_token"
@@ -100,6 +140,43 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
     second_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
     second_entries.count.must_equal 2
     second_entries.next?.must_equal false #wont_be :next?
+  end
+
+  it "paginates entries with criteria using next? and next" do
+    first_list_req = Google::Logging::V2::ListLogEntriesRequest.new(
+      project_ids: ["project1", "project2", "project3"],
+      filter: 'resource.type:"gce_"',
+      order_by: "timestamp"
+    )
+    first_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
+    second_list_req = Google::Logging::V2::ListLogEntriesRequest.new(
+      project_ids: ["project1", "project2", "project3"],
+      filter: 'resource.type:"gce_"',
+      order_by: "timestamp",
+      page_token: "next_page_token"
+    )
+    second_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_log_entries, first_list_res, [first_list_req]
+    mock.expect :list_log_entries, second_list_res, [second_list_req]
+    logging.service.mocked_logging = mock
+
+    first_entries = logging.entries projects: ["project1", "project2", "project3"],
+                                    filter: 'resource.type:"gce_"',
+                                    order: "timestamp"
+    second_entries = first_entries.next
+
+    mock.verify
+
+    first_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    first_entries.count.must_equal 3
+    first_entries.token.wont_be :nil?
+    first_entries.token.must_equal "next_page_token"
+
+    second_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    second_entries.count.must_equal 2
+    second_entries.token.must_be :nil?
   end
 
   it "paginates entries with one project" do

--- a/test/gcloud/logging/project/list_entries_test.rb
+++ b/test/gcloud/logging/project/list_entries_test.rb
@@ -142,6 +142,26 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
     second_entries.next?.must_equal false #wont_be :next?
   end
 
+  it "paginates entries using all" do
+    first_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project]
+    first_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
+    second_list_req = Google::Logging::V2::ListLogEntriesRequest.new project_ids: [project], page_token: "next_page_token"
+    second_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_log_entries, first_list_res, [first_list_req]
+    mock.expect :list_log_entries, second_list_res, [second_list_req]
+    logging.service.mocked_logging = mock
+
+    all_entries = logging.entries.all
+
+    mock.verify
+
+    all_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    all_entries.count.must_equal 5
+    all_entries.next?.must_equal false #wont_be :next?
+  end
+
   it "paginates entries with criteria using next? and next" do
     first_list_req = Google::Logging::V2::ListLogEntriesRequest.new(
       project_ids: ["project1", "project2", "project3"],
@@ -171,12 +191,42 @@ describe Gcloud::Logging::Project, :list_entries, :mock_logging do
 
     first_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
     first_entries.count.must_equal 3
-    first_entries.token.wont_be :nil?
-    first_entries.token.must_equal "next_page_token"
+    first_entries.next?.must_equal true #must_be :next?
 
     second_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
     second_entries.count.must_equal 2
-    second_entries.token.must_be :nil?
+    second_entries.next?.must_equal false #wont_be :next?
+  end
+
+  it "paginates entries with criteria using all" do
+    first_list_req = Google::Logging::V2::ListLogEntriesRequest.new(
+      project_ids: ["project1", "project2", "project3"],
+      filter: 'resource.type:"gce_"',
+      order_by: "timestamp"
+    )
+    first_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(3, "next_page_token"))
+    second_list_req = Google::Logging::V2::ListLogEntriesRequest.new(
+      project_ids: ["project1", "project2", "project3"],
+      filter: 'resource.type:"gce_"',
+      order_by: "timestamp",
+      page_token: "next_page_token"
+    )
+    second_list_res = Google::Logging::V2::ListLogEntriesResponse.decode_json(list_entries_json(2))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_log_entries, first_list_res, [first_list_req]
+    mock.expect :list_log_entries, second_list_res, [second_list_req]
+    logging.service.mocked_logging = mock
+
+    all_entries = logging.entries(projects: ["project1", "project2", "project3"],
+                                  filter: 'resource.type:"gce_"',
+                                  order: "timestamp").all
+
+    mock.verify
+
+    all_entries.each { |m| m.must_be_kind_of Gcloud::Logging::Entry }
+    all_entries.count.must_equal 5
+    all_entries.next?.must_equal false #wont_be :next?
   end
 
   it "paginates entries with one project" do

--- a/test/gcloud/logging/project/sinks_test.rb
+++ b/test/gcloud/logging/project/sinks_test.rb
@@ -100,6 +100,26 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
     second_sinks.next?.must_equal false #wont_be :next?
   end
 
+  it "paginates sinks with all" do
+    first_list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path)
+    first_list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))
+    second_list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path, page_token: "next_page_token")
+    second_list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(2))
+
+    mock = Minitest::Mock.new
+    mock.expect :list_sinks, first_list_res, [first_list_req]
+    mock.expect :list_sinks, second_list_res, [second_list_req]
+    logging.service.mocked_sinks = mock
+
+    all_sinks = logging.sinks.all
+
+    mock.verify
+
+    all_sinks.each { |s| s.must_be_kind_of Gcloud::Logging::Sink }
+    all_sinks.count.must_equal 5
+    all_sinks.next?.must_equal false #wont_be :next?
+  end
+
   it "paginates sinks with max set" do
     list_req = Google::Logging::V2::ListSinksRequest.new(project_name: project_path, page_size: 3)
     list_res = Google::Logging::V2::ListSinksResponse.decode_json(list_sinks_json(3, "next_page_token"))


### PR DESCRIPTION
Add `List#all` methods to Logging. Fix paginating log entries with `List#next`

[closes #561, fixes #566]