### PR TITLE
Pub/Sub Policy Error Handling

### DIFF
--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -450,6 +450,7 @@ module Gcloud
         @policy ||= begin
           ensure_connection!
           resp = connection.get_subscription_policy name
+          fail ApiError.from_response(resp) unless resp.success?
           policy = resp.data
           policy = policy.to_hash if policy.respond_to? :to_hash
           policy

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -349,6 +349,7 @@ module Gcloud
         @policy ||= begin
           ensure_connection!
           resp = connection.get_topic_policy name
+          fail ApiError.from_response(resp) unless resp.success?
           policy = resp.data
           policy = policy.to_hash if policy.respond_to? :to_hash
           policy


### PR DESCRIPTION
If the API request to retrieve an IAM policy fails then an error should be raised. Add the check for a successful response to `Topic#policy` and `Subscription#policy`.