### PR TITLE
Add Logging Retry/Backoff

### DIFF
--- a/lib/gcloud/logging/service.rb
+++ b/lib/gcloud/logging/service.rb
@@ -67,7 +67,7 @@ module Gcloud
 
         list_req = Google::Logging::V2::ListLogEntriesRequest.new(list_params)
 
-        logging.list_log_entries list_req
+        backoff { logging.list_log_entries list_req }
       end
 
       def write_entries entries, log_name: nil, resource: nil, labels: nil
@@ -85,7 +85,7 @@ module Gcloud
 
         write_req = Google::Logging::V2::WriteLogEntriesRequest.new write_params
 
-        logging.write_log_entries write_req
+        backoff { logging.write_log_entries write_req }
       end
 
       def delete_log name
@@ -93,7 +93,7 @@ module Gcloud
           log_name: log_path(name)
         )
 
-        logging.delete_log delete_req
+        backoff { logging.delete_log delete_req }
       end
 
       def list_resource_descriptors token: nil, max: nil
@@ -105,7 +105,7 @@ module Gcloud
           Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new(
             list_params)
 
-        logging.list_monitored_resource_descriptors list_req
+        backoff { logging.list_monitored_resource_descriptors list_req }
       end
 
       def list_sinks token: nil, max: nil
@@ -116,7 +116,7 @@ module Gcloud
 
         list_req = Google::Logging::V2::ListSinksRequest.new(list_params)
 
-        sinks.list_sinks list_req
+        backoff { sinks.list_sinks list_req }
       end
 
       def create_sink name, destination, filter, version
@@ -130,7 +130,7 @@ module Gcloud
           sink: Google::Logging::V2::LogSink.new(sink_params)
         )
 
-        sinks.create_sink create_req
+        backoff { sinks.create_sink create_req }
       end
 
       def get_sink name
@@ -138,7 +138,7 @@ module Gcloud
           sink_name: sink_path(name)
         )
 
-        sinks.get_sink get_req
+        backoff { sinks.get_sink get_req }
       end
 
       def update_sink name, destination, filter, version
@@ -152,7 +152,7 @@ module Gcloud
           sink: Google::Logging::V2::LogSink.new(sink_params)
         )
 
-        sinks.update_sink update_req
+        backoff { sinks.update_sink update_req }
       end
 
       def delete_sink name
@@ -171,7 +171,7 @@ module Gcloud
 
         list_req = Google::Logging::V2::ListLogMetricsRequest.new(list_params)
 
-        metrics.list_log_metrics list_req
+        backoff { metrics.list_log_metrics list_req }
       end
 
       def create_metric name, filter, description
@@ -186,7 +186,7 @@ module Gcloud
           metric: Google::Logging::V2::LogMetric.new(metric_params)
         )
 
-        metrics.create_log_metric create_req
+        backoff { metrics.create_log_metric create_req }
       end
 
       def get_metric name
@@ -194,7 +194,7 @@ module Gcloud
           metric_name: metric_path(name)
         )
 
-        metrics.get_log_metric get_req
+        backoff { metrics.get_log_metric get_req }
       end
 
       def update_metric name, description, filter
@@ -209,7 +209,7 @@ module Gcloud
           metric: Google::Logging::V2::LogMetric.new(metric_params)
         )
 
-        metrics.update_log_metric update_req
+        backoff { metrics.update_log_metric update_req }
       end
 
       def delete_metric name
@@ -217,7 +217,7 @@ module Gcloud
           metric_name: metric_path(name)
         )
 
-        metrics.delete_log_metric delete_req
+        backoff { metrics.delete_log_metric delete_req }
       end
 
       def inspect
@@ -245,6 +245,12 @@ module Gcloud
       def metric_path metric_name
         return metric_name if metric_name.to_s.include? "/"
         "#{project_path}/metrics/#{metric_name}"
+      end
+
+      def backoff options = {}
+        Gcloud::Backoff.new(options).execute_grpc do
+          yield
+        end
       end
     end
   end

--- a/lib/gcloud/logging/service.rb
+++ b/lib/gcloud/logging/service.rb
@@ -40,19 +40,19 @@ module Gcloud
 
       def logging
         return mocked_logging if mocked_logging
-        Google::Logging::V2::LoggingServiceV2::Stub.new host, creds
+        @logging ||= Google::Logging::V2::LoggingServiceV2::Stub.new host, creds
       end
       attr_accessor :mocked_logging
 
       def sinks
         return mocked_sinks if mocked_sinks
-        Google::Logging::V2::ConfigServiceV2::Stub.new host, creds
+        @sinks ||= Google::Logging::V2::ConfigServiceV2::Stub.new host, creds
       end
       attr_accessor :mocked_sinks
 
       def metrics
         return mocked_metrics if mocked_metrics
-        Google::Logging::V2::MetricsServiceV2::Stub.new host, creds
+        @metrics ||= Google::Logging::V2::MetricsServiceV2::Stub.new host, creds
       end
       attr_accessor :mocked_metrics
 

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -409,7 +409,7 @@ module Gcloud
       end
 
       def incremental_backoff options = {}
-        Gcloud::Backoff.new(options).execute do
+        Gcloud::Backoff.new(options).execute_gapi do
           yield
         end
       end

--- a/test/gcloud/logging/backoff_test.rb
+++ b/test/gcloud/logging/backoff_test.rb
@@ -1,0 +1,67 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe "Gcloud Logging Backoff", :mock_logging do
+  it "retries when the session times out" do
+    metric_name = "session-timed-out-metric"
+
+    stub = Object.new
+    def stub.get_log_metric *args
+      @tries ||= 0
+      @tries += 1
+      raise GRPC::BadStatus.new 14, "goaway" if @tries < 3
+      return Google::Logging::V2::LogMetric.decode_json(
+        "{\"name\":\"session-timed-out-metric\",\"description\":\"The servere errors metric\",\"filter\":\"logName:syslog AND severity>=ERROR\"}"
+      )
+    end
+    logging.service.mocked_metrics = stub
+
+    metric = nil
+    assert_backoff_sleep 1, 2 do
+      metric = logging.metric metric_name
+    end
+
+    metric.must_be_kind_of Gcloud::Logging::Metric
+    metric.name.must_equal metric_name
+  end
+
+  it "raises after enough retries" do
+    metric_name = "session-timed-out-metric"
+
+    stub = Object.new
+    def stub.get_log_metric *args
+      raise GRPC::BadStatus.new 14, "goaway"
+    end
+    logging.service.mocked_metrics = stub
+
+    assert_backoff_sleep 1, 2, 3, 4, 5 do
+      expect { logging.metric metric_name }.must_raise Gcloud::UnavailableError
+    end
+  end
+
+  def assert_backoff_sleep *args
+    mock = Minitest::Mock.new
+    args.each { |intv| mock.expect :sleep, nil, [intv] }
+    callback = ->(retries) { mock.sleep retries }
+    backoff = Gcloud::Backoff.new retries: 5, backoff: callback
+
+    Gcloud::Backoff.stub :new, backoff do
+      yield
+    end
+
+    mock.verify
+  end
+end


### PR DESCRIPTION
This PR adds logic to Gcloud::Backoff to handle GRPC goaway errors. This is common when a GRPC connection times out, and the client tries to use the connection. The server sends a goaway response and the client then retries the call on a new connection.