### PR TITLE
Enhance Datastore TransactionError

### DIFF
--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -284,8 +284,14 @@ module Gcloud
           yield tx
           tx.commit
         rescue => e
-          tx.rollback
-          raise TransactionError.new("Transaction failed to commit.", e)
+          begin
+            tx.rollback
+          rescue => re
+            msg = "Transaction failed to commit and rollback."
+            raise TransactionError.new(msg, commit_error: e, rollback_error: re)
+          end
+          raise TransactionError.new("Transaction failed to commit.",
+                                     commit_error: e)
         end
       end
 

--- a/lib/gcloud/datastore/errors.rb
+++ b/lib/gcloud/datastore/errors.rb
@@ -66,12 +66,18 @@ module Gcloud
     class TransactionError < Gcloud::Datastore::Error
       ##
       # An error that occurred within the transaction. (optional)
-      attr_reader :inner
+      attr_reader :commit_error
+      alias_method :inner, :commit_error # backwards compatibility
+
+      ##
+      # An error that occurred within the transaction. (optional)
+      attr_reader :rollback_error
 
       # @private
-      def initialize message, inner = nil
+      def initialize message, commit_error: nil, rollback_error: nil
         super(message)
-        @inner = inner
+        @commit_error   = commit_error
+        @rollback_error = rollback_error
       end
     end
   end


### PR DESCRIPTION
It was possible to have errors on both commit and rollback. When this happened the rollback error would be thrown, with no way to report the commit error to the user. Add commit_error and rollback_error to TransactionError to communicate both error objects.

[closes #645]