### PR TITLE
Use Prerelease GRPC

### DIFF
--- a/acceptance/bigquery/bigquery_test.rb
+++ b/acceptance/bigquery/bigquery_test.rb
@@ -17,7 +17,7 @@ require "gcloud/storage"
 
 # This test is a ruby version of gcloud-node's bigquery test.
 
-describe Gcloud::Pubsub, :bigquery do
+describe Gcloud::Bigquery, :bigquery do
   let(:dataset_id) { "#{prefix}_dataset" }
   let(:dataset) do
     d = bigquery.dataset dataset_id

--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
                           "--exclude", "lib/gcloud/proto/",
                           "--exclude", "lib/google/"]
 
-  gem.add_dependency                  "grpc", "~> 0.13.0"
+  gem.add_dependency                  "grpc", "0.13.1.pre1"
   gem.add_dependency                  "beefcake", "~> 1.0"
   gem.add_dependency                  "google-api-client", "~> 0.8.3"
   gem.add_dependency                  "mime-types", "~> 2.4"


### PR DESCRIPTION
Verify that the prerelease version of GRPC fixes the issues identified with version. 0.13.0.