### PR TITLE
Fix run query with namespace.

### DIFF
--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -447,7 +447,6 @@ module Gcloud
         return nil if namespace.nil?
         Proto::PartitionId.new.tap do |p|
           p.namespace = namespace
-          p.dataset_id = project
         end
       end
     end

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -297,7 +297,6 @@ describe Gcloud::Datastore::Dataset do
 
 
   it "run_query will fulfill a query with a namespace" do
-    dataset.connection.expect :dataset_id, project
     dataset.connection.expect :run_query,
                               run_query_response,
                               [Gcloud::Datastore::Proto::Query, Gcloud::Datastore::Proto::PartitionId]


### PR DESCRIPTION
Otherwise, I get this response from the API:

```
{
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "INVALID_ARGUMENT",
    "message": "app s~foo cannot access app foo's data"
   }
  ],
  "code": 400,
  "message": "app s~foo cannot access app foo's data"
 }
}
```