### PR TITLE
Refresh access tokens sooner

### DIFF
--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -36,7 +36,7 @@ module Gcloud
       # Sign OAuth 2.0 API calls.
       def sign_http_request request
         if @client
-          @client.fetch_access_token! if @client.expired?
+          @client.fetch_access_token! if @client.expires_within? 30
           @client.generate_authenticated_request request: request
         end
         request


### PR DESCRIPTION
Be more proactive in refreshing access tokens to avoid a potential race condition where the access token expires before an API request is received. The [`expires_within?`](http://www.rubydoc.info/github/google/signet/Signet%2FOAuth2%2FClient%3Aexpires_within%3F) method returns `true` if the access token has expired or expires within the next _n_ seconds.

[fixes #638]