### PR TITLE
Fix incorrect base 64 encoding on PubSub message

### DIFF
--- a/acceptance/pubsub/pubsub_test.rb
+++ b/acceptance/pubsub/pubsub_test.rb
@@ -70,9 +70,13 @@ describe Gcloud::Pubsub, :pubsub do
     end
 
     it "should publish a message" do
-      msg = pubsub.topic(topic_names.first).publish "message from me"
+      data = "message from me"
+      msg = pubsub.topic(topic_names.first).publish data, foo: :bar
+
       msg.wont_be :nil?
       msg.must_be_kind_of Gcloud::Pubsub::Message
+      msg.data.must_equal data
+      msg.attributes["foo"].must_equal "bar"
     end
 
     it "should publish multiple messages" do

--- a/lib/gcloud/pubsub/service.rb
+++ b/lib/gcloud/pubsub/service.rb
@@ -117,7 +117,7 @@ module Gcloud
           topic: topic_path(topic),
           messages: messages.map do |data, attributes|
             Google::Pubsub::V1::PubsubMessage.new(
-              data: [data].pack("m").encode("ASCII-8BIT"),
+              data: String(data).encode("ASCII-8BIT"),
               attributes: attributes
             )
           end

--- a/lib/gcloud/pubsub/topic/batch.rb
+++ b/lib/gcloud/pubsub/topic/batch.rb
@@ -48,7 +48,7 @@ module Gcloud
         def to_gcloud_messages message_ids
           msgs = @messages.zip(Array(message_ids)).map do |arr, id|
             Message.from_grpc(Google::Pubsub::V1::PubsubMessage.new(
-                                data: [arr[0]].pack("m").encode("ASCII-8BIT"),
+                                data: String(arr[0]).encode("ASCII-8BIT"),
                                 attributes: arr[1],
                                 message_id: id))
           end

--- a/test/gcloud/pubsub/project/publish_test.rb
+++ b/test/gcloud/pubsub/project/publish_test.rb
@@ -19,15 +19,15 @@ describe Gcloud::Pubsub::Project, :publish, :mock_pubsub do
   let(:message1) { "new-message-here" }
   let(:message2) { "second-new-message" }
   let(:message3) { "third-new-message" }
-  let(:msg_packed1) { [message1].pack("m").encode("ASCII-8BIT") }
-  let(:msg_packed2) { [message2].pack("m").encode("ASCII-8BIT") }
-  let(:msg_packed3) { [message3].pack("m").encode("ASCII-8BIT") }
+  let(:msg_encoded1) { message1.encode("ASCII-8BIT") }
+  let(:msg_encoded2) { message2.encode("ASCII-8BIT") }
+  let(:msg_encoded3) { message3.encode("ASCII-8BIT") }
 
   it "publishes a message" do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1)
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -47,7 +47,7 @@ describe Gcloud::Pubsub::Project, :publish, :mock_pubsub do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1, attributes: {"format" => "text"})
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1, attributes: {"format" => "text"})
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -68,9 +68,9 @@ describe Gcloud::Pubsub::Project, :publish, :mock_pubsub do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1),
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed2),
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed3, attributes: {"format" => "none"})
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2),
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
@@ -97,7 +97,7 @@ describe Gcloud::Pubsub::Project, :publish, :mock_pubsub do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1)
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)

--- a/test/gcloud/pubsub/topic/publish_test.rb
+++ b/test/gcloud/pubsub/topic/publish_test.rb
@@ -21,15 +21,15 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
   let(:message1) { "new-message-here" }
   let(:message2) { "second-new-message" }
   let(:message3) { "third-new-message" }
-  let(:msg_packed1) { [message1].pack("m").encode("ASCII-8BIT") }
-  let(:msg_packed2) { [message2].pack("m").encode("ASCII-8BIT") }
-  let(:msg_packed3) { [message3].pack("m").encode("ASCII-8BIT") }
+  let(:msg_encoded1) { message1.encode("ASCII-8BIT") }
+  let(:msg_encoded2) { message2.encode("ASCII-8BIT") }
+  let(:msg_encoded3) { message3.encode("ASCII-8BIT") }
 
   it "publishes a message" do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1)
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -49,7 +49,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1, attributes: {"format" => "text"})
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1, attributes: {"format" => "text"})
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -70,9 +70,9 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1),
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed2),
-        Google::Pubsub::V1::PubsubMessage.new(data: msg_packed3, attributes: {"format" => "none"})
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2),
+        Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)
@@ -104,7 +104,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       publish_req = Google::Pubsub::V1::PublishRequest.new(
         topic: topic_path(topic_name),
         messages: [
-          Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1)
+          Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1)
         ]
       )
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -124,7 +124,7 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       publish_req = Google::Pubsub::V1::PublishRequest.new(
         topic: topic_path(topic_name),
         messages: [
-          Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1, attributes: { "format" => "text" })
+          Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1, attributes: { "format" => "text" })
         ]
       )
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -145,9 +145,9 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
       publish_req = Google::Pubsub::V1::PublishRequest.new(
         topic: topic_path(topic_name),
         messages: [
-          Google::Pubsub::V1::PubsubMessage.new(data: msg_packed1),
-          Google::Pubsub::V1::PubsubMessage.new(data: msg_packed2),
-          Google::Pubsub::V1::PubsubMessage.new(data: msg_packed3, attributes: {"format" => "none"})
+          Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded1),
+          Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded2),
+          Google::Pubsub::V1::PubsubMessage.new(data: msg_encoded3, attributes: {"format" => "none"})
         ]
       )
       publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2", "msg3"] }.to_json)

--- a/test/gcloud/pubsub/topic_test.rb
+++ b/test/gcloud/pubsub/topic_test.rb
@@ -369,12 +369,12 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "can publish a message" do
     message = "new-message-here"
-    base_64_msg = [message].pack("m").encode("ASCII-8BIT")
+    encoded_msg = message.encode("ASCII-8BIT")
 
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: base_64_msg)
+        Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg)
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -392,12 +392,12 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
 
   it "can publish a message with attributes" do
     message = "new-message-here"
-    base_64_msg = [message].pack("m").encode("ASCII-8BIT")
+    encoded_msg = message.encode("ASCII-8BIT")
 
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: base_64_msg, attributes: { "format" => "text" })
+        Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg, attributes: { "format" => "text" })
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
@@ -417,14 +417,14 @@ describe Gcloud::Pubsub::Topic, :mock_pubsub do
   it "can publish multiple messages with a block" do
     message1 = "first-new-message"
     message2 = "second-new-message"
-    base_64_msg1 = [message1].pack("m").encode("ASCII-8BIT")
-    base_64_msg2 = [message2].pack("m").encode("ASCII-8BIT")
+    encoded_msg1 = message1.encode("ASCII-8BIT")
+    encoded_msg2 = message2.encode("ASCII-8BIT")
 
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),
       messages: [
-        Google::Pubsub::V1::PubsubMessage.new(data: base_64_msg1),
-        Google::Pubsub::V1::PubsubMessage.new(data: base_64_msg2, attributes: { "format" => "none" })
+        Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg1),
+        Google::Pubsub::V1::PubsubMessage.new(data: encoded_msg2, attributes: { "format" => "none" })
       ]
     )
     publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1", "msg2"] }.to_json)


### PR DESCRIPTION
This behavior was a holdover from google api client that should have
been removed for gRPC.

[fixes #605]