### PR TITLE
Add backoff to Logging::Service#delete_sink

### DIFF
--- a/lib/gcloud/logging/service.rb
+++ b/lib/gcloud/logging/service.rb
@@ -160,7 +160,7 @@ module Gcloud
           sink_name: sink_path(name)
         )
 
-        sinks.delete_sink delete_req
+        backoff { sinks.delete_sink delete_req }
       end
 
       def list_metrics token: nil, max: nil


### PR DESCRIPTION
I encountered the error below while trying to delete a Sink. @blowmage observed that `#delete_sink` was the only `Service` API operation missing the `backoff` block. This PR adds it.

```sh
irb(main):010:0> sink.delete
D0316 16:23:51.687952000 140735277699072 chttp2_transport.c:683] got goaway [0]: 73 65 73 73 69 6f 6e 5f 74 69 6d 65 64 5f 6f 75 74 'session_timed_out'
Gcloud::UnavailableError: 14:
	from /Users/quartzmo/code/google/codez/gcloud-ruby/lib/gcloud/logging/sink.rb:194:in `rescue in delete'
	from /Users/quartzmo/code/google/codez/gcloud-ruby/lib/gcloud/logging/sink.rb:190:in `delete'
```