### PR TITLE
Add links to Service guides

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -6,7 +6,7 @@ The `gcloud` library is installable through rubygems:
 $ gem install gcloud
 ```
 
-Gcloud aims to make authentication as simple as possible. Google Cloud requires a **Project ID** and **Service Account Credentials** to connect to the APIs. You can learn more about various options for connection on the [Authentication Guide](AUTHENTICATION).
+Gcloud aims to make authentication as simple as possible. Google Cloud requires a **Project ID** and **Service Account Credentials** to connect to the APIs. You can learn more about various options for connection on the <a ui-sref="docs.guides({ guideId: 'authentication' })" href="AUTHENTICATION">Authentication Guide</a>.
 
 # BigQuery
 

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -35,6 +35,10 @@ module Gcloud
   ##
   # Creates a new object for connecting to Google Cloud.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Project identifier for the Pub/Sub service you are
   #   connecting to.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
@@ -63,6 +67,10 @@ module Gcloud
   ##
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
+  #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
   #
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
   #   set of resources and operations that the connection can access. See [Using
@@ -105,6 +113,10 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @see https://cloud.google.com/storage/docs/authentication#oauth Storage
   #   OAuth 2.0 Authentication
   #
@@ -143,6 +155,10 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
   #   set of resources and operations that the connection can access. See [Using
   #   OAuth 2.0 to Access Google
@@ -177,6 +193,10 @@ module Gcloud
   ##
   # Creates a new object for connecting to the BigQuery service.
   # Each call creates a new connection.
+  #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
   #
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
   #   set of resources and operations that the connection can access. See [Using
@@ -215,6 +235,10 @@ module Gcloud
   ##
   # Creates a new object for connecting to the DNS service.
   # Each call creates a new connection.
+  #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
   #
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
   #   set of resources and operations that the connection can access. See [Using
@@ -257,6 +281,10 @@ module Gcloud
   # Creates a new object for connecting to the Resource Manager service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
   #   set of resources and operations that the connection can access. See [Using
   #   OAuth 2.0 to Access Google
@@ -295,6 +323,10 @@ module Gcloud
   # Creates a new object for connecting to the Search service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
   #   set of resources and operations that the connection can access. See [Using
   #   OAuth 2.0 to Access Google
@@ -318,6 +350,10 @@ module Gcloud
   ##
   # Creates a new object for connecting to the Logging service.
   # Each call creates a new connection.
+  #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
   #
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
   #   set of resources and operations that the connection can access. See [Using

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -27,8 +27,9 @@ require "gcloud/version"
 # information, or if you are running on Google Compute Engine this configuration
 # is taken care of for you.
 #
-# You can learn more about various options for connection on the
-# [Authentication Guide](AUTHENTICATION).
+# You can learn more about various options for connection on the <a
+# ui-sref="docs.guides({ guideId: 'authentication' })"
+# href="AUTHENTICATION">Authentication Guide</a>.
 #
 module Gcloud
   ##

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -66,7 +66,8 @@ module Gcloud
   # the project and credential information to connect to the BigQuery service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you. You can read more about the options for connecting in the
-  # [Authentication Guide](../AUTHENTICATION).
+  # <a ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="../AUTHENTICATION">Authentication Guide</a>.
   #
   # To help you get started quickly, the first few examples below use a public
   # dataset provided by Google. As soon as you have [signed

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -21,6 +21,10 @@ module Gcloud
   # Creates a new `Project` instance connected to the BigQuery service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Identifier for a BigQuery project. If not present,
   #   the default project for the credentials is used.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -62,7 +62,7 @@ module Gcloud
   # BigQuery?](https://cloud.google.com/bigquery/what-is-bigquery).
   #
   # Gcloud's goal is to provide an API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud#bigquery. You can provide
+  # Rubyists. Authentication is handled by {Gcloud#bigquery}. You can provide
   # the project and credential information to connect to the BigQuery service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you. You can read more about the options for connecting in the
@@ -177,7 +177,7 @@ module Gcloud
   #
   # Once you have determined that the job is done and has not failed, you can
   # obtain an instance of Gcloud::Bigquery::QueryData by calling
-  # Gcloud::Bigquery::QueryJob#query_results. The query results for both of
+  # {Gcloud::Bigquery::QueryJob#query_results}. The query results for both of
   # the above examples are stored in temporary tables with a lifetime of about
   # 24 hours. See the final example below for a demonstration of how to store
   # query results in a permanent table.

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -154,8 +154,8 @@ module Gcloud
   # Because you probably should not block for most BigQuery operations,
   # including querying as well as importing, exporting, and copying data, the
   # BigQuery API enables you to manage longer-running jobs. In the asynchronous
-  # approach to running a query, an instance of Gcloud::Bigquery::QueryJob is
-  # returned, rather than an instance of Gcloud::Bigquery::QueryData.
+  # approach to running a query, an instance of {Gcloud::Bigquery::QueryJob} is
+  # returned, rather than an instance of {Gcloud::Bigquery::QueryData}.
   #
   # ```ruby
   # require "gcloud"
@@ -176,7 +176,7 @@ module Gcloud
   # ```
   #
   # Once you have determined that the job is done and has not failed, you can
-  # obtain an instance of Gcloud::Bigquery::QueryData by calling
+  # obtain an instance of {Gcloud::Bigquery::QueryData} by calling
   # {Gcloud::Bigquery::QueryJob#query_results}. The query results for both of
   # the above examples are stored in temporary tables with a lifetime of about
   # 24 hours. See the final example below for a demonstration of how to store
@@ -185,7 +185,8 @@ module Gcloud
   # ## Creating Datasets and Tables
   #
   # The first thing you need to do in a new BigQuery project is to create a
-  # Gcloud::Bigquery::Dataset. Datasets hold tables and control access to them.
+  # {Gcloud::Bigquery::Dataset}. Datasets hold tables and control access to
+  # them.
   #
   # ```ruby
   # require "gcloud/bigquery"
@@ -308,7 +309,7 @@ module Gcloud
   #
   # ### A note about large uploads
   #
-  # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to
+  # You may encounter a Broken pipe (`Errno::EPIPE`) error when attempting to
   # upload large files. To avoid this problem, add the
   # [httpclient](https://rubygems.org/gems/httpclient) gem to your project, and
   # the line (or lines) of configuration shown below. These lines must execute

--- a/lib/gcloud/bigquery/dataset.rb
+++ b/lib/gcloud/bigquery/dataset.rb
@@ -560,6 +560,7 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
+      #
       #   * `needed` - Create the table if it does not exist.
       #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
@@ -567,6 +568,7 @@ module Gcloud
       #   destination table already exists.
       #
       #   The following values are supported:
+      #
       #   * `truncate` - BigQuery overwrites the table data.
       #   * `append` - BigQuery appends the data to the table.
       #   * `empty` - A 'duplicate' error is returned in the job result if the

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -106,6 +106,7 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
+      #
       #   * `needed` - Create the table if it does not exist.
       #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
@@ -113,6 +114,7 @@ module Gcloud
       #   destination table already exists.
       #
       #   The following values are supported:
+      #
       #   * `truncate` - BigQuery overwrites the table data.
       #   * `append` - BigQuery appends the data to the table.
       #   * `empty` - A 'duplicate' error is returned in the job result if the
@@ -425,6 +427,7 @@ module Gcloud
       # @param [String] filter A filter for job state.
       #
       #   Acceptable values are:
+      #
       #   * `done` - Finished jobs
       #   * `pending` - Pending jobs
       #   * `running` - Running jobs

--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -450,6 +450,7 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
+      #
       #   * `needed` - Create the table if it does not exist.
       #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
@@ -457,6 +458,7 @@ module Gcloud
       #   the destination table. The default value is `empty`.
       #
       #   The following values are supported:
+      #
       #   * `truncate` - BigQuery overwrites the table data.
       #   * `append` - BigQuery appends the data to the table.
       #   * `empty` - An error will be returned if the destination table already
@@ -509,6 +511,7 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
+      #
       #   * `needed` - Create the table if it does not exist.
       #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
@@ -516,6 +519,7 @@ module Gcloud
       #   the destination table. The default value is `empty`.
       #
       #   The following values are supported:
+      #
       #   * `truncate` - BigQuery overwrites the table data.
       #   * `append` - BigQuery appends the data to the table.
       #   * `empty` - An error will be returned if the destination table already
@@ -549,6 +553,7 @@ module Gcloud
       #   `csv`.
       #
       #   The following values are supported:
+      #
       #   * `csv` - CSV
       #   * `json` - [Newline-delimited JSON](http://jsonlines.org/)
       #   * `avro` - [Avro](http://avro.apache.org/)
@@ -601,6 +606,7 @@ module Gcloud
       #   `csv`.
       #
       #   The following values are supported:
+      #
       #   * `csv` - CSV
       #   * `json` - [Newline-delimited JSON](http://jsonlines.org/)
       #   * `avro` - [Avro](http://avro.apache.org/)
@@ -609,6 +615,7 @@ module Gcloud
       #   new tables.
       #
       #   The following values are supported:
+      #
       #   * `needed` - Create the table if it does not exist.
       #   * `never` - The table must already exist. A 'notFound' error is
       #     raised if the table does not exist.
@@ -616,6 +623,7 @@ module Gcloud
       #   the table. The default value is `empty`.
       #
       #   The following values are supported:
+      #
       #   * `truncate` - BigQuery overwrites the table data.
       #   * `append` - BigQuery appends the data to the table.
       #   * `empty` - An error will be returned if the table already contains

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -72,7 +72,7 @@ module Gcloud
   # make the most of using Datastore.
   #
   # Gcloud's goal is to provide a API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud#datastore. You can provide
+  # Rubyists. Authentication is handled by {Gcloud#datastore}. You can provide
   # the project and credential information to connect to the Datastore service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you.
@@ -102,7 +102,7 @@ module Gcloud
   # that can be used to model relationships. The simplest Key has a string
   # <tt>kind</tt> value, and either a numeric <tt>id</tt> value, or a string
   # <tt>name</tt> value. A single record can be retrieved by calling
-  # Gcloud::Datastore::Dataset#find and passing the parts of the key:
+  # {Gcloud::Datastore::Dataset#find} and passing the parts of the key:
   #
   # ```ruby
   # require "gcloud"
@@ -112,7 +112,7 @@ module Gcloud
   # entity = dataset.find "Task", "start"
   # ```
   #
-  # Optionally, Gcloud::Datastore::Dataset#find can be given a Key object:
+  # Optionally, {Gcloud::Datastore::Dataset#find} can be given a Key object:
   #
   # ```ruby
   # require "gcloud"
@@ -123,12 +123,12 @@ module Gcloud
   # entity = dataset.find key
   # ```
   #
-  # See Gcloud::Datastore::Dataset#find
+  # See {Gcloud::Datastore::Dataset#find}
   #
   # ## Querying Records
   #
   # Multiple records can be found that match criteria.
-  # (See Gcloud::Datastore::Query#where)
+  # (See {Gcloud::Datastore::Query#where})
   #
   # ```ruby
   # require "gcloud"
@@ -140,7 +140,7 @@ module Gcloud
   # active_lists = dataset.run query
   # ```
   #
-  # Records can also be ordered. (See Gcloud::Datastore::Query#order)
+  # Records can also be ordered. (See {Gcloud::Datastore::Query#order})
   #
   # ```ruby
   # require "gcloud"
@@ -154,7 +154,7 @@ module Gcloud
   # ```
   #
   # The number of records returned can be specified.
-  # (See Gcloud::Datastore::Query#limit)
+  # (See {Gcloud::Datastore::Query#limit})
   #
   # ```ruby
   # require "gcloud"
@@ -169,7 +169,7 @@ module Gcloud
   # ```
   #
   # Records' Key structures can also be queried.
-  # (See Gcloud::Datastore::Query#ancestor)
+  # (See {Gcloud::Datastore::Query#ancestor})
   #
   # ```ruby
   # require "gcloud"
@@ -183,7 +183,7 @@ module Gcloud
   # items = dataset.run query
   # ```
   #
-  # See Gcloud::Datastore::Query and Gcloud::Datastore::Dataset#run
+  # See Gcloud::Datastore::Query and {Gcloud::Datastore::Dataset#run}
   #
   # ## Paginating Records
   #
@@ -220,7 +220,7 @@ module Gcloud
   #
   # ## Creating Records
   #
-  # New entities can be created and persisted buy calling Dataset#save.
+  # New entities can be created and persisted buy calling {Dataset#save}.
   # The entity must have a Key to be saved. If the Key is incomplete then
   # it will be completed when saved.
   #
@@ -242,7 +242,7 @@ module Gcloud
   # Entities hold properties. A property has a name that is a string or symbol,
   # and a value that is an object. Most value objects are supported, including
   # String, Integer, Date, Time, and even other Entity or Key objects. Changes
-  # to the Entity's properties are persisted by calling Dataset#save.
+  # to the Entity's properties are persisted by calling {Dataset#save}.
   #
   # ```ruby
   # require "gcloud"
@@ -260,8 +260,8 @@ module Gcloud
   #
   # ## Deleting Records
   #
-  # Entities can be removed from Datastore by calling Dataset#delete and passing
-  # the Entity object or the entity's Key object.
+  # Entities can be removed from Datastore by calling {Dataset#delete} and
+  # passing the Entity object or the entity's Key object.
   #
   # ```ruby
   # require "gcloud"
@@ -275,7 +275,7 @@ module Gcloud
   # ## Transactions
   #
   # Complex logic can be wrapped in a Transaction. All queries and updates
-  # within the Dataset#transaction block are run within the transaction scope,
+  # within the {Dataset#transaction} block are run within the transaction scope,
   # and will be automatically committed when the block completes.
   #
   # ```ruby
@@ -326,7 +326,7 @@ module Gcloud
   # ```
   #
   # See Gcloud::Datastore::Transaction and
-  # Gcloud::Datastore::Dataset#transaction
+  # {Gcloud::Datastore::Dataset#transaction}
   module Datastore
   end
 end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -225,9 +225,9 @@ module Gcloud
   #
   # ## Creating Records
   #
-  # New entities can be created and persisted buy calling {Dataset#save}.
-  # The entity must have a Key to be saved. If the Key is incomplete then
-  # it will be completed when saved.
+  # New entities can be created and persisted buy calling
+  # {Gcloud::Datastore::Dataset#save}. The entity must have a Key to be saved.
+  # If the Key is incomplete then it will be completed when saved.
   #
   # ```ruby
   # require "gcloud"
@@ -247,7 +247,8 @@ module Gcloud
   # Entities hold properties. A property has a name that is a string or symbol,
   # and a value that is an object. Most value objects are supported, including
   # String, Integer, Date, Time, and even other Entity or Key objects. Changes
-  # to the Entity's properties are persisted by calling {Dataset#save}.
+  # to the Entity's properties are persisted by calling
+  # {Gcloud::Datastore::Dataset#save}.
   #
   # ```ruby
   # require "gcloud"
@@ -265,8 +266,9 @@ module Gcloud
   #
   # ## Deleting Records
   #
-  # Entities can be removed from Datastore by calling {Dataset#delete} and
-  # passing the Entity object or the entity's Key object.
+  # Entities can be removed from Datastore by calling
+  # {Gcloud::Datastore::Dataset#delete} and passing the Entity object or the
+  # entity's Key object.
   #
   # ```ruby
   # require "gcloud"
@@ -280,8 +282,9 @@ module Gcloud
   # ## Transactions
   #
   # Complex logic can be wrapped in a Transaction. All queries and updates
-  # within the {Dataset#transaction} block are run within the transaction scope,
-  # and will be automatically committed when the block completes.
+  # within the {Gcloud::Datastore::Dataset#transaction} block are run within the
+  # transaction scope, and will be automatically committed when the block
+  # completes.
   #
   # ```ruby
   # require "gcloud"

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -88,8 +88,9 @@ module Gcloud
   # dataset.save entity
   # ```
   #
-  # You can learn more about various options for connection on the
-  # [Authentication Guide](../AUTHENTICATION).
+  # You can learn more about various options for connection on the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="../AUTHENTICATION">Authentication Guide</a>.
   #
   # To learn more about Datastore, read the
   # [Google Cloud Datastore Concepts Overview

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -183,7 +183,7 @@ module Gcloud
   # items = dataset.run query
   # ```
   #
-  # See Gcloud::Datastore::Query and {Gcloud::Datastore::Dataset#run}
+  # See {Gcloud::Datastore::Query} and {Gcloud::Datastore::Dataset#run}
   #
   # ## Paginating Records
   #
@@ -215,8 +215,8 @@ module Gcloud
   # end
   # ```
   #
-  # See Gcloud::Datastore::Dataset::LookupResults and
-  # Gcloud::Datastore::Dataset::QueryResults
+  # See {Gcloud::Datastore::Dataset::LookupResults} and
+  # {Gcloud::Datastore::Dataset::QueryResults}
   #
   # ## Creating Records
   #
@@ -325,7 +325,7 @@ module Gcloud
   # end
   # ```
   #
-  # See Gcloud::Datastore::Transaction and
+  # See {Gcloud::Datastore::Transaction} and
   # {Gcloud::Datastore::Dataset#transaction}
   module Datastore
   end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -24,6 +24,10 @@ module Gcloud
   # Creates a new object for connecting to the Datastore service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Dataset identifier for the Datastore you are
   #   connecting to.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -20,7 +20,7 @@ module Gcloud
     #
     # Special Connection instance for running transactions.
     #
-    # See {Gcloud::Datastore::Dataset.transaction}
+    # See {Gcloud::Datastore::Dataset#transaction}
     class Transaction < Dataset
       attr_reader :id
 

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -65,7 +65,7 @@ module Gcloud
   # DNS?](https://cloud.google.com/dns/what-is-cloud-dns).
   #
   # Gcloud's goal is to provide an API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud#dns. You can provide
+  # Rubyists. Authentication is handled by {Gcloud#dns}. You can provide
   # the project and credential information to connect to the Cloud DNS service,
   # or if you are running on Google Compute Engine this configuration is taken
   # care of for you. You can read more about the options for connecting in the
@@ -74,7 +74,7 @@ module Gcloud
   # ## Creating Zones
   #
   # To get started with Google Cloud DNS, use your DNS Project to create a new
-  # Zone. The second argument to Project#create_zone must be a unique
+  # Zone. The second argument to {Project#create_zone} must be a unique
   # domain name for which you can [verify
   # ownership](https://www.google.com/webmasters/verification/home). Substitute
   # a domain name of your own (ending with a dot to signify that it is [fully
@@ -137,14 +137,14 @@ module Gcloud
   # zone.records.first.data #=> ["ns-cloud-d1.googledomains.com.", ...]
   # ```
   #
-  # Note that Record#data returns an array. The Cloud DNS service only allows
+  # Note that {Record#data} returns an array. The Cloud DNS service only allows
   # the zone to have one Record instance for each name and type combination. It
   # supports multiple "resource records" (in this case, the four nameserver
   # addresses) via this `data` collection.
   #
   # ## Managing Records
   #
-  # You can easily add your own records to the zone. Each call to Zone#add
+  # You can easily add your own records to the zone. Each call to {Zone#add}
   # results in a new Cloud DNS Change instance.
   #
   # ```ruby
@@ -162,7 +162,7 @@ module Gcloud
   # of authority (SOA) record should be updated with a higher serial number. The
   # gcloud library automates this update for you, deleting the old SOA record
   # and adding an updated one, as shown in the example above. You can disable or
-  # modify this behavior, of course. See Zone#update for details.
+  # modify this behavior, of course. See {Zone#update} for details.
   #
   # You can retrieve records by name and type. The name argument can be a
   # subdomain (e.g., `www`) fragment for convenience, but notice that the
@@ -178,7 +178,7 @@ module Gcloud
   # records.first.name #=> "www.example.com."
   # ```
   #
-  # You can use Zone#replace to update the `ttl` and `data` for a record.
+  # You can use {Zone#replace} to update the `ttl` and `data` for a record.
   #
   # ```ruby
   # require "gcloud"
@@ -189,8 +189,8 @@ module Gcloud
   # change = zone.replace "www", "A", 86400, ["5.6.7.8"]
   # ```
   #
-  # Or, you can use Zone#modify to update just the `ttl` or `data`, without the
-  # risk of inadvertently changing values that you wish to leave unchanged.
+  # Or, you can use {Zone#modify} to update just the `ttl` or `data`, without
+  # the risk of inadvertently changing values that you wish to leave unchanged.
   #
   # ```ruby
   # require "gcloud"
@@ -216,8 +216,8 @@ module Gcloud
   # ```
   #
   # The best way to add, remove, and update multiple records in a single
-  # [transaction](https://cloud.google.com/dns/records) is to call Zone#update
-  # with a block. See Zone::Transaction.
+  # [transaction](https://cloud.google.com/dns/records) is to call {Zone#update}
+  # with a block. See {Zone::Transaction}.
   #
   # ```ruby
   # require "gcloud"
@@ -236,7 +236,7 @@ module Gcloud
   # end
   # ```
   #
-  # Finally, you can add and delete records by reference, using Zone#update.
+  # Finally, you can add and delete records by reference, using {Zone#update}.
   #
   # ```ruby
   # require "gcloud"

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -21,6 +21,10 @@ module Gcloud
   # Creates a new `Project` instance connected to the DNS service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Identifier for a DNS project. If not present, the
   #   default project for the credentials is used.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -65,11 +65,12 @@ module Gcloud
   # DNS?](https://cloud.google.com/dns/what-is-cloud-dns).
   #
   # Gcloud's goal is to provide an API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by {Gcloud#dns}. You can provide
-  # the project and credential information to connect to the Cloud DNS service,
-  # or if you are running on Google Compute Engine this configuration is taken
-  # care of for you. You can read more about the options for connecting in the
-  # [Authentication Guide](../AUTHENTICATION).
+  # Rubyists. Authentication is handled by {Gcloud#dns}. You can provide the
+  # project and credential information to connect to the Cloud DNS service, or
+  # if you are running on Google Compute Engine this configuration is taken care
+  # of for you. You can read more about the options for connecting in the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="../AUTHENTICATION">Authentication Guide</a>.
   #
   # ## Creating Zones
   #

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -79,8 +79,8 @@ module Gcloud
   # ## Creating Zones
   #
   # To get started with Google Cloud DNS, use your DNS Project to create a new
-  # Zone. The second argument to {Project#create_zone} must be a unique
-  # domain name for which you can [verify
+  # Zone. The second argument to {Gcloud::Dns::Project#create_zone} must be a
+  # unique domain name for which you can [verify
   # ownership](https://www.google.com/webmasters/verification/home). Substitute
   # a domain name of your own (ending with a dot to signify that it is [fully
   # qualified](https://en.wikipedia.org/wiki/Fully_qualified_domain_name)) as
@@ -142,15 +142,15 @@ module Gcloud
   # zone.records.first.data #=> ["ns-cloud-d1.googledomains.com.", ...]
   # ```
   #
-  # Note that {Record#data} returns an array. The Cloud DNS service only allows
-  # the zone to have one Record instance for each name and type combination. It
-  # supports multiple "resource records" (in this case, the four nameserver
-  # addresses) via this `data` collection.
+  # Note that {Gcloud::Dns::Record#data} returns an array. The Cloud DNS service
+  # only allows the zone to have one Record instance for each name and type
+  # combination. It supports multiple "resource records" (in this case, the four
+  # nameserver addresses) via this `data` collection.
   #
   # ## Managing Records
   #
-  # You can easily add your own records to the zone. Each call to {Zone#add}
-  # results in a new Cloud DNS Change instance.
+  # You can easily add your own records to the zone. Each call to
+  # {Gcloud::Dns::Zone#add} results in a new Cloud DNS Change instance.
   #
   # ```ruby
   # require "gcloud"
@@ -167,7 +167,7 @@ module Gcloud
   # of authority (SOA) record should be updated with a higher serial number. The
   # gcloud library automates this update for you, deleting the old SOA record
   # and adding an updated one, as shown in the example above. You can disable or
-  # modify this behavior, of course. See {Zone#update} for details.
+  # modify this behavior, of course. See {Gcloud::Dns::Zone#update} for details.
   #
   # You can retrieve records by name and type. The name argument can be a
   # subdomain (e.g., `www`) fragment for convenience, but notice that the
@@ -183,7 +183,8 @@ module Gcloud
   # records.first.name #=> "www.example.com."
   # ```
   #
-  # You can use {Zone#replace} to update the `ttl` and `data` for a record.
+  # You can use {Gcloud::Dns::Zone#replace} to update the `ttl` and `data` for a
+  # record.
   #
   # ```ruby
   # require "gcloud"
@@ -194,8 +195,9 @@ module Gcloud
   # change = zone.replace "www", "A", 86400, ["5.6.7.8"]
   # ```
   #
-  # Or, you can use {Zone#modify} to update just the `ttl` or `data`, without
-  # the risk of inadvertently changing values that you wish to leave unchanged.
+  # Or, you can use {Gcloud::Dns::Zone#modify} to update just the `ttl` or
+  # `data`, without the risk of inadvertently changing values that you wish to
+  # leave unchanged.
   #
   # ```ruby
   # require "gcloud"
@@ -221,8 +223,9 @@ module Gcloud
   # ```
   #
   # The best way to add, remove, and update multiple records in a single
-  # [transaction](https://cloud.google.com/dns/records) is to call {Zone#update}
-  # with a block. See {Zone::Transaction}.
+  # [transaction](https://cloud.google.com/dns/records) is to call
+  # {Gcloud::Dns::Zone#update} with a block. See
+  # {Gcloud::Dns::Zone::Transaction}.
   #
   # ```ruby
   # require "gcloud"
@@ -241,7 +244,8 @@ module Gcloud
   # end
   # ```
   #
-  # Finally, you can add and delete records by reference, using {Zone#update}.
+  # Finally, you can add and delete records by reference, using
+  # {Gcloud::Dns::Zone#update}.
   #
   # ```ruby
   # require "gcloud"

--- a/lib/gcloud/dns/record.rb
+++ b/lib/gcloud/dns/record.rb
@@ -20,11 +20,13 @@ module Gcloud
     ##
     # # DNS Record
     #
-    # Represents a set of DNS resource records (RRs) for a given {#name} and
-    # {#type} in a {Zone}. Since it is a value object, a newly created Record
-    # instance is transient until it is added to a Zone with {Zone#update}. Note
-    # that {Zone#add} and the {Zone#update} block parameter can be used instead
-    # of {Zone#record} or `Record.new` to create new records.
+    # Represents a set of DNS resource records (RRs) for a given
+    # {Gcloud::Dns::Record#name} and {Gcloud::Dns::Record#type} in a
+    # {Gcloud::Dns::Zone}. Since it is a value object, a newly created Record
+    # instance is transient until it is added to a Zone with
+    # {Gcloud::Dns::Zone#update}. Note that {Gcloud::Dns::Zone#add} and the
+    # {Gcloud::Dns::Zone#update} block parameter can be used instead of
+    # {Gcloud::Dns::Zone#record} or `Record.new` to create new records.
     #
     # @example
     #   require "gcloud"
@@ -114,7 +116,7 @@ module Gcloud
       ##
       # Returns a deep copy of the record. Useful for updating records, since
       # the original, unmodified record must be passed for deletion when using
-      # {Zone#update}.
+      # {Gcloud::Dns::Zone#update}.
       #
       def dup
         other = super

--- a/lib/gcloud/dns/zone.rb
+++ b/lib/gcloud/dns/zone.rb
@@ -211,6 +211,7 @@ module Gcloud
       # @param [Symbol, String] order Sort the changes by change sequence.
       #
       #   Acceptable values are:
+      #
       #   * `asc` - Sort by ascending change sequence
       #   * `desc` - Sort by descending change sequence
       #

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -21,6 +21,10 @@ module Gcloud
   # Creates a new object for connecting to the Logging service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Project identifier for the Logging service you are
   #   connecting to.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -72,11 +72,12 @@ module Gcloud
   # Logging?](https://cloud.google.com/logging/docs/).
   #
   # Gcloud's goal is to provide an API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by {Gcloud#logging}. You can provide
-  # the project and credential information to connect to the Cloud Logging
-  # service, or if you are running on Google Compute Engine this configuration
-  # is taken care of for you. You can read more about the options for connecting
-  # in the [Authentication Guide](../AUTHENTICATION).
+  # Rubyists. Authentication is handled by {Gcloud#logging}. You can provide the
+  # project and credential information to connect to the Cloud Logging service,
+  # or if you are running on Google Compute Engine this configuration is taken
+  # care of for you. You can read more about the options for connecting in the
+  # <a ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="../AUTHENTICATION">Authentication Guide</a>.
   #
   # ## Listing log entries
   #

--- a/lib/gcloud/logging/resource.rb
+++ b/lib/gcloud/logging/resource.rb
@@ -24,7 +24,8 @@ module Gcloud
     # instances, and so forth. Each of those kinds of objects is described by an
     # instance of {ResourceDescriptor}.
     #
-    # For use with {Gcloud::Logging::Entry#resource=} and
+    # For use with {Gcloud::Logging::Entry#resource},
+    # {Gcloud::Logging::Project#resource}, and
     # {Gcloud::Logging::Project#write_entries}.
     #
     # @example

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -21,6 +21,10 @@ module Gcloud
   # Creates a new object for connecting to the Pub/Sub service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Project identifier for the Pub/Sub service you are
   #   connecting to.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -65,7 +65,7 @@ module Gcloud
   # applications.
   #
   # Gcloud's goal is to provide a API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud#pubsub. You can provide the
+  # Rubyists. Authentication is handled by {Gcloud#pubsub}. You can provide the
   # project and credential information to connect to the Pub/Sub service, or if
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
@@ -86,7 +86,7 @@ module Gcloud
   # ## Retrieving Topics
   #
   # A Topic is a named resource to which messages are sent by publishers.
-  # A Topic is found by its name. (See Project#topic)
+  # A Topic is found by its name. (See {Project#topic})
   #
   # ```ruby
   # require "gcloud"
@@ -98,7 +98,7 @@ module Gcloud
   #
   # ## Creating a Topic
   #
-  # A Topic is created from a Project. (See Project#create_topic)
+  # A Topic is created from a Project. (See {Project#create_topic})
   #
   # ```ruby
   # require "gcloud"
@@ -112,7 +112,7 @@ module Gcloud
   #
   # A Subscription is a named resource representing the stream of messages from
   # a single, specific Topic, to be delivered to the subscribing application.
-  # A Subscription is found by its name. (See Topic#subscription)
+  # A Subscription is found by its name. (See {Topic#subscription})
   #
   # ```ruby
   # require "gcloud"
@@ -127,8 +127,8 @@ module Gcloud
   #
   # ## Creating a Subscription
   #
-  # A Subscription is created from a Topic. (See Topic#subscribe and
-  # Project#subscribe)
+  # A Subscription is created from a Topic. (See {Topic#subscribe} and
+  # {Project#subscribe})
   #
   # ```ruby
   # require "gcloud"
@@ -160,7 +160,7 @@ module Gcloud
   #
   # Messages are published to a topic. Any message published to a topic without
   # a subscription will be lost. Ensure the topic has a subscription before
-  # publishing. (See Topic#publish and Project#publish)
+  # publishing. (See {Topic#publish} and {Project#publish})
   #
   # ```ruby
   # require "gcloud"
@@ -204,7 +204,7 @@ module Gcloud
   #
   # ## Pulling Messages
   #
-  # Messages are pulled from a Subscription. (See Subscription#pull)
+  # Messages are pulled from a Subscription. (See {Subscription#pull})
   #
   # ```ruby
   # require "gcloud"
@@ -229,7 +229,7 @@ module Gcloud
   # ```
   #
   # The request for messages can also block until messages are available.
-  # (See Subscription#wait_for_messages)
+  # (See {Subscription#wait_for_messages})
   #
   # ```ruby
   # require "gcloud"
@@ -248,7 +248,7 @@ module Gcloud
   #
   # A Message that can be acknowledged is called a ReceivedMessage.
   # ReceivedMessages can be acknowledged one at a time:
-  # (See ReceivedMessage#acknowledge!)
+  # (See {ReceivedMessage#acknowledge!})
   #
   # ```ruby
   # require "gcloud"
@@ -261,7 +261,7 @@ module Gcloud
   # ```
   #
   # Or, multiple messages can be acknowledged in a single API call:
-  # (See Subscription#acknowledge)
+  # (See {Subscription#acknowledge})
   #
   # ```ruby
   # require "gcloud"
@@ -279,7 +279,7 @@ module Gcloud
   # A message must be acknowledged after it is pulled, or Pub/Sub will mark the
   # message for redelivery. The message acknowledgement deadline can delayed if
   # more time is needed. This will allow more time to process the message before
-  # the message is marked for redelivery. (See ReceivedMessage#delay!)
+  # the message is marked for redelivery. (See {ReceivedMessage#delay!})
   #
   # ```ruby
   # require "gcloud"
@@ -314,7 +314,7 @@ module Gcloud
   # ```
   #
   # Multiple messages can be delayed or made available for immediate redelivery:
-  # (See Subscription#delay)
+  # (See {Subscription#delay})
   #
   # ```ruby
   # require "gcloud"
@@ -331,7 +331,7 @@ module Gcloud
   #
   # Long running workers are easy to create with `listen`, which runs an
   # infinitely blocking loop to process messages as they are received. (See
-  # Subscription#listen)
+  # {Subscription#listen})
   #
   # ```ruby
   # require "gcloud"
@@ -379,7 +379,7 @@ module Gcloud
   # ## Working Across Projects
   #
   # All calls to the Pub/Sub service use the same project and credentials
-  # provided to the Gcloud#pubsub method. However, it is common to reference
+  # provided to the {Gcloud#pubsub} method. However, it is common to reference
   # topics or subscriptions in other projects, which can be achieved by using
   # the `project` option. The main credentials must have permissions to the
   # topics and subscriptions in other projects.

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -90,7 +90,7 @@ module Gcloud
   # ## Retrieving Topics
   #
   # A Topic is a named resource to which messages are sent by publishers.
-  # A Topic is found by its name. (See {Project#topic})
+  # A Topic is found by its name. (See {Gcloud::Pubsub::Project#topic})
   #
   # ```ruby
   # require "gcloud"
@@ -102,7 +102,8 @@ module Gcloud
   #
   # ## Creating a Topic
   #
-  # A Topic is created from a Project. (See {Project#create_topic})
+  # A Topic is created from a Project. (See
+  # {Gcloud::Pubsub::Project#create_topic})
   #
   # ```ruby
   # require "gcloud"
@@ -115,8 +116,9 @@ module Gcloud
   # ## Retrieving Subscriptions
   #
   # A Subscription is a named resource representing the stream of messages from
-  # a single, specific Topic, to be delivered to the subscribing application.
-  # A Subscription is found by its name. (See {Topic#subscription})
+  # a single, specific Topic, to be delivered to the subscribing application. A
+  # Subscription is found by its name. (See
+  # {Gcloud::Pubsub::Topic#subscription})
   #
   # ```ruby
   # require "gcloud"
@@ -131,8 +133,8 @@ module Gcloud
   #
   # ## Creating a Subscription
   #
-  # A Subscription is created from a Topic. (See {Topic#subscribe} and
-  # {Project#subscribe})
+  # A Subscription is created from a Topic. (See
+  # {Gcloud::Pubsub::Topic#subscribe} and {Gcloud::Pubsub::Project#subscribe})
   #
   # ```ruby
   # require "gcloud"
@@ -164,7 +166,8 @@ module Gcloud
   #
   # Messages are published to a topic. Any message published to a topic without
   # a subscription will be lost. Ensure the topic has a subscription before
-  # publishing. (See {Topic#publish} and {Project#publish})
+  # publishing. (See {Gcloud::Pubsub::Topic#publish} and
+  # {Gcloud::Pubsub::Project#publish})
   #
   # ```ruby
   # require "gcloud"
@@ -208,7 +211,8 @@ module Gcloud
   #
   # ## Pulling Messages
   #
-  # Messages are pulled from a Subscription. (See {Subscription#pull})
+  # Messages are pulled from a Subscription. (See
+  # {Gcloud::Pubsub::Subscription#pull})
   #
   # ```ruby
   # require "gcloud"
@@ -233,7 +237,7 @@ module Gcloud
   # ```
   #
   # The request for messages can also block until messages are available.
-  # (See {Subscription#wait_for_messages})
+  # (See {Gcloud::Pubsub::Subscription#wait_for_messages})
   #
   # ```ruby
   # require "gcloud"
@@ -252,7 +256,7 @@ module Gcloud
   #
   # A Message that can be acknowledged is called a ReceivedMessage.
   # ReceivedMessages can be acknowledged one at a time:
-  # (See {ReceivedMessage#acknowledge!})
+  # (See {Gcloud::Pubsub::ReceivedMessage#acknowledge!})
   #
   # ```ruby
   # require "gcloud"
@@ -265,7 +269,7 @@ module Gcloud
   # ```
   #
   # Or, multiple messages can be acknowledged in a single API call:
-  # (See {Subscription#acknowledge})
+  # (See {Gcloud::Pubsub::Subscription#acknowledge})
   #
   # ```ruby
   # require "gcloud"
@@ -283,7 +287,8 @@ module Gcloud
   # A message must be acknowledged after it is pulled, or Pub/Sub will mark the
   # message for redelivery. The message acknowledgement deadline can delayed if
   # more time is needed. This will allow more time to process the message before
-  # the message is marked for redelivery. (See {ReceivedMessage#delay!})
+  # the message is marked for redelivery. (See
+  # {Gcloud::Pubsub::ReceivedMessage#delay!})
   #
   # ```ruby
   # require "gcloud"
@@ -318,7 +323,7 @@ module Gcloud
   # ```
   #
   # Multiple messages can be delayed or made available for immediate redelivery:
-  # (See {Subscription#delay})
+  # (See {Gcloud::Pubsub::Subscription#delay})
   #
   # ```ruby
   # require "gcloud"
@@ -335,7 +340,7 @@ module Gcloud
   #
   # Long running workers are easy to create with `listen`, which runs an
   # infinitely blocking loop to process messages as they are received. (See
-  # {Subscription#listen})
+  # {Gcloud::Pubsub::Subscription#listen})
   #
   # ```ruby
   # require "gcloud"

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -112,7 +112,8 @@ module Gcloud
   #
   # Project is a collection of settings, credentials, and metadata about the
   # application or applications you're working on. You can retrieve and inspect
-  # all projects that you have permissions to. (See {Manager#projects})
+  # all projects that you have permissions to. (See
+  # {Gcloud::ResourceManager::Manager#projects})
   #
   # ```ruby
   # require "gcloud"
@@ -126,7 +127,8 @@ module Gcloud
   #
   # ## Managing Projects with Labels
   #
-  # Labels can be added to or removed from projects. (See {Project#labels})
+  # Labels can be added to or removed from projects. (See
+  # {Gcloud::ResourceManager::Project#labels})
   #
   # ```ruby
   # require "gcloud"
@@ -140,7 +142,8 @@ module Gcloud
   # end
   # ```
   #
-  # Projects can then be filtered by labels. (See {Manager#projects})
+  # Projects can then be filtered by labels. (See
+  # {Gcloud::ResourceManager::Manager#projects})
   #
   # ```ruby
   # require "gcloud"
@@ -157,7 +160,7 @@ module Gcloud
   # ## Creating a Project
   #
   # You can also use the API to create new projects. (See
-  # {Manager#create_project})
+  # {Gcloud::ResourceManager::Manager#create_project})
   #
   # ```ruby
   # require "gcloud"
@@ -172,7 +175,8 @@ module Gcloud
   # ## Deleting a Project
   #
   # You can delete projects when they are no longer needed. (See
-  # {Manager#delete} and {Project#delete})
+  # {Gcloud::ResourceManager::Manager#delete} and
+  # {Gcloud::ResourceManager::Project#delete})
   #
   # ```ruby
   # require "gcloud"
@@ -184,10 +188,11 @@ module Gcloud
   #
   # ## Undeleting a Project
   #
-  # You can also restore a deleted project within the waiting period that
-  # starts when the project was deleted. Restoring a project returns it to the
-  # state it was in prior to being deleted. (See {Manager#undelete} and
-  # {Project#undelete})
+  # You can also restore a deleted project within the waiting period that starts
+  # when the project was deleted. Restoring a project returns it to the state it
+  # was in prior to being deleted. (See
+  # {Gcloud::ResourceManager::Manager#undelete} and
+  # {Gcloud::ResourceManager::Project#undelete})
   #
   # ```ruby
   # require "gcloud"
@@ -205,7 +210,8 @@ module Gcloud
   # has access to _what_ (role). See [Cloud IAM
   # Overview](https://cloud.google.com/iam/docs/overview) for more information.
   #
-  # A project's access control policy can be retrieved. (See {Project#policy})
+  # A project's access control policy can be retrieved. (See
+  # {Gcloud::ResourceManager::Project#policy})
   #
   # ```ruby
   # require "gcloud"
@@ -216,7 +222,8 @@ module Gcloud
   # policy = project.policy
   # ```
   #
-  # A project's access control policy can also be set. (See {Project#policy=})
+  # A project's access control policy can also be set. (See
+  # {Gcloud::ResourceManager::Project#policy=})
   #
   # ```ruby
   # require "gcloud"
@@ -234,7 +241,8 @@ module Gcloud
   # project.policy = viewer_policy
   # ```
   #
-  # And permissions can be tested on a project. (See {Project#test_permissions})
+  # And permissions can be tested on a project. (See
+  # {Gcloud::ResourceManager::Project#test_permissions})
   #
   # ```ruby
   # require "gcloud"

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -75,9 +75,9 @@ module Gcloud
   # Currently, the full functionality of the Resource Manager API is available
   # only to whitelisted users. (Contact your account manager or a member of the
   # Google Cloud sales team if you are interested in access.) Read-only methods
-  # such as ResourceManager::Manager#projects and
-  # ResourceManager::Manager#project are accessible to any user who enables the
-  # Resource Manager API in the [Developers
+  # such as {ResourceManager::Manager#projects} and
+  # {ResourceManager::Manager#project} are accessible to any user who enables
+  # the Resource Manager API in the [Developers
   # Console](https://console.developers.google.com).
   #
   # ## Authentication
@@ -108,7 +108,7 @@ module Gcloud
   #
   # Project is a collection of settings, credentials, and metadata about the
   # application or applications you're working on. You can retrieve and inspect
-  # all projects that you have permissions to. (See Manager#projects)
+  # all projects that you have permissions to. (See {Manager#projects})
   #
   # ```ruby
   # require "gcloud"
@@ -122,7 +122,7 @@ module Gcloud
   #
   # ## Managing Projects with Labels
   #
-  # Labels can be added to or removed from projects. (See Project#labels)
+  # Labels can be added to or removed from projects. (See {Project#labels})
   #
   # ```ruby
   # require "gcloud"
@@ -136,7 +136,7 @@ module Gcloud
   # end
   # ```
   #
-  # Projects can then be filtered by labels. (See Manager#projects)
+  # Projects can then be filtered by labels. (See {Manager#projects})
   #
   # ```ruby
   # require "gcloud"
@@ -153,7 +153,7 @@ module Gcloud
   # ## Creating a Project
   #
   # You can also use the API to create new projects. (See
-  # Manager#create_project)
+  # {Manager#create_project})
   #
   # ```ruby
   # require "gcloud"
@@ -168,7 +168,7 @@ module Gcloud
   # ## Deleting a Project
   #
   # You can delete projects when they are no longer needed. (See
-  # Manager#delete and Project#delete)
+  # {Manager#delete} and {Project#delete})
   #
   # ```ruby
   # require "gcloud"
@@ -182,8 +182,8 @@ module Gcloud
   #
   # You can also restore a deleted project within the waiting period that
   # starts when the project was deleted. Restoring a project returns it to the
-  # state it was in prior to being deleted. (See Manager#undelete and
-  # Project#undelete)
+  # state it was in prior to being deleted. (See {Manager#undelete} and
+  # {Project#undelete})
   #
   # ```ruby
   # require "gcloud"
@@ -201,7 +201,7 @@ module Gcloud
   # has access to _what_ (role). See [Cloud IAM
   # Overview](https://cloud.google.com/iam/docs/overview) for more information.
   #
-  # A project's access control policy can be retrieved. (See Project#policy)
+  # A project's access control policy can be retrieved. (See {Project#policy})
   #
   # ```ruby
   # require "gcloud"
@@ -212,7 +212,7 @@ module Gcloud
   # policy = project.policy
   # ```
   #
-  # A project's access control policy can also be set. (See Project#policy=)
+  # A project's access control policy can also be set. (See {Project#policy=})
   #
   # ```ruby
   # require "gcloud"
@@ -230,7 +230,7 @@ module Gcloud
   # project.policy = viewer_policy
   # ```
   #
-  # And permissions can be tested on a project. (See Project#test_permissions)
+  # And permissions can be tested on a project. (See {Project#test_permissions})
   #
   # ```ruby
   # require "gcloud"

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -21,6 +21,10 @@ module Gcloud
   # Creates a new `Project` instance connected to the Resource Manager service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
   #   path the file must be readable.
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -57,11 +57,13 @@ module Gcloud
       #   request. Filter rules are case insensitive.
       #
       #   The fields eligible for filtering are:
+      #
       #   * `name`
       #   * `id`
       #   * `labels.key` - where `key` is the name of a label
       #
       #   Some examples of using labels as filters:
+      #
       #   * `name:*` - The project has a name.
       #   * `name:Howl` - The project's name is Howl or howl.
       #   * `name:HOWL` - Equivalent to above.

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -21,6 +21,10 @@ module Gcloud
   # Creates a new `Project` instance connected to the Search service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Identifier for a Search project. If not present, the
   #   default project for the credentials is used.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -79,7 +79,7 @@ module Gcloud
   # credential information to connect to the Cloud Search service, or if you are
   # running on Google Compute Engine this configuration is taken care of for
   # you. You can read more about the options for connecting in the
-  # [Authentication Guide](../AUTHENTICATION).
+  # <a ui-sref="docs.guides({ guideId: 'authentication' })" href="../AUTHENTICATION">Authentication Guide</a>.
   #
   # ## Managing Indexes
   #

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -205,7 +205,7 @@ module Gcloud
   # [Cloud Search types](https://cloud.google.com/search/documents_indexes#document_fields_field_names_and_multi-valued_fields).
   # The type will be inferred from the value when possible, or you can
   # explicitly specify it by passing a symbol with the `type` option to
-  # {Document#add}.
+  # {Gcloud::Search::Document#add}.
   #
   # - String (`:atom`, `:html`, `:text`, or `:default`)
   # - Number (`:number`)

--- a/lib/gcloud/search.rb
+++ b/lib/gcloud/search.rb
@@ -75,7 +75,7 @@ module Gcloud
   #
   # ## Authentication
   #
-  # Authentication is handled by Gcloud#search. You can provide the project and
+  # Authentication is handled by {Gcloud#search}. You can provide the project and
   # credential information to connect to the Cloud Search service, or if you are
   # running on Google Compute Engine this configuration is taken care of for
   # you. You can read more about the options for connecting in the
@@ -201,7 +201,7 @@ module Gcloud
   # [Cloud Search types](https://cloud.google.com/search/documents_indexes#document_fields_field_names_and_multi-valued_fields).
   # The type will be inferred from the value when possible, or you can
   # explicitly specify it by passing a symbol with the `type` option to
-  # Document#add.
+  # {Document#add}.
   #
   # - String (`:atom`, `:html`, `:text`, or `:default`)
   # - Number (`:number`)

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -142,6 +142,7 @@ module Gcloud
       #   `:number` values.
       #
       #   The following values are supported:
+      #
       #   * `:default` - The value is a string. The format will be automatically
       #     detected. This is the default value for strings.
       #   * `:text` - The value is a string with maximum length 1024**2

--- a/lib/gcloud/search/document.rb
+++ b/lib/gcloud/search/document.rb
@@ -23,9 +23,11 @@ module Gcloud
     # # Document
     #
     # A document is an object that stores data that can be searched. Each
-    # document has a {#doc_id} that is unique within its index, a {#rank}, and a
-    # list of {#fields} that contain typed data. Its field values can be
-    # accessed through hash-like methods such as {#[]} and {#each}.
+    # document has a {Gcloud::Search::Document#doc_id} that is unique within its
+    # index, a {Gcloud::Search::Document#rank}, and a list of
+    # {Gcloud::Search::Document#fields} that contain typed data. Its field
+    # values can be accessed through hash-like methods such as
+    # {Gcloud::Search::Document#[]} and {Gcloud::Search::Document#each}.
     #
     # @example
     #   require "gcloud"
@@ -54,8 +56,9 @@ module Gcloud
 
       ##
       # The unique identifier for the document. Can be set explicitly when the
-      # document is saved. (See {Index#document} and {#doc_id=}.) If missing, it
-      # is automatically assigned to the document when saved.
+      # document is saved. (See {Gcloud::Search::Index#document} and
+      # {Gcloud::Search::Document#doc_id=}.) If missing, it is automatically
+      # assigned to the document when saved.
       def doc_id
         @raw["docId"]
       end
@@ -74,8 +77,9 @@ module Gcloud
       ##
       # A positive integer which determines the default ordering of documents
       # returned from a search. The rank can be set explicitly when the document
-      # is saved. (See {Index#document} and {#rank=}.)  If missing, it is
-      # automatically assigned to the document when saved.
+      # is saved. (See {Gcloud::Search::Index#document} and
+      # {Gcloud::Search::Document#rank=}.)  If missing, it is automatically
+      # assigned to the document when saved.
       def rank
         @raw["rank"]
       end
@@ -83,11 +87,11 @@ module Gcloud
       ##
       # Sets the rank of the document.
       #
-      # The same rank should not be assigned to many documents, and should
-      # never be assigned to more than 10,000 documents. By default (when it is
-      # not specified or set to 0), it is set at the time the document is
-      # created to the number of seconds since January 1, 2011. The rank can be
-      # used in {Index#search} options `expressions`, `order`, and
+      # The same rank should not be assigned to many documents, and should never
+      # be assigned to more than 10,000 documents. By default (when it is not
+      # specified or set to 0), it is set at the time the document is created to
+      # the number of seconds since January 1, 2011. The rank can be used in
+      # {Gcloud::Search::Index#search} options `expressions`, `order`, and
       # `fields`, where it is referenced as `rank`.
       def rank= new_rank
         @raw["rank"] = new_rank

--- a/lib/gcloud/search/field_value.rb
+++ b/lib/gcloud/search/field_value.rb
@@ -60,6 +60,7 @@ module Gcloud
       #   number values.
       #
       #   The following values are supported:
+      #
       #   * `:text` - The value is a string with maximum length 1024**2
       #     characters.
       #   * `:html` - The value is an HTML-formatted string with maximum length

--- a/lib/gcloud/search/field_values.rb
+++ b/lib/gcloud/search/field_values.rb
@@ -93,6 +93,7 @@ module Gcloud
       #   `:number` values.
       #
       #   The following values are supported:
+      #
       #   * `:default` - The value is a string. The format will be automatically
       #     detected. This is the default value for strings.
       #   * `:text` - The value is a string with maximum length 1024**2

--- a/lib/gcloud/search/fields.rb
+++ b/lib/gcloud/search/fields.rb
@@ -100,6 +100,7 @@ module Gcloud
       #   `:number` values.
       #
       #   The following values are supported:
+      #
       #   * `:default` - The value is a string. The format will be automatically
       #     detected. This is the default value for strings.
       #   * `:text` - The value is a string with maximum length 1024**2

--- a/lib/gcloud/search/index.rb
+++ b/lib/gcloud/search/index.rb
@@ -27,9 +27,11 @@ module Gcloud
     # the documents that reference them. You can manage groups of documents by
     # putting them into separate indexes.
     #
-    # With an index, you can retrieve documents with {#find} and {#documents};
-    # manage them with {#document}, {#save}, and {#remove}; and perform searches
-    # over their fields with {#search}.
+    # With an index, you can retrieve documents with
+    # {Gcloud::Search::Index#find} and {Gcloud::Search::Index#documents}; manage
+    # them with {Gcloud::Search::Index#document}, {Gcloud::Search::Index#save},
+    # and {Gcloud::Search::Index#remove}; and perform searches over their fields
+    # with {Gcloud::Search::Index#search}.
     #
     # @example
     #   require "gcloud"
@@ -181,9 +183,10 @@ module Gcloud
 
       ##
       # Helper for creating a new Document instance. The returned instance is
-      # local: It is either not yet saved to the service (see {#save}), or if it
-      # has been given the id of an existing document, it is not yet populated
-      # with the document's data (see {#find}).
+      # local: It is either not yet saved to the service (see
+      # {Gcloud::Search::Index#save}), or if it has been given the id of an
+      # existing document, it is not yet populated with the document's data (see
+      # {Gcloud::Search::Index#find}).
       #
       # @param [String, nil] doc_id An optional unique ID for the new document.
       #   When the document is saved, this value must contain only visible,
@@ -198,8 +201,8 @@ module Gcloud
       #   10,000 documents. By default (when it is not specified or set to 0),
       #   it is set at the time the document is saved to the number of seconds
       #   since January 1, 2011. The rank can be used in the `expressions`,
-      #   `order`, and `fields` options in {#search}, where it should referenced
-      #   as `rank`.
+      #   `order`, and `fields` options in {Gcloud::Search::Index#search}, where
+      #   it should referenced as `rank`.
       #
       # @return [Gcloud::Search::Document]
       #
@@ -279,11 +282,13 @@ module Gcloud
 
       ##
       # Saves a new or existing document to the index. If the document instance
-      # is new and has been given an id (see {#document}), it will replace an
-      # existing document in the index that has the same unique id.
+      # is new and has been given an id (see {Gcloud::Search::Index#document}),
+      # it will replace an existing document in the index that has the same
+      # unique id.
       #
       # @param [Gcloud::Search::Document] document A Document instance, either
-      #   new (see {#document}) or existing (see {#find}).
+      #   new (see {Gcloud::Search::Index#document}) or existing (see
+      #   {Gcloud::Search::Index#find}).
       #
       # @return [Gcloud::Search::Document]
       #

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -97,7 +97,7 @@ module Gcloud
   # A Bucket is the container for your data. There is no limit on the number of
   # buckets that you can create in a project. You can use buckets to organize
   # and control access to your data. Each bucket has a unique name, which is how
-  # they are retrieved: (See {Project#bucket})
+  # they are retrieved: (See {Gcloud::Storage::Project#bucket})
   #
   # ```ruby
   # require "gcloud"
@@ -108,7 +108,8 @@ module Gcloud
   # bucket = storage.bucket "my-todo-app"
   # ```
   #
-  # You can also retrieve all buckets on a project: (See {Project#buckets})
+  # You can also retrieve all buckets on a project: (See
+  # {Gcloud::Storage::Project#buckets})
   #
   # ```ruby
   # require "gcloud"
@@ -120,7 +121,7 @@ module Gcloud
   # ```
   #
   # If you have a significant number of buckets, you may need to paginate
-  # through them: (See {Bucket::List#token})
+  # through them: (See {Gcloud::Storage::Bucket::List#token})
   #
   # ```ruby
   # require "gcloud"
@@ -143,8 +144,8 @@ module Gcloud
   #
   # ## Creating a Bucket
   #
-  # A unique name is all that is needed to create a new bucket:
-  # (See {Project#create_bucket})
+  # A unique name is all that is needed to create a new bucket: (See
+  # {Gcloud::Storage::Project#create_bucket})
   #
   # ```ruby
   # require "gcloud"
@@ -163,7 +164,7 @@ module Gcloud
   # no limit on the number of objects that you can create in a bucket.
   #
   # Files are retrieved by their name, which is the path of the file in the
-  # bucket: (See {Bucket#file})
+  # bucket: (See {Gcloud::Storage::Bucket#file})
   #
   # ```ruby
   # require "gcloud"
@@ -200,7 +201,7 @@ module Gcloud
   # ```
   #
   # If you have a significant number of files, you may need to paginate through
-  # them: (See {File::List#token})
+  # them: (See {Gcloud::Storage::File::List#token})
   #
   # ```ruby
   # require "gcloud"
@@ -227,7 +228,7 @@ module Gcloud
   #
   # A new File can be uploaded by specifying the location of a file on the local
   # file system, and the name/path that the file should be stored in the bucket.
-  # (See {Bucket#create_file})
+  # (See {Gcloud::Storage::Bucket#create_file})
   #
   # ```ruby
   # require "gcloud"
@@ -269,7 +270,8 @@ module Gcloud
   #
   # ## Downloading a File
   #
-  # Files can be downloaded to the local file system. (See {File#download})
+  # Files can be downloaded to the local file system. (See
+  # {Gcloud::Storage::File#download})
   #
   # ```ruby
   # require "gcloud"
@@ -285,8 +287,8 @@ module Gcloud
   # ## Using Signed URLs
   #
   # Access without authentication can be granted to a File for a specified
-  # period of time. This URL uses a cryptographic signature
-  # of your credentials to access the file. (See {File#signed_url})
+  # period of time. This URL uses a cryptographic signature of your credentials
+  # to access the file. (See {Gcloud::Storage::File#signed_url})
   #
   # ```ruby
   # require "gcloud"
@@ -302,12 +304,11 @@ module Gcloud
   #
   # ## Controlling Access to a Bucket
   #
-  # Access to a bucket is controlled with {Bucket#acl}. A bucket has owners,
-  # writers, and readers. Permissions can be granted to an individual user's
-  # email address, a group's email address, as well as many predefined lists.
-  # See the
-  # [Access Control guide](https://cloud.google.com/storage/docs/access-control)
-  # for more.
+  # Access to a bucket is controlled with {Gcloud::Storage::Bucket#acl}. A
+  # bucket has owners, writers, and readers. Permissions can be granted to an
+  # individual user's email address, a group's email address, as well as many
+  # predefined lists. See the [Access Control
+  # guide](https://cloud.google.com/storage/docs/access-control) for more.
   #
   # Access to a bucket can be granted to a user by appending `"user-"` to the
   # email address:
@@ -355,8 +356,9 @@ module Gcloud
   # ## Controlling Access to a File
   #
   # Access to a file is controlled in two ways, either by the setting the
-  # default permissions to all files in a bucket with {Bucket#default_acl}, or
-  # by setting permissions to an individual file with {File#acl}.
+  # default permissions to all files in a bucket with
+  # {Gcloud::Storage::Bucket#default_acl}, or by setting permissions to an
+  # individual file with {Gcloud::Storage::File#acl}.
   #
   # Access to a file can be granted to a user by appending `"user-"` to the
   # email address:

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -80,8 +80,9 @@ module Gcloud
   # file = bucket.file "path/to/my-file.ext"
   # ```
   #
-  # You can learn more about various options for connection on the
-  # [Authentication Guide](../AUTHENTICATION).
+  # You can learn more about various options for connection on the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="../AUTHENTICATION">Authentication Guide</a>.
   #
   # To learn more about Cloud Storage, read the
   # [Google Cloud Storage Overview

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -64,7 +64,7 @@ module Gcloud
   # infrastructure to perform data operations in a cost effective manner.
   #
   # Gcloud's goal is to provide a API that is familiar and comfortable to
-  # Rubyists. Authentication is handled by Gcloud#storage. You can provide the
+  # Rubyists. Authentication is handled by {Gcloud#storage}. You can provide the
   # project and credential information to connect to the Storage service, or if
   # you are running on Google Compute Engine this configuration is taken care
   # of for you.
@@ -92,7 +92,7 @@ module Gcloud
   # A Bucket is the container for your data. There is no limit on the number of
   # buckets that you can create in a project. You can use buckets to organize
   # and control access to your data. Each bucket has a unique name, which is how
-  # they are retrieved: (See Project#bucket)
+  # they are retrieved: (See {Project#bucket})
   #
   # ```ruby
   # require "gcloud"
@@ -103,7 +103,7 @@ module Gcloud
   # bucket = storage.bucket "my-todo-app"
   # ```
   #
-  # You can also retrieve all buckets on a project: (See Project#buckets)
+  # You can also retrieve all buckets on a project: (See {Project#buckets})
   #
   # ```ruby
   # require "gcloud"
@@ -115,7 +115,7 @@ module Gcloud
   # ```
   #
   # If you have a significant number of buckets, you may need to paginate
-  # through them: (See Bucket::List#token)
+  # through them: (See {Bucket::List#token})
   #
   # ```ruby
   # require "gcloud"
@@ -139,7 +139,7 @@ module Gcloud
   # ## Creating a Bucket
   #
   # A unique name is all that is needed to create a new bucket:
-  # (See Project#create_bucket)
+  # (See {Project#create_bucket})
   #
   # ```ruby
   # require "gcloud"
@@ -158,7 +158,7 @@ module Gcloud
   # no limit on the number of objects that you can create in a bucket.
   #
   # Files are retrieved by their name, which is the path of the file in the
-  # bucket: (See Bucket#file)
+  # bucket: (See {Bucket#file})
   #
   # ```ruby
   # require "gcloud"
@@ -195,7 +195,7 @@ module Gcloud
   # ```
   #
   # If you have a significant number of files, you may need to paginate through
-  # them: (See File::List#token)
+  # them: (See {File::List#token})
   #
   # ```ruby
   # require "gcloud"
@@ -222,7 +222,7 @@ module Gcloud
   #
   # A new File can be uploaded by specifying the location of a file on the local
   # file system, and the name/path that the file should be stored in the bucket.
-  # (See Bucket#create_file)
+  # (See {Bucket#create_file})
   #
   # ```ruby
   # require "gcloud"
@@ -264,7 +264,7 @@ module Gcloud
   #
   # ## Downloading a File
   #
-  # Files can be downloaded to the local file system. (See File#download)
+  # Files can be downloaded to the local file system. (See {File#download})
   #
   # ```ruby
   # require "gcloud"
@@ -281,7 +281,7 @@ module Gcloud
   #
   # Access without authentication can be granted to a File for a specified
   # period of time. This URL uses a cryptographic signature
-  # of your credentials to access the file. (See File#signed_url)
+  # of your credentials to access the file. (See {File#signed_url})
   #
   # ```ruby
   # require "gcloud"
@@ -297,7 +297,7 @@ module Gcloud
   #
   # ## Controlling Access to a Bucket
   #
-  # Access to a bucket is controlled with Bucket#acl. A bucket has owners,
+  # Access to a bucket is controlled with {Bucket#acl}. A bucket has owners,
   # writers, and readers. Permissions can be granted to an individual user's
   # email address, a group's email address, as well as many predefined lists.
   # See the
@@ -350,8 +350,8 @@ module Gcloud
   # ## Controlling Access to a File
   #
   # Access to a file is controlled in two ways, either by the setting the
-  # default permissions to all files in a bucket with Bucket#default_acl, or by
-  # setting permissions to an individual file with File#acl.
+  # default permissions to all files in a bucket with {Bucket#default_acl}, or
+  # by setting permissions to an individual file with {File#acl}.
   #
   # Access to a file can be granted to a user by appending `"user-"` to the
   # email address:

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -21,6 +21,10 @@ module Gcloud
   # Creates a new object for connecting to the Storage service.
   # Each call creates a new connection.
   #
+  # For more information on connecting to Google Cloud see the <a
+  # ui-sref="docs.guides({ guideId: 'authentication' })"
+  # href="AUTHENTICATION">Authentication Guide</a>.
+  #
   # @param [String] project Project identifier for the Storage service you are
   #   connecting to.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -485,6 +485,7 @@ module Gcloud
       #   file.
       #
       #   Acceptable values are:
+      #
       #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
       #     `authenticatedRead` - File owner gets OWNER access, and
       #     allAuthenticatedUsers get READER access.

--- a/lib/gcloud/storage/file.rb
+++ b/lib/gcloud/storage/file.rb
@@ -291,6 +291,7 @@ module Gcloud
       #   downloaded file contents are correct. Default is `:md5`.
       #
       #   Acceptable values are:
+      #
       #   * `md5` - Verify file content match using the MD5 hash.
       #   * `crc32c` - Verify file content match using the CRC32c hash.
       #   * `all` - Perform all available file content verification.
@@ -367,6 +368,7 @@ module Gcloud
       #   file.
       #
       #   Acceptable values are:
+      #
       #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
       #     `authenticatedRead` - File owner gets OWNER access, and
       #     allAuthenticatedUsers get READER access.

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -198,6 +198,7 @@ module Gcloud
       #   bucket.
       #
       #   Acceptable values are:
+      #
       #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
       #     `authenticatedRead` - Project team owners get OWNER access, and
       #     allAuthenticatedUsers get READER access.
@@ -212,6 +213,7 @@ module Gcloud
       #   access controls to this bucket.
       #
       #   Acceptable values are:
+      #
       #   * `auth`, `auth_read`, `authenticated`, `authenticated_read`,
       #     `authenticatedRead` - File owner gets OWNER access, and
       #     allAuthenticatedUsers get READER access.


### PR DESCRIPTION
Some links to the classes and methods documented in the top-level service guides were not converted to the YARD syntax. This should add those links back to the documentation.