### PR TITLE
Make Translation a delegate of String

### DIFF
--- a/lib/gcloud/translate/translation.rb
+++ b/lib/gcloud/translate/translation.rb
@@ -13,19 +13,13 @@
 # limitations under the License.
 
 
+require "delegate"
+
 module Gcloud
   module Translate
     ##
     # TODO
-    class Translation
-      ##
-      # The translated text.
-      #
-      # @return [String]
-      attr_reader :text
-      alias_method :to_s, :text
-      alias_method :to_str, :text
-
+    class Translation < DelegateClass(::String)
       ##
       # The that was translated.
       #
@@ -48,11 +42,19 @@ module Gcloud
       ##
       # @private Create a new object.
       def initialize text, to, origin, from, detected
-        @text = text
+        super text
         @to = to
         @origin = origin
         @from = from
         @detected = detected
+      end
+
+      ##
+      # The translated text.
+      #
+      # @return [String]
+      def text
+        __getobj__
       end
 
       ##

--- a/test/gcloud/translate/translate_test.rb
+++ b/test/gcloud/translate/translate_test.rb
@@ -43,7 +43,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
-    translation.must_be :detected?
+    translation.detected?.must_equal true
   end
 
   it "translates a single input with from" do
@@ -66,7 +66,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
-    translation.wont_be :detected?
+    translation.detected?.must_equal false
   end
 
   it "translates a single input with format" do
@@ -89,7 +89,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
-    translation.must_be :detected?
+    translation.detected?.must_equal true
   end
 
   it "translates a single input with cid" do
@@ -112,7 +112,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translation.target.must_equal "es"
     translation.from.must_equal "en"
     translation.source.must_equal "en"
-    translation.must_be :detected?
+    translation.detected?.must_equal true
   end
 
   it "translates multiple inputs" do
@@ -137,7 +137,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
-    translations.first.must_be :detected?
+    translations.first.detected?.must_equal true
 
     translations.last.text.must_equal "Como estas hoy?"
     translations.last.origin.must_equal "How are you today?"
@@ -146,7 +146,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
-    translations.last.must_be :detected?
+    translations.last.detected?.must_equal true
   end
 
   it "translates multiple inputs with from" do
@@ -171,7 +171,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
-    translations.first.wont_be :detected?
+    translations.first.detected?.must_equal false
 
     translations.last.text.must_equal "Como estas hoy?"
     translations.last.origin.must_equal "How are you today?"
@@ -180,7 +180,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
-    translations.last.wont_be :detected?
+    translations.last.detected?.must_equal false
   end
 
   it "translates multiple inputs with format" do
@@ -205,7 +205,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
-    translations.first.must_be :detected?
+    translations.first.detected?.must_equal true
 
     translations.last.text.must_equal "Como estas <em>hoy</em>?"
     translations.last.origin.must_equal "How are <em>you</em> today?"
@@ -214,7 +214,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
-    translations.last.must_be :detected?
+    translations.last.detected?.must_equal true
   end
 
   it "translates multiple inputs with cid" do
@@ -239,7 +239,7 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.first.target.must_equal "es"
     translations.first.from.must_equal "en"
     translations.first.source.must_equal "en"
-    translations.first.must_be :detected?
+    translations.first.detected?.must_equal true
 
     translations.last.text.must_equal "Como estas hoy?"
     translations.last.origin.must_equal "How are you today?"
@@ -248,6 +248,6 @@ describe Gcloud::Translate::Api, :translate, :mock_translate do
     translations.last.target.must_equal "es"
     translations.last.from.must_equal "en"
     translations.last.source.must_equal "en"
-    translations.last.must_be :detected?
+    translations.last.detected?.must_equal true
   end
 end


### PR DESCRIPTION
Adding the method `Translate#to_str` so we can use a Translate instance object as a String might have been a bit too clever. It might be clearer in the documentation if the object is an actual delegate of String. This approach is already in use on all the `List` classes and `Gcloud::ResourceManager::Project::Updater`.

Thoughts?