### PR TITLE
Add location to Bigquery::Project#create_dataset

### DIFF
--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -355,7 +355,8 @@ module Gcloud
           "friendlyName" => options[:name],
           "description" => options[:description],
           "defaultTableExpirationMs" => options[:expiration],
-          "access" => options[:access]
+          "access" => options[:access],
+          "location" => options[:location]
         }.delete_if { |_, v| v.nil? }
       end
 

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -265,6 +265,9 @@ module Gcloud
       #   [BigQuery Access
       #   Control](https://cloud.google.com/bigquery/access-control) for more
       #   information.
+      # @param [String] location The geographic location where the dataset
+      #   should reside. Possible values include `EU` and `US`. The default
+      #   value is `US`.
       # @yield [access] a block for setting rules
       # @yieldparam [Dataset::Access] access the object accepting rules
       #
@@ -308,7 +311,7 @@ module Gcloud
       #   end
       #
       def create_dataset dataset_id, name: nil, description: nil,
-                         expiration: nil, access: nil
+                         expiration: nil, access: nil, location: nil
         if block_given?
           access_builder = Dataset::Access.new connection.default_access_rules,
                                                "projectId" => project
@@ -318,7 +321,7 @@ module Gcloud
 
         ensure_connection!
         options = { name: name, description: description,
-                    expiration: expiration, access: access }
+                    expiration: expiration, access: access, location: location }
         resp = connection.insert_dataset dataset_id, options
         return Dataset.from_gapi(resp.data, connection) if resp.success?
         fail ApiError.from_response(resp)

--- a/test/gcloud/bigquery/project_test.rb
+++ b/test/gcloud/bigquery/project_test.rb
@@ -26,27 +26,31 @@ describe Gcloud::Bigquery::Project, :mock_bigquery do
     dataset.must_be_kind_of Gcloud::Bigquery::Dataset
   end
 
-  it "creates a dataset with a name and description" do
+  it "creates a dataset with options" do
     id = "my_dataset"
     name = "My Dataset"
     description = "This is my dataset"
     default_expiration = 999
+    location = "EU"
 
     mock_connection.post "/bigquery/v2/projects/#{project}/datasets" do |env|
       JSON.parse(env.body)["friendlyName"].must_equal name
       JSON.parse(env.body)["description"].must_equal description
       JSON.parse(env.body)["defaultTableExpirationMs"].must_equal default_expiration
+      JSON.parse(env.body)["location"].must_equal location
       [200, {"Content-Type"=>"application/json"},
-       create_dataset_json(id, name, description, default_expiration)]
+       create_dataset_json(id, name, description, default_expiration, location)]
     end
 
     dataset = bigquery.create_dataset id, name: name,
                                       description: description,
-                                      expiration: default_expiration
+                                      expiration: default_expiration,
+                                      location: location
     dataset.must_be_kind_of Gcloud::Bigquery::Dataset
     dataset.name.must_equal name
     dataset.description.must_equal description
     dataset.default_expiration.must_equal default_expiration
+    dataset.location.must_equal location
   end
 
   it "raises when creating a dataset with a blank id" do
@@ -300,8 +304,8 @@ describe Gcloud::Bigquery::Project, :mock_bigquery do
     job.job_id.must_equal job_id
   end
 
-  def create_dataset_json id, name = nil, description = nil, default_expiration = nil
-    random_dataset_hash(id, name, description, default_expiration).to_json
+  def create_dataset_json id, name = nil, description = nil, default_expiration = nil, location = "US"
+    random_dataset_hash(id, name, description, default_expiration, location).to_json
   end
 
   def find_dataset_json id, name = nil, description = nil, default_expiration = nil

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -292,7 +292,7 @@ class MockBigquery < Minitest::Spec
     @connection
   end
 
-  def random_dataset_hash id = nil, name = nil, description = nil, default_expiration = nil
+  def random_dataset_hash id = nil, name = nil, description = nil, default_expiration = nil, location = "US"
     id ||= "my_dataset"
     name ||= "My Dataset"
     description ||= "This is my dataset"
@@ -313,7 +313,7 @@ class MockBigquery < Minitest::Spec
       "access" => [],
       "creationTime" => Time.now.to_i*1000,
       "lastModifiedTime" => Time.now.to_i*1000,
-      "location" => "US"
+      "location" => location
     }
   end
 


### PR DESCRIPTION
Although our current policy is not to include experimental Cloud Platform API features in gcloud-ruby, this was not our strict policy when we added support for BigQuery, and the ability to read `dataset.location` at that time, making it seem inconsistent to allow setting this property. Also, as @gramos74 [commented](https://github.com/GoogleCloudPlatform/gcloud-ruby/issues/571#issuecomment-191330515) today, adding the ability to set location will bring gcloud in line with other tools:

> In fact, choosing a location is not only available via API, it is also a option when you create manually a dataset in the BigQuery web console.

[closes #571]