### PR TITLE
Add Translate Service

### DIFF
--- a/acceptance/logging/logging_test.rb
+++ b/acceptance/logging/logging_test.rb
@@ -14,7 +14,7 @@
 
 require "logging_helper"
 
-# This test is a ruby version of gcloud-node"s logging test.
+# This test is a ruby version of gcloud-node's logging test.
 
 describe Gcloud::Logging, :logging do
   describe "Sinks" do

--- a/acceptance/translate/translate_test.rb
+++ b/acceptance/translate/translate_test.rb
@@ -1,0 +1,49 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "translate_helper"
+
+# This test is a ruby version of gcloud-node's translate test.
+
+describe Gcloud::Translate, :translate do
+  it "detects a langauge" do
+    translate.detect("Hello").results.first.language.must_equal "en"
+    translate.detect("Hola").results.first.language.must_equal "es"
+
+    detections = translate.detect "Hello", "Hola"
+    detections.count.must_equal 2
+    detections.first.results.first.language.must_equal "en"
+    detections.last.results.first.language.must_equal "es"
+  end
+
+  it "translates input" do
+    translate.translate("Hello", to: "es").text.must_equal "Hola"
+    translate.translate("How are you today?", to: "es").text.must_equal "Como estas hoy?"
+
+    translations = translate.translate "Hello", "How are you today?", to: "es"
+    translations.count.must_equal 2
+    translations.first.text.must_equal "Hola"
+    translations.last.text.must_equal "Como estas hoy?"
+  end
+
+  it "lists supported languages" do
+    languages = translate.languages
+    languages.count.must_be :>, 0
+    languages.first.name.must_be :nil?
+
+    languages = translate.languages "en"
+    languages.count.must_be :>, 0
+    languages.first.name.wont_be :nil?
+  end
+end

--- a/acceptance/translate_helper.rb
+++ b/acceptance/translate_helper.rb
@@ -1,0 +1,71 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "gcloud/translate"
+
+Gcloud::Backoff.retries = 10
+
+if ENV["GCLOUD_TEST_TRANSLATE_KEY"]
+  # Create shared translate object so we don't create new for each test
+  $translate = Gcloud.translate ENV["GCLOUD_TEST_TRANSLATE_KEY"]
+else
+  puts "No API Key found for the Translate acceptance tests."
+end
+
+module Acceptance
+  ##
+  # Test class for running against a Translate instance.
+  # Ensures that there is an active connection for the tests to use.
+  #
+  # This class can be used with the spec DSL.
+  # To do so, add :translate to describe:
+  #
+  #   describe "My Translate Test", :translate do
+  #     it "does a thing" do
+  #       your.code.must_be :thing?
+  #     end
+  #   end
+  class TranslateTest < Minitest::Test
+    attr_accessor :translate
+
+    ##
+    # Setup project based on available ENV variables
+    def setup
+      @translate = $translate
+
+      refute_nil @translate, "You do not have an active translate to run the tests."
+
+      super
+    end
+
+    # Add spec DSL
+    extend Minitest::Spec::DSL
+
+    # Register this spec type for when :translate is used.
+    register_spec_type(self) do |desc, *addl|
+      addl.include? :translate
+    end
+  end
+
+  def self.run_one_method klass, method_name, reporter
+    result = nil
+    (1..3).each do |try|
+      result = Minitest.run_one_method(klass, method_name)
+      break if (result.passed? || result.skipped?)
+      puts "Retrying #{klass}##{method_name} (#{try})"
+    end
+    reporter.record result
+  end
+end

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -374,4 +374,25 @@ module Gcloud
     require "gcloud/logging"
     Gcloud.logging @project, @keyfile, scope: scope
   end
+
+  ##
+  # Creates a new object for connecting to the Translate service.
+  # Each call creates a new connection.
+  #
+  # For more information on connecting to Google Cloud see the [Authentication
+  # Guide](https://googlecloudplatform.github.io/gcloud-ruby/#/docs/guides/authentication).
+  #
+  # @return [Gcloud::Translate::Api]
+  #
+  # @example
+  #   require "gcloud"
+  #
+  #   gcloud = Gcloud.new
+  #   translate = gcloud.translate
+  #   # ...
+  #
+  def translate key = nil
+    require "gcloud/translate"
+    Gcloud.translate key
+  end
 end

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -379,8 +379,11 @@ module Gcloud
   # Creates a new object for connecting to the Translate service.
   # Each call creates a new connection.
   #
-  # For more information on connecting to Google Cloud see the [Authentication
-  # Guide](https://googlecloudplatform.github.io/gcloud-ruby/#/docs/guides/authentication).
+  # TODO: Add info for creatign an API Key here...
+  # TODO: Explain that the API Key is likely temproary and can change in a
+  # future release.
+  #
+  # @param [String] key API Key is blah blah blah...
   #
   # @return [Gcloud::Translate::Api]
   #
@@ -388,8 +391,21 @@ module Gcloud
   #   require "gcloud"
   #
   #   gcloud = Gcloud.new
+  #   translate = gcloud.translate "api-key-abc123XYZ789"
+  #
+  #   translation = translate.translate "Hello world!", to: "la"
+  #   puts translation #=> Salve mundi!
+  #
+  # @example Using API Key from the environment variable.
+  #   require "gcloud"
+  #
+  #   ENV["TRANSLATE_KEY"] = "api-key-abc123XYZ789"
+  #
+  #   gcloud = Gcloud.new
   #   translate = gcloud.translate
-  #   # ...
+  #
+  #   translation = translate.translate "Hello world!", to: "la"
+  #   puts translation #=> Salve mundi!
   #
   def translate key = nil
     require "gcloud/translate"

--- a/lib/gcloud/translate.rb
+++ b/lib/gcloud/translate.rb
@@ -1,0 +1,57 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud"
+require "gcloud/translate/api"
+
+module Gcloud
+  ##
+  # Creates a new `Api` instance connected to the Translate service.
+  # Each call creates a new connection.
+  #
+  # TODO: Add info for creatign an API Key here...
+  #
+  # @param [String] key API Key
+  #
+  # @return [Gcloud::Translate::Api]
+  #
+  # @example
+  #   require "gcloud"
+  #
+  #   translate = Gcloud.translate "api-key-abc123XYZ789"
+  #
+  #   zone = translate.zone "example-com"
+  #
+  # @example Using API Key from the environment variable.
+  #   require "gcloud"
+  #
+  #   ENV["TRANSLATE_KEY"] = "api-key-abc123XYZ789"
+  #
+  #   translate = Gcloud.translate
+  #
+  #   zone = translate.zone "example-com"
+  #
+  def self.translate key = nil
+    Gcloud::Translate::Api.new key
+  end
+
+  ##
+  # # Google Cloud Translate
+  #
+  # TODO
+  #
+  module Translate
+  end
+end

--- a/lib/gcloud/translate.rb
+++ b/lib/gcloud/translate.rb
@@ -18,12 +18,14 @@ require "gcloud/translate/api"
 
 module Gcloud
   ##
-  # Creates a new `Api` instance connected to the Translate service.
+  # Creates a new object for connecting to the Translate service.
   # Each call creates a new connection.
   #
   # TODO: Add info for creatign an API Key here...
+  # TODO: Explain that the API Key is likely temproary and can change in a
+  # future release.
   #
-  # @param [String] key API Key
+  # @param [String] key API Key is blah blah blah...
   #
   # @return [Gcloud::Translate::Api]
   #
@@ -32,7 +34,8 @@ module Gcloud
   #
   #   translate = Gcloud.translate "api-key-abc123XYZ789"
   #
-  #   zone = translate.zone "example-com"
+  #   translation = translate.translate "Hello world!", to: "la"
+  #   puts translation #=> Salve mundi!
   #
   # @example Using API Key from the environment variable.
   #   require "gcloud"
@@ -41,7 +44,8 @@ module Gcloud
   #
   #   translate = Gcloud.translate
   #
-  #   zone = translate.zone "example-com"
+  #   translation = translate.translate "Hello world!", to: "la"
+  #   puts translation #=> Salve mundi!
   #
   def self.translate key = nil
     Gcloud::Translate::Api.new key
@@ -50,7 +54,20 @@ module Gcloud
   ##
   # # Google Cloud Translate
   #
-  # TODO
+  # TODO: Explain how to obtain an API Key, linking to exisitng documents on
+  # Google Cloud.
+  # TODO: Explain that the API Key is likely temproary and can change in a
+  # future release.
+  # TODO: Show how to retrieve a translation.
+  # TODO: Show how to retrieve a translation setting the `from`.
+  # TODO: Show how to retrieve multiple translations, including `to` and `from`.
+  # TODO: Show how to detect a language.
+  # TODO: Show how to detect a language for multiple input strings.
+  # TODO: Show how to get all the languages supported by the Google Cloud
+  # Translate service.
+  # TODO: Show how to get all the languages supported by the Google Cloud
+  # Translate service and specify the language the names should be shown in.
+  # (English vs. Spanish vs. Russian)
   #
   module Translate
   end

--- a/lib/gcloud/translate/api.rb
+++ b/lib/gcloud/translate/api.rb
@@ -43,36 +43,32 @@ module Gcloud
 
       ##
       # TODO
-      def translate *text, to: nil, from: nil, format: nil, cid: nil,
-                    quota_user: nil, user_ip: nil
+      def translate *text, to: nil, from: nil, format: nil, cid: nil
         return nil if text.empty?
         fail ArgumentError, "to is required" if to.nil?
         to = to.to_s
         from = from.to_s if from
         format = format.to_s if format
         resp = connection.translate(*text, to: to, from: from,
-                                           format: format, cid: cid,
-                                           quota_user: quota_user,
-                                           user_ip: user_ip)
+                                           format: format, cid: cid)
         fail ApiError.from_response(resp) unless resp.success?
         Translation.from_response resp, text, to, from
       end
 
       ##
       # TODO
-      def detect *text, quota_user: nil, user_ip: nil
+      def detect *text
         return nil if text.empty?
-        resp = connection.detect(*text, quota_user: quota_user,
-                                        user_ip: user_ip)
+        resp = connection.detect(*text)
         fail ApiError.from_response(resp) unless resp.success?
         Detection.from_response resp, text
       end
 
       ##
       # TODO
-      def languages language = nil, quota_user: nil, user_ip: nil
-        resp = connection.languages language, quota_user: quota_user,
-                                              user_ip: user_ip
+      def languages language = nil
+        language = language.to_s if language
+        resp = connection.languages language
         fail ApiError.from_response(resp) unless resp.success?
         Array(resp.data["languages"]).map { |gapi| Language.from_gapi gapi }
       end

--- a/lib/gcloud/translate/api.rb
+++ b/lib/gcloud/translate/api.rb
@@ -1,0 +1,81 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud/translate/connection"
+require "gcloud/translate/translation"
+require "gcloud/translate/detection"
+require "gcloud/translate/language"
+require "gcloud/translate/errors"
+
+module Gcloud
+  module Translate
+    ##
+    # TODO
+    class Api
+      ##
+      # @private The Connection object.
+      attr_accessor :connection
+
+      ##
+      # @private Creates a new Translate Api instance.
+      #
+      # See {Gcloud.translate}
+      def initialize key
+        key ||= ENV["TRANSLATE_KEY"]
+        if key.nil?
+          key_mising_msg = "An API key is required to use the Translate API."
+          fail ArgumentError, key_mising_msg
+        end
+        @connection = Connection.new key
+      end
+
+      ##
+      # TODO
+      def translate *text, to: nil, from: nil, format: nil, cid: nil,
+                    quota_user: nil, user_ip: nil
+        return nil if text.empty?
+        fail ArgumentError, "to is required" if to.nil?
+        to = to.to_s
+        from = from.to_s if from
+        format = format.to_s if format
+        resp = connection.translate(*text, to: to, from: from,
+                                           format: format, cid: cid,
+                                           quota_user: quota_user,
+                                           user_ip: user_ip)
+        fail ApiError.from_response(resp) unless resp.success?
+        Translation.from_response resp, text, to, from
+      end
+
+      ##
+      # TODO
+      def detect *text, quota_user: nil, user_ip: nil
+        return nil if text.empty?
+        resp = connection.detect(*text, quota_user: quota_user,
+                                        user_ip: user_ip)
+        fail ApiError.from_response(resp) unless resp.success?
+        Detection.from_response resp, text
+      end
+
+      ##
+      # TODO
+      def languages language = nil, quota_user: nil, user_ip: nil
+        resp = connection.languages language, quota_user: quota_user,
+                                              user_ip: user_ip
+        fail ApiError.from_response(resp) unless resp.success?
+        Array(resp.data["languages"]).map { |gapi| Language.from_gapi gapi }
+      end
+    end
+  end
+end

--- a/lib/gcloud/translate/api.rb
+++ b/lib/gcloud/translate/api.rb
@@ -110,6 +110,7 @@ module Gcloud
         resp = connection.translate(*text, to: to, from: from,
                                            format: format, cid: cid)
         fail ApiError.from_response(resp) unless resp.success?
+        puts resp.body
         Translation.from_response resp, text, to, from
       end
 

--- a/lib/gcloud/translate/api.rb
+++ b/lib/gcloud/translate/api.rb
@@ -42,7 +42,65 @@ module Gcloud
       end
 
       ##
-      # TODO
+      # Returns text translations from one language to another.
+      #
+      # @param [String] text The text to translate.
+      # @param [String] to The target language into which the text should be
+      #   translated. This is an iso639-1 language code.
+      # @param [String] from The source language of the text. This is an
+      #   iso639-1 language code. This is optional.
+      # @param [String] text The format of the text. Possible values include
+      #   `:text` and `:html`. This is optional.
+      # @param [String] cid The customization id for translate. This is
+      #   optional.
+      #
+      # @return [Translation, Array<Translation>] A single {Translation} object
+      #   if just one text was given, or an array of {Translation} objects if
+      #   multiple texts were given.
+      #
+      # @example
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   translation = translate.translate "Hello world!", to: "la"
+      #   puts translation #=> Salve mundi!
+      #
+      # @example Setting the `from` language.
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   translation = translate.translate "Hello world!"
+      #                                     to: :la, from: :en,
+      #   puts translation #=> Salve mundi!
+      #
+      # @example Retrieving multiple translations.
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   translations = translate.translate "Hello my friend.",
+      #                                      "See you soon.",
+      #                                      to: "la", from: "en"
+      #   puts translations.count #=> 2
+      #   puts translations #=> Salve mi amice.
+      #                     #=> Vide te mox.
+      #
+      # @example Retrieving translation containing HTML tags.
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   translation = translate.translate "<em>Hello</em> world!",
+      #                                     to: :la, from: :en,
+      #                                     format: :html
+      #   puts translation #=> <em>Salve</em> mundi!
+      #
       def translate *text, to: nil, from: nil, format: nil, cid: nil
         return nil if text.empty?
         fail ArgumentError, "to is required" if to.nil?
@@ -56,7 +114,38 @@ module Gcloud
       end
 
       ##
-      # TODO
+      # Detect the language of text.
+      #
+      # @param [String] text The text to detect.
+      #
+      # @return [Detection, Array<Detection>] A single {Detection} object if
+      #   just one text was given, or an array of {Detection} objects if
+      #   multiple texts were given.
+      #
+      # @example
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   detection = translate.detect "Hello world!"
+      #   puts detection.language #=> en
+      #   puts detection.confidence #=> 0.7100697
+      #
+      # @example Detecting multiple texts.
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   detections = translate.detect "Hello world!",
+      #                                 "Bonjour le monde!"
+      #   puts detections.count #=> 2
+      #   puts detection.first.language #=> en
+      #   puts detection.first.confidence #=> 0.7100697
+      #   puts detection.last.language #=> fr
+      #   puts detection.last.confidence #=> 0.40440267
+      #
       def detect *text
         return nil if text.empty?
         resp = connection.detect(*text)
@@ -65,7 +154,40 @@ module Gcloud
       end
 
       ##
-      # TODO
+      # List the languages supported by the API. These are the languages that
+      # text can be translated to and from.
+      #
+      # @param [String] language The language and collation in which the names
+      #   of the languages are returned. If this is `nil` then no names are
+      #   returned.
+      #
+      # @return [Array<Language>] An array of {Language} objects supported by
+      #   the API.
+      #
+      # @example
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   languages = translate.languages
+      #   puts languages.count #=> 104
+      #
+      #   english = languages.detect { |l| l.code == "en" }
+      #   puts english.name #=> nil
+      #
+      # @example Get all languages with their names in French.Anglais
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   translate = gcloud.translate
+      #
+      #   languages = translate.languages "fr"
+      #   puts languages.count #=> 104
+      #
+      #   english = languages.detect { |l| l.code == "en" }
+      #   puts english.name #=> Anglais
+      #
       def languages language = nil
         language = language.to_s if language
         resp = connection.languages language

--- a/lib/gcloud/translate/connection.rb
+++ b/lib/gcloud/translate/connection.rb
@@ -36,15 +36,12 @@ module Gcloud
         @client.key = key # set key after discovery, helps with tests
       end
 
-      def translate *text, to: nil, from: nil, format: nil, cid: nil,
-                    quota_user: nil, user_ip: nil
+      def translate *text, to: nil, from: nil, format: nil, cid: nil
         params = { q:         text,
                    target:    to,
                    source:    from,
                    format:    format,
-                   cid:       cid,
-                   quotaUser: quota_user,
-                   userIp:    user_ip
+                   cid:       cid
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(
@@ -53,23 +50,15 @@ module Gcloud
         )
       end
 
-      def detect *text, quota_user: nil, user_ip: nil
-        params = { q:         text,
-                   quotaUser: quota_user,
-                   userIp:    user_ip
-                 }.delete_if { |_, v| v.nil? }
-
+      def detect *text
         @client.execute(
           api_method: @translate.detections.list,
-          parameters: params
+          parameters: { q: text }
         )
       end
 
-      def languages language = nil, quota_user: nil, user_ip: nil
-        params = { target:    language,
-                   quotaUser: quota_user,
-                   userIp:    user_ip
-                 }.delete_if { |_, v| v.nil? }
+      def languages language = nil
+        params = { target: language }.delete_if { |_, v| v.nil? }
 
         @client.execute(
           api_method: @translate.languages.list,

--- a/lib/gcloud/translate/connection.rb
+++ b/lib/gcloud/translate/connection.rb
@@ -1,0 +1,85 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud/version"
+require "google/api_client"
+
+module Gcloud
+  module Translate
+    ##
+    # @private Represents the connection to Translate, as well as expose the API
+    # calls
+    class Connection
+      API_VERSION = "v2"
+
+      attr_accessor :client
+
+      ##
+      # Creates a new Connection instance.
+      def initialize key
+        @client = Google::APIClient.new application_name:    "gcloud-ruby",
+                                        application_version: Gcloud::VERSION,
+                                        authorization: nil
+        @translate = @client.discovered_api "translate", API_VERSION
+        @client.key = key # set key after discovery, helps with tests
+      end
+
+      def translate *text, to: nil, from: nil, format: nil, cid: nil,
+                    quota_user: nil, user_ip: nil
+        params = { q:         text,
+                   target:    to,
+                   source:    from,
+                   format:    format,
+                   cid:       cid,
+                   quotaUser: quota_user,
+                   userIp:    user_ip
+                 }.delete_if { |_, v| v.nil? }
+
+        @client.execute(
+          api_method: @translate.translations.list,
+          parameters: params
+        )
+      end
+
+      def detect *text, quota_user: nil, user_ip: nil
+        params = { q:         text,
+                   quotaUser: quota_user,
+                   userIp:    user_ip
+                 }.delete_if { |_, v| v.nil? }
+
+        @client.execute(
+          api_method: @translate.detections.list,
+          parameters: params
+        )
+      end
+
+      def languages language = nil, quota_user: nil, user_ip: nil
+        params = { target:    language,
+                   quotaUser: quota_user,
+                   userIp:    user_ip
+                 }.delete_if { |_, v| v.nil? }
+
+        @client.execute(
+          api_method: @translate.languages.list,
+          parameters: params
+        )
+      end
+
+      def inspect
+        "#{self.class}(#{@project})"
+      end
+    end
+  end
+end

--- a/lib/gcloud/translate/connection.rb
+++ b/lib/gcloud/translate/connection.rb
@@ -37,11 +37,12 @@ module Gcloud
       end
 
       def translate *text, to: nil, from: nil, format: nil, cid: nil
-        params = { q:         text,
-                   target:    to,
-                   source:    from,
-                   format:    format,
-                   cid:       cid
+        params = { q:           text,
+                   target:      to,
+                   source:      from,
+                   format:      format,
+                   cid:         cid,
+                   prettyprint: false
                  }.delete_if { |_, v| v.nil? }
 
         @client.execute(
@@ -53,12 +54,13 @@ module Gcloud
       def detect *text
         @client.execute(
           api_method: @translate.detections.list,
-          parameters: { q: text }
+          parameters: { q: text, prettyprint: false }
         )
       end
 
       def languages language = nil
-        params = { target: language }.delete_if { |_, v| v.nil? }
+        params = { target:      language,
+                   prettyprint: false }.delete_if { |_, v| v.nil? }
 
         @client.execute(
           api_method: @translate.languages.list,

--- a/lib/gcloud/translate/detection.rb
+++ b/lib/gcloud/translate/detection.rb
@@ -18,24 +18,48 @@ module Gcloud
     ##
     # TODO
     class Detection
+      ##
+      # The text the language detection was performed on.
+      #
+      # @return [String]
       attr_reader :text
+
+      ##
+      # A list of of languages which were detected for the given text. The most
+      # likely language detection is listed first.
+      #
+      # @return [Array<Detection::Result>]
       attr_reader :results
 
+      ##
+      # @private Create a new object.
       def initialize text, results
         @text = text
         @results = results
       end
 
+      ##
+      # The confidence of the most likely detection result.
+      #
+      # @return [Float]
       def confidence
         return nil if results.empty?
         results.first.confidence
       end
 
+      ##
+      # The most likely language detected. This is an iso639-1 language code.
+      #
+      # @return [String]
       def language
         return nil if results.empty?
         results.first.language
       end
 
+      ##
+      # Whether the most likely language detection result was deemed reliable.
+      #
+      # @return [Booean]
       def reliable?
         return nil if results.empty?
         results.first.reliable?
@@ -54,15 +78,30 @@ module Gcloud
       end
 
       class Result
+        ##
+        # The confidence of the detection result.
+        #
+        # @return [Float]
         attr_reader :confidence
+
+        ##
+        # The language detected. This is an iso639-1 language code.
+        #
+        # @return [String]
         attr_reader :language
 
+        ##
+        # @private Create a new object.
         def initialize confidence, language, reliable
           @confidence = confidence
           @language = language
           @reliable = reliable
         end
 
+        ##
+        # Whether the language detection result was deemed reliable.
+        #
+        # @return [Booean]
         def reliable?
           @reliable
         end

--- a/lib/gcloud/translate/detection.rb
+++ b/lib/gcloud/translate/detection.rb
@@ -57,15 +57,6 @@ module Gcloud
       end
 
       ##
-      # Whether the most likely language detection result was deemed reliable.
-      #
-      # @return [Booean]
-      def reliable?
-        return nil if results.empty?
-        results.first.reliable?
-      end
-
-      ##
       # @private New Detection from a DetectionsListResponse object as
       # defined by the Google API Client object.
       def self.from_response resp, text
@@ -92,25 +83,16 @@ module Gcloud
 
         ##
         # @private Create a new object.
-        def initialize confidence, language, reliable
+        def initialize confidence, language
           @confidence = confidence
           @language = language
-          @reliable = reliable
-        end
-
-        ##
-        # Whether the language detection result was deemed reliable.
-        #
-        # @return [Booean]
-        def reliable?
-          @reliable
         end
 
         ##
         # @private New Detection::Result from a DetectionsResource object as
         # defined by the Google API Client object.
         def self.from_gapi gapi
-          new gapi["confidence"], gapi["language"], gapi["isReliable"]
+          new gapi["confidence"], gapi["language"]
         end
       end
     end

--- a/lib/gcloud/translate/detection.rb
+++ b/lib/gcloud/translate/detection.rb
@@ -1,0 +1,79 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Gcloud
+  module Translate
+    ##
+    # TODO
+    class Detection
+      attr_reader :text
+      attr_reader :results
+
+      def initialize text, results
+        @text = text
+        @results = results
+      end
+
+      def confidence
+        return nil if results.empty?
+        results.first.confidence
+      end
+
+      def language
+        return nil if results.empty?
+        results.first.language
+      end
+
+      def reliable?
+        return nil if results.empty?
+        results.first.reliable?
+      end
+
+      ##
+      # @private New Detection from a DetectionsListResponse object as
+      # defined by the Google API Client object.
+      def self.from_response resp, text
+        res = text.zip(Array(resp.data.detections)).map do |txt, gapi_list|
+          results = gapi_list.map { |gapi| Result.from_gapi gapi }
+          new txt, results
+        end
+        return res.first if res.size == 1
+        res
+      end
+
+      class Result
+        attr_reader :confidence
+        attr_reader :language
+
+        def initialize confidence, language, reliable
+          @confidence = confidence
+          @language = language
+          @reliable = reliable
+        end
+
+        def reliable?
+          @reliable
+        end
+
+        ##
+        # @private New Detection::Result from a DetectionsResource object as
+        # defined by the Google API Client object.
+        def self.from_gapi gapi
+          new gapi["confidence"], gapi["language"], gapi["isReliable"]
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/translate/errors.rb
+++ b/lib/gcloud/translate/errors.rb
@@ -1,0 +1,68 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud/errors"
+
+module Gcloud
+  module Translate
+    ##
+    # Base Translate exception class.
+    class Error < Gcloud::Error
+    end
+
+    ##
+    # Raised when an API call is not successful.
+    class ApiError < Error
+      ##
+      # The code of the error.
+      attr_reader :code
+
+      ##
+      # The errors encountered.
+      attr_reader :errors
+
+      # @private
+      def initialize message, code, errors = []
+        super message
+        @code   = code
+        @errors = errors
+      end
+
+      # @private
+      def self.from_response resp
+        if resp.data? && resp.data["error"]
+          from_response_data resp.data["error"]
+        else
+          from_response_status resp
+        end
+      end
+
+      # @private
+      def self.from_response_data error
+        new error["message"], error["code"], error["errors"]
+      end
+
+      # @private
+      def self.from_response_status resp
+        if resp.status == 404
+          new "#{resp.error_message}: #{resp.request.uri.request_uri}",
+              resp.status
+        else
+          new resp.error_message, resp.status
+        end
+      end
+    end
+  end
+end

--- a/lib/gcloud/translate/language.rb
+++ b/lib/gcloud/translate/language.rb
@@ -1,0 +1,37 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Gcloud
+  module Translate
+    ##
+    # TODO
+    class Language
+      attr_reader :code
+      attr_reader :name
+
+      def initialize code, name
+        @code = code
+        @name = name
+      end
+
+      ##
+      # @private New Language from a LanguagesResource object as defined by the
+      # Google API Client object.
+      def self.from_gapi gapi
+        new gapi["language"], gapi["name"]
+      end
+    end
+  end
+end

--- a/lib/gcloud/translate/language.rb
+++ b/lib/gcloud/translate/language.rb
@@ -18,9 +18,20 @@ module Gcloud
     ##
     # TODO
     class Language
+      ##
+      # The language code. This is an iso639-1 language code.
+      #
+      # @return [String]
       attr_reader :code
+
+      ##
+      # The localized name of the language, if available.
+      #
+      # @return [String]
       attr_reader :name
 
+      ##
+      # @private Create a new object.
       def initialize code, name
         @code = code
         @name = name

--- a/lib/gcloud/translate/translation.rb
+++ b/lib/gcloud/translate/translation.rb
@@ -1,0 +1,65 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Gcloud
+  module Translate
+    ##
+    # TODO
+    class Translation
+      attr_reader :text
+      attr_reader :to
+      alias_method :language, :to
+      alias_method :target, :to
+      attr_reader :origin
+      attr_reader :from
+      alias_method :source, :from
+
+      def initialize text, to, origin, from, detected
+        @text = text
+        @to = to
+        @origin = origin
+        @from = from
+        @detected = detected
+      end
+
+      def detected?
+        @detected
+      end
+
+      alias_method :to_s, :text
+      alias_method :to_str, :text
+
+      ##
+      # @private New Translation from a TranslationsListResponse object as
+      # defined by the Google API Client object.
+      def self.from_response resp, text, to, from
+        res = text.zip(Array(resp.data["translations"])).map do |origin, gapi|
+          from_gapi gapi, to, origin, from
+        end
+        return res.first if res.size == 1
+        res
+      end
+
+      ##
+      # @private New Translation from a TranslationsResource object as defined
+      # by the Google API Client object.
+      def self.from_gapi gapi, to, origin, from
+        from ||= gapi["detectedSourceLanguage"]
+        detected = !gapi["detectedSourceLanguage"].nil?
+        new gapi["translatedText"], to, origin, from, detected
+      end
+    end
+  end
+end

--- a/lib/gcloud/translate/translation.rb
+++ b/lib/gcloud/translate/translation.rb
@@ -18,14 +18,35 @@ module Gcloud
     ##
     # TODO
     class Translation
+      ##
+      # The translated text.
+      #
+      # @return [String]
       attr_reader :text
+      alias_method :to_s, :text
+      alias_method :to_str, :text
+
+      ##
+      # The that was translated.
+      #
+      # @return [String]
+      attr_reader :origin
+
+      ##
+      # The target language the text was translated to.
+      #
+      # @return [String]
       attr_reader :to
       alias_method :language, :to
       alias_method :target, :to
-      attr_reader :origin
+
+      ##
+      # The source language the text was translated from.
       attr_reader :from
       alias_method :source, :from
 
+      ##
+      # @private Create a new object.
       def initialize text, to, origin, from, detected
         @text = text
         @to = to
@@ -34,12 +55,14 @@ module Gcloud
         @detected = detected
       end
 
+      ##
+      # Determines if the source language the text was translated from was
+      # detected by the Google Cloud Translate API.
+      #
+      # @return [Boolean]
       def detected?
         @detected
       end
-
-      alias_method :to_s, :text
-      alias_method :to_str, :text
 
       ##
       # @private New Translation from a TranslationsListResponse object as

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -64,6 +64,12 @@ namespace :test do
     Dir.glob("test/gcloud/logging/**/*_test.rb").each { |file| require_relative "../#{file}"}
   end
 
+  desc "Runs translate tests."
+  task :translate do
+    $LOAD_PATH.unshift "lib", "test"
+    Dir.glob("test/gcloud/translate/**/*_test.rb").each { |file| require_relative "../#{file}"}
+  end
+
   desc "Runs tests with coverage."
   task :coverage, :project, :keyfile do |t, args|
     project = args[:project]
@@ -430,6 +436,12 @@ namespace :test do
           puts e.message
         end
       end
+    end
+
+    desc "Runs the translate acceptance tests."
+    task :translate do |t, args|
+      $LOAD_PATH.unshift "lib", "test", "acceptance"
+      Dir.glob("acceptance/translate/**/*_test.rb").each { |file| require_relative "../#{file}"}
     end
 
     desc "Removes *ALL* acceptance test data. Use with caution."

--- a/test/gcloud/translate/detect_test.rb
+++ b/test/gcloud/translate/detect_test.rb
@@ -18,33 +18,12 @@ describe Gcloud::Translate::Api, :detect, :mock_translate do
   it "doesn't make an API call if text is not given" do
     detection = translate.detect
     detection.must_be :nil?
-
-    detection = translate.detect quota_user: "quota_user-1234567899"
-    detection.must_be :nil?
   end
-
-  it "detects multiple langauges with user_ip" do
-    mock_connection.get "/language/translate/v2/detect" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   ["Hello", "Hola"]
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_equal "127.0.0.1"
-      [200, { "Content-Type" => "application/json" },
-       detect_json("en", "es")]
-    end
-
-    detections = translate.detect "Hello", "Hola", user_ip: "127.0.0.1"
-    translation = translate.translate to: "es", from: :en, format: :html
-    translation.must_be :nil?
-  end
-
 
   it "detects a single langauge" do
     mock_connection.get "/language/translate/v2/detect" do |env|
       env.params["key"].must_equal key
       env.params["q"].must_equal   "Hello"
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        detect_json("en")]
     end
@@ -55,93 +34,15 @@ describe Gcloud::Translate::Api, :detect, :mock_translate do
     detection.results.first.language.must_equal "en"
   end
 
-  it "detects a single langauge with quota_user" do
-    mock_connection.get "/language/translate/v2/detect" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   "Hello"
-      env.params["quotaUser"].must_equal "quota_user-1234567899"
-      env.params["userIp"].must_be :nil?
-      [200, { "Content-Type" => "application/json" },
-       detect_json("en")]
-    end
-
-    detection = translate.detect "Hello", quota_user: "quota_user-1234567899"
-    detection.language.must_equal "en"
-    detection.results.count.must_equal 1
-    detection.results.first.language.must_equal "en"
-  end
-
-  it "detects a single langauge with user_ip" do
-    mock_connection.get "/language/translate/v2/detect" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   "Hello"
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_equal "127.0.0.1"
-      [200, { "Content-Type" => "application/json" },
-       detect_json("en")]
-    end
-
-    detection = translate.detect "Hello", user_ip: "127.0.0.1"
-    detection.language.must_equal "en"
-    detection.results.count.must_equal 1
-    detection.results.first.language.must_equal "en"
-  end
-
   it "detects multiple langauges" do
     mock_connection.get "/language/translate/v2/detect" do |env|
       env.params["key"].must_equal key
       env.params["q"].must_equal   ["Hello", "Hola"]
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        detect_json("en", "es")]
     end
 
     detections = translate.detect "Hello", "Hola"
-    detections.count.must_equal 2
-
-    detections.first.language.must_equal "en"
-    detections.first.results.count.must_equal 1
-    detections.first.results.first.language.must_equal "en"
-
-    detections.last.language.must_equal "es"
-    detections.last.results.count.must_equal 1
-    detections.last.results.first.language.must_equal "es"
-  end
-
-  it "detects multiple langauges with quota_user" do
-    mock_connection.get "/language/translate/v2/detect" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   ["Hello", "Hola"]
-      env.params["quotaUser"].must_equal "quota_user-1234567899"
-      env.params["userIp"].must_be :nil?
-      [200, { "Content-Type" => "application/json" },
-       detect_json("en", "es")]
-    end
-
-    detections = translate.detect "Hello", "Hola", quota_user: "quota_user-1234567899"
-    detections.count.must_equal 2
-
-    detections.first.language.must_equal "en"
-    detections.first.results.count.must_equal 1
-    detections.first.results.first.language.must_equal "en"
-
-    detections.last.language.must_equal "es"
-    detections.last.results.count.must_equal 1
-    detections.last.results.first.language.must_equal "es"
-  end
-
-  it "detects multiple langauges with user_ip" do
-    mock_connection.get "/language/translate/v2/detect" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   ["Hello", "Hola"]
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_equal "127.0.0.1"
-      [200, { "Content-Type" => "application/json" },
-       detect_json("en", "es")]
-    end
-
-    detections = translate.detect "Hello", "Hola", user_ip: "127.0.0.1"
     detections.count.must_equal 2
 
     detections.first.language.must_equal "en"

--- a/test/gcloud/translate/detect_test.rb
+++ b/test/gcloud/translate/detect_test.rb
@@ -1,0 +1,155 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Translate::Api, :detect, :mock_translate do
+  it "doesn't make an API call if text is not given" do
+    detection = translate.detect
+    detection.must_be :nil?
+
+    detection = translate.detect quota_user: "quota_user-1234567899"
+    detection.must_be :nil?
+  end
+
+  it "detects multiple langauges with user_ip" do
+    mock_connection.get "/language/translate/v2/detect" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "Hola"]
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_equal "127.0.0.1"
+      [200, { "Content-Type" => "application/json" },
+       detect_json("en", "es")]
+    end
+
+    detections = translate.detect "Hello", "Hola", user_ip: "127.0.0.1"
+    translation = translate.translate to: "es", from: :en, format: :html
+    translation.must_be :nil?
+  end
+
+
+  it "detects a single langauge" do
+    mock_connection.get "/language/translate/v2/detect" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       detect_json("en")]
+    end
+
+    detection = translate.detect "Hello"
+    detection.language.must_equal "en"
+    detection.results.count.must_equal 1
+    detection.results.first.language.must_equal "en"
+  end
+
+  it "detects a single langauge with quota_user" do
+    mock_connection.get "/language/translate/v2/detect" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["quotaUser"].must_equal "quota_user-1234567899"
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       detect_json("en")]
+    end
+
+    detection = translate.detect "Hello", quota_user: "quota_user-1234567899"
+    detection.language.must_equal "en"
+    detection.results.count.must_equal 1
+    detection.results.first.language.must_equal "en"
+  end
+
+  it "detects a single langauge with user_ip" do
+    mock_connection.get "/language/translate/v2/detect" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_equal "127.0.0.1"
+      [200, { "Content-Type" => "application/json" },
+       detect_json("en")]
+    end
+
+    detection = translate.detect "Hello", user_ip: "127.0.0.1"
+    detection.language.must_equal "en"
+    detection.results.count.must_equal 1
+    detection.results.first.language.must_equal "en"
+  end
+
+  it "detects multiple langauges" do
+    mock_connection.get "/language/translate/v2/detect" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "Hola"]
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       detect_json("en", "es")]
+    end
+
+    detections = translate.detect "Hello", "Hola"
+    detections.count.must_equal 2
+
+    detections.first.language.must_equal "en"
+    detections.first.results.count.must_equal 1
+    detections.first.results.first.language.must_equal "en"
+
+    detections.last.language.must_equal "es"
+    detections.last.results.count.must_equal 1
+    detections.last.results.first.language.must_equal "es"
+  end
+
+  it "detects multiple langauges with quota_user" do
+    mock_connection.get "/language/translate/v2/detect" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "Hola"]
+      env.params["quotaUser"].must_equal "quota_user-1234567899"
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       detect_json("en", "es")]
+    end
+
+    detections = translate.detect "Hello", "Hola", quota_user: "quota_user-1234567899"
+    detections.count.must_equal 2
+
+    detections.first.language.must_equal "en"
+    detections.first.results.count.must_equal 1
+    detections.first.results.first.language.must_equal "en"
+
+    detections.last.language.must_equal "es"
+    detections.last.results.count.must_equal 1
+    detections.last.results.first.language.must_equal "es"
+  end
+
+  it "detects multiple langauges with user_ip" do
+    mock_connection.get "/language/translate/v2/detect" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "Hola"]
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_equal "127.0.0.1"
+      [200, { "Content-Type" => "application/json" },
+       detect_json("en", "es")]
+    end
+
+    detections = translate.detect "Hello", "Hola", user_ip: "127.0.0.1"
+    detections.count.must_equal 2
+
+    detections.first.language.must_equal "en"
+    detections.first.results.count.must_equal 1
+    detections.first.results.first.language.must_equal "en"
+
+    detections.last.language.must_equal "es"
+    detections.last.results.count.must_equal 1
+    detections.last.results.first.language.must_equal "es"
+  end
+end

--- a/test/gcloud/translate/languages_test.rb
+++ b/test/gcloud/translate/languages_test.rb
@@ -19,8 +19,6 @@ describe Gcloud::Translate::Api, :languages, :mock_translate do
     mock_connection.get "/language/translate/v2/languages" do |env|
       env.params["key"].must_equal key
       env.params["target"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        language_json]
     end
@@ -30,77 +28,15 @@ describe Gcloud::Translate::Api, :languages, :mock_translate do
     languages.first.name.must_be :nil?
   end
 
-  it "lists languages without a language with quota_user" do
-    mock_connection.get "/language/translate/v2/languages" do |env|
-      env.params["key"].must_equal key
-      env.params["target"].must_be :nil?
-      env.params["quotaUser"].must_equal "quota_user-1234567899"
-      env.params["userIp"].must_be :nil?
-      [200, { "Content-Type" => "application/json" },
-       language_json]
-    end
-
-    languages = translate.languages quota_user: "quota_user-1234567899"
-    languages.count.must_be :>, 0
-    languages.first.name.must_be :nil?
-  end
-
-  it "lists languages without a language with user_ip" do
-    mock_connection.get "/language/translate/v2/languages" do |env|
-      env.params["key"].must_equal key
-      env.params["target"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_equal "127.0.0.1"
-      [200, { "Content-Type" => "application/json" },
-       language_json]
-    end
-
-    languages = translate.languages user_ip: "127.0.0.1"
-    languages.count.must_be :>, 0
-    languages.first.name.must_be :nil?
-  end
-
   it "lists languages with a language" do
     mock_connection.get "/language/translate/v2/languages" do |env|
       env.params["key"].must_equal key
       env.params["target"].must_equal "en"
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        language_json("en")]
     end
 
     languages = translate.languages "en"
-    languages.count.must_be :>, 0
-    languages.first.name.wont_be :nil?
-  end
-
-  it "lists languages with a language with quota_user" do
-    mock_connection.get "/language/translate/v2/languages" do |env|
-      env.params["key"].must_equal key
-      env.params["target"].must_equal "en"
-      env.params["quotaUser"].must_equal "quota_user-1234567899"
-      env.params["userIp"].must_be :nil?
-      [200, { "Content-Type" => "application/json" },
-       language_json("en")]
-    end
-
-    languages = translate.languages "en", quota_user: "quota_user-1234567899"
-    languages.count.must_be :>, 0
-    languages.first.name.wont_be :nil?
-  end
-
-  it "lists languages with a language with user_ip" do
-    mock_connection.get "/language/translate/v2/languages" do |env|
-      env.params["key"].must_equal key
-      env.params["target"].must_equal "en"
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_equal "127.0.0.1"
-      [200, { "Content-Type" => "application/json" },
-       language_json("en")]
-    end
-
-    languages = translate.languages "en", user_ip: "127.0.0.1"
     languages.count.must_be :>, 0
     languages.first.name.wont_be :nil?
   end

--- a/test/gcloud/translate/languages_test.rb
+++ b/test/gcloud/translate/languages_test.rb
@@ -1,0 +1,107 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Translate::Api, :languages, :mock_translate do
+  it "lists languages without a language" do
+    mock_connection.get "/language/translate/v2/languages" do |env|
+      env.params["key"].must_equal key
+      env.params["target"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       language_json]
+    end
+
+    languages = translate.languages
+    languages.count.must_be :>, 0
+    languages.first.name.must_be :nil?
+  end
+
+  it "lists languages without a language with quota_user" do
+    mock_connection.get "/language/translate/v2/languages" do |env|
+      env.params["key"].must_equal key
+      env.params["target"].must_be :nil?
+      env.params["quotaUser"].must_equal "quota_user-1234567899"
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       language_json]
+    end
+
+    languages = translate.languages quota_user: "quota_user-1234567899"
+    languages.count.must_be :>, 0
+    languages.first.name.must_be :nil?
+  end
+
+  it "lists languages without a language with user_ip" do
+    mock_connection.get "/language/translate/v2/languages" do |env|
+      env.params["key"].must_equal key
+      env.params["target"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_equal "127.0.0.1"
+      [200, { "Content-Type" => "application/json" },
+       language_json]
+    end
+
+    languages = translate.languages user_ip: "127.0.0.1"
+    languages.count.must_be :>, 0
+    languages.first.name.must_be :nil?
+  end
+
+  it "lists languages with a language" do
+    mock_connection.get "/language/translate/v2/languages" do |env|
+      env.params["key"].must_equal key
+      env.params["target"].must_equal "en"
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       language_json("en")]
+    end
+
+    languages = translate.languages "en"
+    languages.count.must_be :>, 0
+    languages.first.name.wont_be :nil?
+  end
+
+  it "lists languages with a language with quota_user" do
+    mock_connection.get "/language/translate/v2/languages" do |env|
+      env.params["key"].must_equal key
+      env.params["target"].must_equal "en"
+      env.params["quotaUser"].must_equal "quota_user-1234567899"
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       language_json("en")]
+    end
+
+    languages = translate.languages "en", quota_user: "quota_user-1234567899"
+    languages.count.must_be :>, 0
+    languages.first.name.wont_be :nil?
+  end
+
+  it "lists languages with a language with user_ip" do
+    mock_connection.get "/language/translate/v2/languages" do |env|
+      env.params["key"].must_equal key
+      env.params["target"].must_equal "en"
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_equal "127.0.0.1"
+      [200, { "Content-Type" => "application/json" },
+       language_json("en")]
+    end
+
+    languages = translate.languages "en", user_ip: "127.0.0.1"
+    languages.count.must_be :>, 0
+    languages.first.name.wont_be :nil?
+  end
+end

--- a/test/gcloud/translate/translate_test.rb
+++ b/test/gcloud/translate/translate_test.rb
@@ -1,0 +1,391 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Translate::Api, :translate, :mock_translate do
+  it "doesn't make an API call if text is not given" do
+    translation = translate.translate
+    translation.must_be :nil?
+
+    translation = translate.translate to: "es", from: :en, format: :html
+    translation.must_be :nil?
+  end
+
+  it "translates a single input" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en")]
+    end
+
+    translation = translate.translate "Hello", to: "es"
+    translation.text.must_equal "Hola"
+    translation.origin.must_equal "Hello"
+    translation.to.must_equal "es"
+    translation.language.must_equal "es"
+    translation.target.must_equal "es"
+    translation.from.must_equal "en"
+    translation.source.must_equal "en"
+    translation.must_be :detected?
+  end
+
+  it "translates a single input with from" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["target"].must_equal "es"
+      env.params["source"].must_equal "en"
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", nil)]
+    end
+
+    translation = translate.translate "Hello", to: "es", from: :en
+    translation.text.must_equal "Hola"
+    translation.origin.must_equal "Hello"
+    translation.to.must_equal "es"
+    translation.language.must_equal "es"
+    translation.target.must_equal "es"
+    translation.from.must_equal "en"
+    translation.source.must_equal "en"
+    translation.wont_be :detected?
+  end
+
+  it "translates a single input with format" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "<h1>Hello</h1>"
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_equal "html"
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("<h1>Hola</h1>", "en")]
+    end
+
+    translation = translate.translate "<h1>Hello</h1>", to: "es", format: :html
+    translation.text.must_equal "<h1>Hola</h1>"
+    translation.origin.must_equal "<h1>Hello</h1>"
+    translation.to.must_equal "es"
+    translation.language.must_equal "es"
+    translation.target.must_equal "es"
+    translation.from.must_equal "en"
+    translation.source.must_equal "en"
+    translation.must_be :detected?
+  end
+
+  it "translates a single input with cid" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_equal "user-1234567899"
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en")]
+    end
+
+    translation = translate.translate "Hello", to: "es", cid: "user-1234567899"
+    translation.text.must_equal "Hola"
+    translation.origin.must_equal "Hello"
+    translation.to.must_equal "es"
+    translation.language.must_equal "es"
+    translation.target.must_equal "es"
+    translation.from.must_equal "en"
+    translation.source.must_equal "en"
+    translation.must_be :detected?
+  end
+
+  it "translates a single input with quota_user" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_equal "quota_user-1234567899"
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en")]
+    end
+
+    translation = translate.translate "Hello", to: "es", quota_user: "quota_user-1234567899"
+    translation.text.must_equal "Hola"
+    translation.origin.must_equal "Hello"
+    translation.to.must_equal "es"
+    translation.language.must_equal "es"
+    translation.target.must_equal "es"
+    translation.from.must_equal "en"
+    translation.source.must_equal "en"
+    translation.must_be :detected?
+  end
+
+  it "translates a single input with user_ip" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_equal "127.0.0.1"
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en")]
+    end
+
+    translation = translate.translate "Hello", to: "es", user_ip: "127.0.0.1"
+    translation.text.must_equal "Hola"
+    translation.origin.must_equal "Hello"
+    translation.to.must_equal "es"
+    translation.language.must_equal "es"
+    translation.target.must_equal "es"
+    translation.from.must_equal "en"
+    translation.source.must_equal "en"
+    translation.must_be :detected?
+  end
+
+  it "translates multiple inputs" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "How are you today?"]
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en", "Como estas hoy?", "en")]
+    end
+
+    translations = translate.translate "Hello", "How are you today?", to: "es"
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "Hola"
+    translations.first.origin.must_equal "Hello"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.must_be :detected?
+
+    translations.last.text.must_equal "Como estas hoy?"
+    translations.last.origin.must_equal "How are you today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.must_be :detected?
+  end
+
+  it "translates multiple inputs with from" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "How are you today?"]
+      env.params["target"].must_equal "es"
+      env.params["source"].must_equal "en"
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", nil, "Como estas hoy?", nil)]
+    end
+
+    translations = translate.translate "Hello", "How are you today?", to: :es, from: :en
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "Hola"
+    translations.first.origin.must_equal "Hello"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.wont_be :detected?
+
+    translations.last.text.must_equal "Como estas hoy?"
+    translations.last.origin.must_equal "How are you today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.wont_be :detected?
+  end
+
+  it "translates multiple inputs with format" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["<h1>Hello</h1>", "How are <em>you</em> today?"]
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_equal "html"
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("<h1>Hola</h1>", "en", "Como estas <em>hoy</em>?", "en")]
+    end
+
+    translations = translate.translate "<h1>Hello</h1>", "How are <em>you</em> today?", to: "es", format: :html
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "<h1>Hola</h1>"
+    translations.first.origin.must_equal "<h1>Hello</h1>"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.must_be :detected?
+
+    translations.last.text.must_equal "Como estas <em>hoy</em>?"
+    translations.last.origin.must_equal "How are <em>you</em> today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.must_be :detected?
+  end
+
+  it "translates multiple inputs with cid" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "How are you today?"]
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_equal "user-1234567899"
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en", "Como estas hoy?", "en")]
+    end
+
+    translations = translate.translate "Hello", "How are you today?", to: "es", cid: "user-1234567899"
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "Hola"
+    translations.first.origin.must_equal "Hello"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.must_be :detected?
+
+    translations.last.text.must_equal "Como estas hoy?"
+    translations.last.origin.must_equal "How are you today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.must_be :detected?
+  end
+
+  it "translates multiple inputs with quota_user" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "How are you today?"]
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_equal "quota_user-1234567899"
+      env.params["userIp"].must_be :nil?
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en", "Como estas hoy?", "en")]
+    end
+
+    translations = translate.translate "Hello", "How are you today?", to: "es", quota_user: "quota_user-1234567899"
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "Hola"
+    translations.first.origin.must_equal "Hello"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.must_be :detected?
+
+    translations.last.text.must_equal "Como estas hoy?"
+    translations.last.origin.must_equal "How are you today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.must_be :detected?
+  end
+
+  it "translates multiple inputs with user_ip" do
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   ["Hello", "How are you today?"]
+      env.params["target"].must_equal "es"
+      env.params["source"].must_be :nil?
+      env.params["format"].must_be :nil?
+      env.params["cid"].must_be :nil?
+      env.params["quotaUser"].must_be :nil?
+      env.params["userIp"].must_equal "127.0.0.1"
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en", "Como estas hoy?", "en")]
+    end
+
+    translations = translate.translate "Hello", "How are you today?", to: "es", user_ip: "127.0.0.1"
+    translations.count.must_equal 2
+
+    translations.first.text.must_equal "Hola"
+    translations.first.origin.must_equal "Hello"
+    translations.first.to.must_equal "es"
+    translations.first.language.must_equal "es"
+    translations.first.target.must_equal "es"
+    translations.first.from.must_equal "en"
+    translations.first.source.must_equal "en"
+    translations.first.must_be :detected?
+
+    translations.last.text.must_equal "Como estas hoy?"
+    translations.last.origin.must_equal "How are you today?"
+    translations.last.to.must_equal "es"
+    translations.last.language.must_equal "es"
+    translations.last.target.must_equal "es"
+    translations.last.from.must_equal "en"
+    translations.last.source.must_equal "en"
+    translations.last.must_be :detected?
+  end
+end

--- a/test/gcloud/translate/translate_test.rb
+++ b/test/gcloud/translate/translate_test.rb
@@ -31,8 +31,6 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_be :nil?
       env.params["format"].must_be :nil?
       env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("Hola", "en")]
     end
@@ -56,8 +54,6 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_equal "en"
       env.params["format"].must_be :nil?
       env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("Hola", nil)]
     end
@@ -81,8 +77,6 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_be :nil?
       env.params["format"].must_equal "html"
       env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("<h1>Hola</h1>", "en")]
     end
@@ -106,63 +100,11 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_be :nil?
       env.params["format"].must_be :nil?
       env.params["cid"].must_equal "user-1234567899"
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("Hola", "en")]
     end
 
     translation = translate.translate "Hello", to: "es", cid: "user-1234567899"
-    translation.text.must_equal "Hola"
-    translation.origin.must_equal "Hello"
-    translation.to.must_equal "es"
-    translation.language.must_equal "es"
-    translation.target.must_equal "es"
-    translation.from.must_equal "en"
-    translation.source.must_equal "en"
-    translation.must_be :detected?
-  end
-
-  it "translates a single input with quota_user" do
-    mock_connection.get "/language/translate/v2" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   "Hello"
-      env.params["target"].must_equal "es"
-      env.params["source"].must_be :nil?
-      env.params["format"].must_be :nil?
-      env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_equal "quota_user-1234567899"
-      env.params["userIp"].must_be :nil?
-      [200, { "Content-Type" => "application/json" },
-       translate_json("Hola", "en")]
-    end
-
-    translation = translate.translate "Hello", to: "es", quota_user: "quota_user-1234567899"
-    translation.text.must_equal "Hola"
-    translation.origin.must_equal "Hello"
-    translation.to.must_equal "es"
-    translation.language.must_equal "es"
-    translation.target.must_equal "es"
-    translation.from.must_equal "en"
-    translation.source.must_equal "en"
-    translation.must_be :detected?
-  end
-
-  it "translates a single input with user_ip" do
-    mock_connection.get "/language/translate/v2" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   "Hello"
-      env.params["target"].must_equal "es"
-      env.params["source"].must_be :nil?
-      env.params["format"].must_be :nil?
-      env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_equal "127.0.0.1"
-      [200, { "Content-Type" => "application/json" },
-       translate_json("Hola", "en")]
-    end
-
-    translation = translate.translate "Hello", to: "es", user_ip: "127.0.0.1"
     translation.text.must_equal "Hola"
     translation.origin.must_equal "Hello"
     translation.to.must_equal "es"
@@ -181,8 +123,6 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_be :nil?
       env.params["format"].must_be :nil?
       env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("Hola", "en", "Como estas hoy?", "en")]
     end
@@ -217,8 +157,6 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_equal "en"
       env.params["format"].must_be :nil?
       env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("Hola", nil, "Como estas hoy?", nil)]
     end
@@ -253,8 +191,6 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_be :nil?
       env.params["format"].must_equal "html"
       env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("<h1>Hola</h1>", "en", "Como estas <em>hoy</em>?", "en")]
     end
@@ -289,85 +225,11 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
       env.params["source"].must_be :nil?
       env.params["format"].must_be :nil?
       env.params["cid"].must_equal "user-1234567899"
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_be :nil?
       [200, { "Content-Type" => "application/json" },
        translate_json("Hola", "en", "Como estas hoy?", "en")]
     end
 
     translations = translate.translate "Hello", "How are you today?", to: "es", cid: "user-1234567899"
-    translations.count.must_equal 2
-
-    translations.first.text.must_equal "Hola"
-    translations.first.origin.must_equal "Hello"
-    translations.first.to.must_equal "es"
-    translations.first.language.must_equal "es"
-    translations.first.target.must_equal "es"
-    translations.first.from.must_equal "en"
-    translations.first.source.must_equal "en"
-    translations.first.must_be :detected?
-
-    translations.last.text.must_equal "Como estas hoy?"
-    translations.last.origin.must_equal "How are you today?"
-    translations.last.to.must_equal "es"
-    translations.last.language.must_equal "es"
-    translations.last.target.must_equal "es"
-    translations.last.from.must_equal "en"
-    translations.last.source.must_equal "en"
-    translations.last.must_be :detected?
-  end
-
-  it "translates multiple inputs with quota_user" do
-    mock_connection.get "/language/translate/v2" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   ["Hello", "How are you today?"]
-      env.params["target"].must_equal "es"
-      env.params["source"].must_be :nil?
-      env.params["format"].must_be :nil?
-      env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_equal "quota_user-1234567899"
-      env.params["userIp"].must_be :nil?
-      [200, { "Content-Type" => "application/json" },
-       translate_json("Hola", "en", "Como estas hoy?", "en")]
-    end
-
-    translations = translate.translate "Hello", "How are you today?", to: "es", quota_user: "quota_user-1234567899"
-    translations.count.must_equal 2
-
-    translations.first.text.must_equal "Hola"
-    translations.first.origin.must_equal "Hello"
-    translations.first.to.must_equal "es"
-    translations.first.language.must_equal "es"
-    translations.first.target.must_equal "es"
-    translations.first.from.must_equal "en"
-    translations.first.source.must_equal "en"
-    translations.first.must_be :detected?
-
-    translations.last.text.must_equal "Como estas hoy?"
-    translations.last.origin.must_equal "How are you today?"
-    translations.last.to.must_equal "es"
-    translations.last.language.must_equal "es"
-    translations.last.target.must_equal "es"
-    translations.last.from.must_equal "en"
-    translations.last.source.must_equal "en"
-    translations.last.must_be :detected?
-  end
-
-  it "translates multiple inputs with user_ip" do
-    mock_connection.get "/language/translate/v2" do |env|
-      env.params["key"].must_equal key
-      env.params["q"].must_equal   ["Hello", "How are you today?"]
-      env.params["target"].must_equal "es"
-      env.params["source"].must_be :nil?
-      env.params["format"].must_be :nil?
-      env.params["cid"].must_be :nil?
-      env.params["quotaUser"].must_be :nil?
-      env.params["userIp"].must_equal "127.0.0.1"
-      [200, { "Content-Type" => "application/json" },
-       translate_json("Hola", "en", "Como estas hoy?", "en")]
-    end
-
-    translations = translate.translate "Hello", "How are you today?", to: "es", user_ip: "127.0.0.1"
     translations.count.must_equal 2
 
     translations.first.text.must_equal "Hola"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,6 +26,7 @@ require "gcloud/dns"
 require "gcloud/resource_manager"
 require "gcloud/search"
 require "gcloud/logging"
+require "gcloud/translate"
 
 class MockStorage < Minitest::Spec
   let(:project) { storage.connection.project }
@@ -956,5 +957,55 @@ class MockLogging < Minitest::Spec
 
   def project_path
     "projects/#{project}"
+  end
+end
+
+
+class MockTranslate < Minitest::Spec
+  let(:key) { "test-api-key" }
+  let(:translate) { $gcloud_translate_global ||= Gcloud::Translate::Api.new(key) }
+
+  def setup
+    @connection = Faraday::Adapter::Test::Stubs.new
+    translate.connection.client.connection = Faraday.new "https://www.googleapis.com" do |builder|
+      builder.options.params_encoder = Faraday::FlatParamsEncoder
+      builder.adapter :test, @connection
+    end
+  end
+
+  def teardown
+    @connection.verify_stubbed_calls
+  end
+
+  def mock_connection
+    @connection
+  end
+
+  def translate_json *pairs
+    pairs = Array(pairs).flatten.each_slice(2).to_a
+    translations = pairs.map do |text, language|
+      { translatedText: text, detectedSourceLanguage: language }
+    end
+    { translations: translations }.to_json
+  end
+
+  def detect_json *languages
+    detections = languages.map do |lang|
+      [{ confidence: 0.123, isReliable: false, language: lang }]
+    end
+    { detections: detections }.to_json
+  end
+
+  def language_json lang = nil
+    if lang == "en"
+      {"languages"=>[{"language"=>"af", "name"=>"Afrikaans"}, {"language"=>"sq", "name"=>"Albanian"}, {"language"=>"am", "name"=>"Amharic"}, {"language"=>"ar", "name"=>"Arabic"}, {"language"=>"hy", "name"=>"Armenian"}, {"language"=>"az", "name"=>"Azerbaijani"}, {"language"=>"eu", "name"=>"Basque"}, {"language"=>"be", "name"=>"Belarusian"}, {"language"=>"bn", "name"=>"Bengali"}, {"language"=>"bs", "name"=>"Bosnian"}, {"language"=>"bg", "name"=>"Bulgarian"}, {"language"=>"ca", "name"=>"Catalan"}, {"language"=>"ceb", "name"=>"Cebuano"}, {"language"=>"ny", "name"=>"Chichewa"}, {"language"=>"zh", "name"=>"Chinese (Simplified)"}, {"language"=>"zh-TW", "name"=>"Chinese (Traditional)"}, {"language"=>"co", "name"=>"Corsican"}, {"language"=>"hr", "name"=>"Croatian"}, {"language"=>"cs", "name"=>"Czech"}, {"language"=>"da", "name"=>"Danish"}, {"language"=>"nl", "name"=>"Dutch"}, {"language"=>"en", "name"=>"English"}, {"language"=>"eo", "name"=>"Esperanto"}, {"language"=>"et", "name"=>"Estonian"}, {"language"=>"tl", "name"=>"Filipino"}, {"language"=>"fi", "name"=>"Finnish"}, {"language"=>"fr", "name"=>"French"}, {"language"=>"fy", "name"=>"Frisian"}, {"language"=>"gl", "name"=>"Galician"}, {"language"=>"ka", "name"=>"Georgian"}, {"language"=>"de", "name"=>"German"}, {"language"=>"el", "name"=>"Greek"}, {"language"=>"gu", "name"=>"Gujarati"}, {"language"=>"ht", "name"=>"Haitian Creole"}, {"language"=>"ha", "name"=>"Hausa"}, {"language"=>"haw", "name"=>"Hawaiian"}, {"language"=>"iw", "name"=>"Hebrew"}, {"language"=>"hi", "name"=>"Hindi"}, {"language"=>"hmn", "name"=>"Hmong"}, {"language"=>"hu", "name"=>"Hungarian"}, {"language"=>"is", "name"=>"Icelandic"}, {"language"=>"ig", "name"=>"Igbo"}, {"language"=>"id", "name"=>"Indonesian"}, {"language"=>"ga", "name"=>"Irish"}, {"language"=>"it", "name"=>"Italian"}, {"language"=>"ja", "name"=>"Japanese"}, {"language"=>"jw", "name"=>"Javanese"}, {"language"=>"kn", "name"=>"Kannada"}, {"language"=>"kk", "name"=>"Kazakh"}, {"language"=>"km", "name"=>"Khmer"}, {"language"=>"ko", "name"=>"Korean"}, {"language"=>"ku", "name"=>"Kurdish (Kurmanji)"}, {"language"=>"ky", "name"=>"Kyrgyz"}, {"language"=>"lo", "name"=>"Lao"}, {"language"=>"la", "name"=>"Latin"}, {"language"=>"lv", "name"=>"Latvian"}, {"language"=>"lt", "name"=>"Lithuanian"}, {"language"=>"lb", "name"=>"Luxembourgish"}, {"language"=>"mk", "name"=>"Macedonian"}, {"language"=>"mg", "name"=>"Malagasy"}, {"language"=>"ms", "name"=>"Malay"}, {"language"=>"ml", "name"=>"Malayalam"}, {"language"=>"mt", "name"=>"Maltese"}, {"language"=>"mi", "name"=>"Maori"}, {"language"=>"mr", "name"=>"Marathi"}, {"language"=>"mn", "name"=>"Mongolian"}, {"language"=>"my", "name"=>"Myanmar (Burmese)"}, {"language"=>"ne", "name"=>"Nepali"}, {"language"=>"no", "name"=>"Norwegian"}, {"language"=>"ps", "name"=>"Pashto"}, {"language"=>"fa", "name"=>"Persian"}, {"language"=>"pl", "name"=>"Polish"}, {"language"=>"pt", "name"=>"Portuguese"}, {"language"=>"pa", "name"=>"Punjabi"}, {"language"=>"ro", "name"=>"Romanian"}, {"language"=>"ru", "name"=>"Russian"}, {"language"=>"sm", "name"=>"Samoan"}, {"language"=>"gd", "name"=>"Scots Gaelic"}, {"language"=>"sr", "name"=>"Serbian"}, {"language"=>"st", "name"=>"Sesotho"}, {"language"=>"sn", "name"=>"Shona"}, {"language"=>"sd", "name"=>"Sindhi"}, {"language"=>"si", "name"=>"Sinhala"}, {"language"=>"sk", "name"=>"Slovak"}, {"language"=>"sl", "name"=>"Slovenian"}, {"language"=>"so", "name"=>"Somali"}, {"language"=>"es", "name"=>"Spanish"}, {"language"=>"su", "name"=>"Sundanese"}, {"language"=>"sw", "name"=>"Swahili"}, {"language"=>"sv", "name"=>"Swedish"}, {"language"=>"tg", "name"=>"Tajik"}, {"language"=>"ta", "name"=>"Tamil"}, {"language"=>"te", "name"=>"Telugu"}, {"language"=>"th", "name"=>"Thai"}, {"language"=>"tr", "name"=>"Turkish"}, {"language"=>"uk", "name"=>"Ukrainian"}, {"language"=>"ur", "name"=>"Urdu"}, {"language"=>"uz", "name"=>"Uzbek"}, {"language"=>"vi", "name"=>"Vietnamese"}, {"language"=>"cy", "name"=>"Welsh"}, {"language"=>"xh", "name"=>"Xhosa"}, {"language"=>"yi", "name"=>"Yiddish"}, {"language"=>"yo", "name"=>"Yoruba"}, {"language"=>"zu", "name"=>"Zulu"}]}.to_json
+    else
+      {"languages"=>[{"language"=>"af"}, {"language"=>"am"}, {"language"=>"ar"}, {"language"=>"az"}, {"language"=>"be"}, {"language"=>"bg"}, {"language"=>"bn"}, {"language"=>"bs"}, {"language"=>"ca"}, {"language"=>"ceb"}, {"language"=>"co"}, {"language"=>"cs"}, {"language"=>"cy"}, {"language"=>"da"}, {"language"=>"de"}, {"language"=>"el"}, {"language"=>"en"}, {"language"=>"eo"}, {"language"=>"es"}, {"language"=>"et"}, {"language"=>"eu"}, {"language"=>"fa"}, {"language"=>"fi"}, {"language"=>"fr"}, {"language"=>"fy"}, {"language"=>"ga"}, {"language"=>"gd"}, {"language"=>"gl"}, {"language"=>"gu"}, {"language"=>"ha"}, {"language"=>"haw"}, {"language"=>"hi"}, {"language"=>"hmn"}, {"language"=>"hr"}, {"language"=>"ht"}, {"language"=>"hu"}, {"language"=>"hy"}, {"language"=>"id"}, {"language"=>"ig"}, {"language"=>"is"}, {"language"=>"it"}, {"language"=>"iw"}, {"language"=>"ja"}, {"language"=>"jw"}, {"language"=>"ka"}, {"language"=>"kk"}, {"language"=>"km"}, {"language"=>"kn"}, {"language"=>"ko"}, {"language"=>"ku"}, {"language"=>"ky"}, {"language"=>"la"}, {"language"=>"lb"}, {"language"=>"lo"}, {"language"=>"lt"}, {"language"=>"lv"}, {"language"=>"mg"}, {"language"=>"mi"}, {"language"=>"mk"}, {"language"=>"ml"}, {"language"=>"mn"}, {"language"=>"mr"}, {"language"=>"ms"}, {"language"=>"mt"}, {"language"=>"my"}, {"language"=>"ne"}, {"language"=>"nl"}, {"language"=>"no"}, {"language"=>"ny"}, {"language"=>"pa"}, {"language"=>"pl"}, {"language"=>"ps"}, {"language"=>"pt"}, {"language"=>"ro"}, {"language"=>"ru"}, {"language"=>"sd"}, {"language"=>"si"}, {"language"=>"sk"}, {"language"=>"sl"}, {"language"=>"sm"}, {"language"=>"sn"}, {"language"=>"so"}, {"language"=>"sq"}, {"language"=>"sr"}, {"language"=>"st"}, {"language"=>"su"}, {"language"=>"sv"}, {"language"=>"sw"}, {"language"=>"ta"}, {"language"=>"te"}, {"language"=>"tg"}, {"language"=>"th"}, {"language"=>"tl"}, {"language"=>"tr"}, {"language"=>"uk"}, {"language"=>"ur"}, {"language"=>"uz"}, {"language"=>"vi"}, {"language"=>"xh"}, {"language"=>"yi"}, {"language"=>"yo"}, {"language"=>"zh"}, {"language"=>"zh-TW"}, {"language"=>"zu"}]}.to_json
+    end
+  end
+
+  # Register this spec type for when :storage is used.
+  register_spec_type(self) do |desc, *addl|
+    addl.include? :mock_translate
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -991,7 +991,7 @@ class MockTranslate < Minitest::Spec
 
   def detect_json *languages
     detections = languages.map do |lang|
-      [{ confidence: 0.123, isReliable: false, language: lang }]
+      [{ confidence: 0.123, language: lang, isReliable: false }] # isReliable is deprecated
     end
     { detections: detections }.to_json
   end


### PR DESCRIPTION
Add initial implementation of the Translate service and documentation.

The Translate service is using an API Key for authentication instead of service accounts, like the rest of gcloud-ruby is using. AFAICT the Translate service only supports API Keys, and won't accept OAuth access tokens. If this can be fixed we would prefer to use OAuth access tokens, but for now we will launch with API Keys.