### PR TITLE
Update Pub/Sub IAM

### DIFF
--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -507,6 +507,15 @@ module Gcloud
       #   check access for. Permissions with wildcards (such as `*` or
       #   `storage.*`) are not allowed.
       #
+      #   The permissions that can be checked on a subscription are:
+      #
+      #   * pubsub.subscriptions.consume
+      #   * pubsub.subscriptions.get
+      #   * pubsub.subscriptions.delete
+      #   * pubsub.subscriptions.update
+      #   * pubsub.subscriptions.getIamPolicy
+      #   * pubsub.subscriptions.setIamPolicy
+      #
       # @return [Array<String>] The permissions that have access.
       #
       # @example
@@ -515,10 +524,10 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   sub = pubsub.subscription "my-subscription"
-      #   perms = sub.test_permissions "projects.subscriptions.list",
-      #                                "projects.subscriptions.pull"
-      #   perms.include? "projects.subscriptions.list" #=> true
-      #   perms.include? "projects.subscriptions.pull" #=> false
+      #   perms = sub.test_permissions "pubsub.subscriptions.get",
+      #                                "pubsub.subscriptions.consume"
+      #   perms.include? "pubsub.subscriptions.get" #=> true
+      #   perms.include? "pubsub.subscriptions.consume" #=> false
       #
       def test_permissions *permissions
         permissions = Array(permissions).flatten

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -406,6 +406,16 @@ module Gcloud
       #   check access for. Permissions with wildcards (such as `*` or
       #   `storage.*`) are not allowed.
       #
+      #   The permissions that can be checked on a topic are:
+      #
+      #   * pubsub.topics.publish
+      #   * pubsub.topics.attachSubscription
+      #   * pubsub.topics.get
+      #   * pubsub.topics.delete
+      #   * pubsub.topics.update
+      #   * pubsub.topics.getIamPolicy
+      #   * pubsub.topics.setIamPolicy
+      #
       # @return [Array<Strings>] The permissions that have access.
       #
       # @example
@@ -414,10 +424,10 @@ module Gcloud
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
       #   topic = pubsub.topic "my-topic"
-      #   perms = topic.test_permissions "projects.topic.list",
-      #                                  "projects.topic.publish"
-      #   perms.include? "projects.topic.list" #=> true
-      #   perms.include? "projects.topic.publish" #=> false
+      #   perms = topic.test_permissions "pubsub.topics.get",
+      #                                  "pubsub.topics.publish"
+      #   perms.include? "pubsub.topics.get" #=> true
+      #   perms.include? "pubsub.topics.publish" #=> false
       #
       def test_permissions *permissions
         permissions = Array(permissions).flatten

--- a/test/gcloud/pubsub/subscription/policy_test.rb
+++ b/test/gcloud/pubsub/subscription/policy_test.rb
@@ -154,14 +154,14 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
     mock_connection.post "/v1/projects/#{project}/subscriptions/#{sub_name}:testIamPermissions" do |env|
       json_permissions = JSON.parse env.body
       json_permissions["permissions"].count.must_equal 2
-      json_permissions["permissions"].first.must_equal "projects.subscriptions.list"
-      json_permissions["permissions"].last.must_equal  "projects.subscriptions.pull"
+      json_permissions["permissions"].first.must_equal "pubsub.subscriptions.get"
+      json_permissions["permissions"].last.must_equal  "pubsub.subscriptions.consume"
       [200, {"Content-Type"=>"application/json"},
-       { "permissions" => ["projects.subscriptions.list"] }.to_json]
+       { "permissions" => ["pubsub.subscriptions.get"] }.to_json]
     end
 
-    permissions = subscription.test_permissions "projects.subscriptions.list",
-                                                "projects.subscriptions.pull"
-    permissions.must_equal ["projects.subscriptions.list"]
+    permissions = subscription.test_permissions "pubsub.subscriptions.get",
+                                                "pubsub.subscriptions.consume"
+    permissions.must_equal ["pubsub.subscriptions.get"]
   end
 end

--- a/test/gcloud/pubsub/topic/policy_test.rb
+++ b/test/gcloud/pubsub/topic/policy_test.rb
@@ -150,14 +150,14 @@ describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
     mock_connection.post "/v1/projects/#{project}/topics/#{topic_name}:testIamPermissions" do |env|
       json_permissions = JSON.parse env.body
       json_permissions["permissions"].count.must_equal 2
-      json_permissions["permissions"].first.must_equal "projects.topic.list"
-      json_permissions["permissions"].last.must_equal  "projects.topic.publish"
+      json_permissions["permissions"].first.must_equal "pubsub.topics.get"
+      json_permissions["permissions"].last.must_equal  "pubsub.topics.publish"
       [200, {"Content-Type"=>"application/json"},
-       { "permissions" => ["projects.topic.list"] }.to_json]
+       { "permissions" => ["pubsub.topics.get"] }.to_json]
     end
 
-    permissions = topic.test_permissions "projects.topic.list",
-                                         "projects.topic.publish"
-    permissions.must_equal ["projects.topic.list"]
+    permissions = topic.test_permissions "pubsub.topics.get",
+                                         "pubsub.topics.publish"
+    permissions.must_equal ["pubsub.topics.get"]
   end
 end


### PR DESCRIPTION
The build is failing due to a permissions change in getting and setting the IAM policy. This change adds some additional checks to the tests to ensure that the account has permissions to access and update the policy.

Correct the permissions values used in the code examples to use the correct permissions, and list the permissions values that can be checked on `test_permissions` documentation.