### PR TITLE
Fix Vision Error Handling

### DIFF
--- a/lib/gcloud/vision/project.rb
+++ b/lib/gcloud/vision/project.rb
@@ -90,6 +90,7 @@ module Gcloud
                                               properties: properties)
 
         resp = connection.annotate requests
+        fail ApiError.from_response(resp) unless resp.success?
         analyses = Array(resp.data["responses"]).map do |gapi|
           Analysis.from_gapi gapi
         end


### PR DESCRIPTION
Update ApiError to use the error format returned by the Vision service.
Add the missing check and raise and error when the API call is not successful.