### PR TITLE
Fix bug in Datastore Transaction#delete

### DIFF
--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -59,9 +59,12 @@ module Gcloud
       #     end
       #   end
       #
-      def delete *entities
+      def delete *entities_or_keys
+        keys = entities_or_keys.map do |e_or_k|
+          e_or_k.respond_to?(:key) ? e_or_k.key.to_proto : e_or_k.to_proto
+        end
         shared_mutation.tap do |m|
-          m.delete = entities.map { |entity| entity.key.to_proto }
+          m.delete = keys
         end
         # Do not delete yet
         true

--- a/test/gcloud/datastore/transaction_test.rb
+++ b/test/gcloud/datastore/transaction_test.rb
@@ -45,6 +45,7 @@ describe Gcloud::Datastore::Transaction do
       e["name"] = "thingamajig"
     end
     transaction.save entity
+    transaction.send(:shared_mutation).upsert.must_include entity.to_proto
   end
 
   it "delete does not persist entities" do
@@ -53,6 +54,16 @@ describe Gcloud::Datastore::Transaction do
       e["name"] = "thingamajig"
     end
     transaction.delete entity
+    transaction.send(:shared_mutation).delete.must_include entity.key.to_proto
+  end
+
+  it "delete does not persist keys" do
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    transaction.delete entity.key
+    transaction.send(:shared_mutation).delete.must_include entity.key.to_proto
   end
 
   it "commit persists entities" do


### PR DESCRIPTION
Dataset#delete accepts entities and keys, but Transaction#delete only
accepted entities and would error if it was given a key.
Bring Transaction#delete to parity with Dataset#delete in what it accepts.

[fixes #633]