### PR TITLE
Fix bug in Entity#persisted? post save

### DIFF
--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -127,6 +127,8 @@ module Gcloud
         save_entities_to_mutation entities, mutation
         response = connection.commit mutation
         auto_id_assign_ids response.mutation_result.insert_auto_id_key
+        # Make sure all entity keys are frozen so all show as persisted
+        entities.each { |e| e.key.freeze unless e.persisted? }
         entities
       end
 

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -45,6 +45,7 @@ module Gcloud
       #
       def save *entities
         save_entities_to_mutation entities, shared_mutation
+        @_saved_entities += entities
         # Do not save or assign auto_ids yet
         entities
       end
@@ -87,6 +88,8 @@ module Gcloud
 
         response = connection.commit shared_mutation, @id
         auto_id_assign_ids response.mutation_result.insert_auto_id_key
+        # Make sure all entity keys are frozen so all show as persisted
+        @_saved_entities.each { |e| e.key.freeze unless e.persisted? }
         true
       end
 
@@ -108,6 +111,7 @@ module Gcloud
         @shared_mutation = nil
         @id = nil
         @_auto_id_entities = []
+        @_saved_entities = []
       end
 
       protected

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -102,7 +102,9 @@ describe Gcloud::Datastore::Dataset do
       e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
       e["name"] = "thingamajig"
     end
+    entity.wont_be :persisted?
     dataset.save entity
+    entity.must_be :persisted?
   end
 
   it "find can take a kind and id" do

--- a/test/gcloud/datastore/transaction_test.rb
+++ b/test/gcloud/datastore/transaction_test.rb
@@ -66,7 +66,9 @@ describe Gcloud::Datastore::Transaction do
       e["name"] = "thingamajig"
     end
     transaction.save entity
+    entity.wont_be :persisted?
     transaction.commit
+    entity.must_be :persisted?
   end
 
   it "rollback does not persist entities" do


### PR DESCRIPTION
Fixes a bug where Datastore entities may not be marked as `persisted?` after they were saved.

[fixes #630]