### PR TITLE
Make some Logging params required

### DIFF
--- a/acceptance/logging/logging_test.rb
+++ b/acceptance/logging/logging_test.rb
@@ -73,8 +73,8 @@ describe Gcloud::Logging, :logging do
   describe "Metrics" do
     it "creates, updates, refreshes, gets, lists, and deletes a metric" do
       metric = logging.create_metric "#{prefix}-metric",
-                                     description: "Metric for acceptance tsets",
-                                     filter: "severity = ALERT"
+                                     "severity = ALERT",
+                                     description: "Metric for acceptance tsets"
 
       metric.name.must_equal "#{prefix}-metric"
       metric.description.must_equal "Metric for acceptance tsets"

--- a/acceptance/logging/logging_test.rb
+++ b/acceptance/logging/logging_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Logging, :logging do
       skip
       pubsub_dest = "pubsub.googleapis.com/projects/#{logging.project}/topics/#{prefix}-topic"
       sink = logging.create_sink "#{prefix}-sink",
-                                 destination: pubsub_dest,
+                                 pubsub_dest,
                                  filter: "severity = ALERT"
 
       sink.name.must_equal "#{prefix}-sink"
@@ -60,8 +60,7 @@ describe Gcloud::Logging, :logging do
     it "lists sinks" do
       skip
       pubsub_dest = "pubsub.googleapis.com/projects/#{logging.project}/topics/#{prefix}-topic"
-      sink = logging.create_sink "#{prefix}-list-sink",
-                                 destination: pubsub_dest
+      sink = logging.create_sink "#{prefix}-list-sink", pubsub_dest
 
       logging.sinks.wont_be :empty?
       logging.sinks(max: 1).length.must_equal 1

--- a/acceptance/logging_helper.rb
+++ b/acceptance/logging_helper.rb
@@ -75,8 +75,8 @@ end
 
 def clean_up_logging_sinks_metrics
   puts "Cleaning up logging sinks and metrics after tests."
-  # $logging.sinks.collect { |s| s.name.starts_with? $prefix }.map &:delete
-  $logging.metrics.collect { |m| m.name.starts_with? $prefix }.map &:delete
+  # $logging.sinks.select { |s| s.name.start_with? $prefix }.map &:delete
+  $logging.metrics.select { |m| m.name.start_with? $prefix }.map &:delete
 rescue => e
   puts "Error while cleaning up logging sinks and metrics after tests.\n\n#{e}"
 end

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -156,10 +156,9 @@ module Gcloud
   # storage = gcloud.storage
   #
   # bucket = storage.create_bucket "my-syslog-bucket"
-  # destination = "storage.googleapis.com/#{bucket.id}"
   #
   # sink = logging.create_sink "my-sink",
-  #                            destination: destination,
+  #                            "storage.googleapis.com/#{bucket.id}",
   #                            filter: "log:syslog"
   # ```
   #

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -201,7 +201,7 @@ module Gcloud
   #
   # gcloud = Gcloud.new
   # logging = gcloud.logging
-  # metric = logging.create_metric "errors", filter: "severity>=ERROR"
+  # metric = logging.create_metric "errors", "severity>=ERROR"
   # ```
   #
   # ### Listing metrics

--- a/lib/gcloud/logging/metric.rb
+++ b/lib/gcloud/logging/metric.rb
@@ -35,7 +35,7 @@ module Gcloud
     #
     #   gcloud = Gcloud.new
     #   logging = gcloud.logging
-    #   metric = logging.create_metric "errors", filter: "severity>=ERROR"
+    #   metric = logging.create_metric "errors", "severity>=ERROR"
     #
     class Metric
       ##

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -573,8 +573,8 @@ module Gcloud
       #   name.
       # @param [String] filter An [advanced logs
       #   filter](https://cloud.google.com/logging/docs/view/advanced_filters).
-      # @param [String] description A description of this metric, which is used
-      #   in documentation.
+      # @param [String, nil] description A description of this metric, which is
+      #   used in documentation.
       #
       # @return [Gcloud::Logging::Metric]
       #
@@ -583,11 +583,11 @@ module Gcloud
       #
       #   gcloud = Gcloud.new
       #   logging = gcloud.logging
-      #   metric = logging.create_metric "errors", filter: "severity>=ERROR"
+      #   metric = logging.create_metric "errors", "severity>=ERROR"
       #
-      def create_metric name, description: nil, filter: nil
+      def create_metric name, filter, description: nil
         ensure_service!
-        grpc = service.create_metric name, description, filter
+        grpc = service.create_metric name, filter, description
         Metric.from_grpc grpc, service
       rescue GRPC::BadStatus => e
         raise Gcloud::Error.from_error(e)

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -445,7 +445,7 @@ module Gcloud
       #   See [About
       #   sinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs#about_sinks)
       #   for examples.
-      # @param [String] filter An [advanced logs
+      # @param [String, nil] filter An [advanced logs
       #  filter](https://cloud.google.com/logging/docs/view/advanced_filters)
       #  that defines the log entries to be exported. The filter must be
       #  consistent with the log entry format designed by the `version`
@@ -466,13 +466,12 @@ module Gcloud
       #   storage = gcloud.storage
       #
       #   bucket = storage.create_bucket "my-syslog-bucket"
-      #   destination = "storage.googleapis.com/#{bucket.id}"
       #
       #   sink = logging.create_sink "my-sink",
-      #                              destination: destination,
+      #                              "storage.googleapis.com/#{bucket.id}",
       #                              filter: "log:syslog"
       #
-      def create_sink name, destination: nil, filter: nil, version: :unspecified
+      def create_sink name, destination, filter: nil, version: :unspecified
         version = Sink.resolve_version version
         ensure_service!
         grpc = service.create_sink name, destination, filter, version

--- a/lib/gcloud/logging/service.rb
+++ b/lib/gcloud/logging/service.rb
@@ -174,7 +174,7 @@ module Gcloud
         metrics.list_log_metrics list_req
       end
 
-      def create_metric name, description, filter
+      def create_metric name, filter, description
         metric_params = {
           name: name,
           description: description,

--- a/lib/gcloud/logging/sink.rb
+++ b/lib/gcloud/logging/sink.rb
@@ -42,10 +42,9 @@ module Gcloud
     #   storage = gcloud.storage
     #
     #   bucket = storage.create_bucket "my-syslog-bucket"
-    #   destination = "storage.googleapis.com/#{bucket.id}"
     #
     #   sink = logging.create_sink "my-sink",
-    #                              destination: destination,
+    #                              "storage.googleapis.com/#{bucket.id}",
     #                              filter: "log:syslog"
     #
     class Sink

--- a/test/gcloud/logging/project/sinks_test.rb
+++ b/test/gcloud/logging/project/sinks_test.rb
@@ -158,24 +158,27 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
 
   it "creates a sink" do
     new_sink_name = "new-sink-#{Time.now.to_i}"
-    new_sink = Google::Logging::V2::LogSink.new name: new_sink_name
+    new_sink_destination = "storage.googleapis.com/new-sinks"
+    new_sink = Google::Logging::V2::LogSink.new name: new_sink_name, destination: new_sink_destination
+
     create_req = Google::Logging::V2::CreateSinkRequest.new(
       project_name: "projects/test",
       sink: new_sink
     )
-    create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge("name" => new_sink_name).to_json)
+    create_res = Google::Logging::V2::LogSink.decode_json(empty_sink_hash.merge("name" => new_sink_name,
+                                                                                "destination" => new_sink_destination).to_json)
 
     mock = Minitest::Mock.new
     mock.expect :create_sink, create_res, [create_req]
     logging.service.mocked_sinks = mock
 
-    sink = logging.create_sink new_sink_name
+    sink = logging.create_sink new_sink_name, new_sink_destination
 
     mock.verify
 
     sink.must_be_kind_of Gcloud::Logging::Sink
     sink.name.must_equal new_sink_name
-    sink.destination.must_be :empty?
+    sink.destination.must_equal new_sink_destination
     sink.filter.must_be :empty?
     sink.must_be :unspecified?
   end
@@ -204,8 +207,10 @@ describe Gcloud::Logging::Project, :sinks, :mock_logging do
     mock.expect :create_sink, create_res, [create_req]
     logging.service.mocked_sinks = mock
 
-    sink = logging.create_sink new_sink_name, destination: new_sink_destination,
-      filter: new_sink_filter, version: :v2
+    sink = logging.create_sink new_sink_name,
+                               new_sink_destination,
+                               filter: new_sink_filter,
+                               version: :v2
 
     mock.verify
 


### PR DESCRIPTION
Both `Project#create_metric` and `Project#create_sink` contained optional keyword arguments that need to be required parameters.

This PR also fixes a small error in Logging acceptance test resource cleanup.

[closes #574, #575]