### PR TITLE
Fix bug in autoack

### DIFF
--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -356,6 +356,7 @@ module Gcloud
       #
       def acknowledge *messages
         ack_ids = coerce_ack_ids messages
+        return true if ack_ids.empty?
         ensure_service!
         service.acknowledge name, *ack_ids
         true


### PR DESCRIPTION
With gRPC, it is no longer allowed to send an empty acknowledge request.

[closes #606]