### PR TITLE
Allow batch operations outside of a transaction

### DIFF
--- a/acceptance/datastore/datastore_test.rb
+++ b/acceptance/datastore/datastore_test.rb
@@ -148,6 +148,32 @@ describe "Datastore", :datastore do
       entities.count.must_equal 0
     end
 
+    it "should save/find/delete multiple entities with commit" do
+      post.key  = Gcloud::Datastore::Key.new "Post"
+      post2.key = Gcloud::Datastore::Key.new "Post"
+
+      post.key.must_be :incomplete?
+      post2.key.must_be :incomplete?
+
+      dataset.save post
+
+      post.key.must_be :complete?
+      post2.key.must_be :incomplete?
+
+      dataset.commit do |c|
+        c.delete post
+        c.save post2
+      end
+
+      post.key.must_be :complete?
+      post2.key.must_be :complete?
+
+      dataset.delete post2
+
+      entities = dataset.find_all post.key, post2.key
+      entities.count.must_equal 0
+    end
+
     it "entities retrieved from datastore have immutable keys" do
       post.key = Gcloud::Datastore::Key.new "Post", "post1"
       dataset.save post

--- a/lib/gcloud/datastore/commit.rb
+++ b/lib/gcloud/datastore/commit.rb
@@ -1,0 +1,131 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Gcloud
+  module Datastore
+    ##
+    # # Commit
+    #
+    # Object yielded from `commit` methods to allow multiple changes to be made
+    # in a single commit.
+    #
+    # @example
+    #   dataset.commit do |c|
+    #     c.save task1, task2
+    #     c.delete entity1, entity2
+    #   end
+    #
+    # @see {Gcloud::Datastore::Dataset#commit}
+    # @see {Gcloud::Datastore::Transaction#commit}
+    class Commit
+      ##
+      # @private Create a new Commit object.
+      def initialize
+        @shared_entities = []
+        @shared_auto_ids = []
+        @shared_deletes  = []
+      end
+
+      ##
+      # Saves entities to the Datastore.
+      #
+      # @param [Entity, Key] entities_or_keys One or more Entity or Key
+      #   objects to remove.
+      #
+      # @example
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
+      #   dataset.commit do |c|
+      #     c.save task1, task2
+      #   end
+      #
+      def save *entities
+        entities.each do |entity|
+          shared_auto_ids << entity if entity.key.incomplete?
+          shared_entities << entity
+        end
+        # Do not save yet
+        entities
+      end
+
+      ##
+      # Remove entities from the Datastore.
+      #
+      # @param [Entity, Key] entities_or_keys One or more Entity or Key
+      #   objects to remove.
+      #
+      # @example
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
+      #   dataset.commit do |c|
+      #     c.delete entity1, entity2
+      #   end
+      #
+      def delete *entities_or_keys
+        keys = entities_or_keys.map do |e_or_k|
+          e_or_k.respond_to?(:key) ? e_or_k.key : e_or_k
+        end
+        keys.each { |k| shared_deletes << k }
+        # Do not delete yet
+        true
+      end
+
+      # @private Mutation object to be committed.
+      def mutation
+        Proto.new_mutation.tap do |m|
+          m.insert_auto_id = shared_auto_ids.map(&:to_proto)
+          m.upsert = shared_upserts.map(&:to_proto)
+          m.delete = shared_deletes.map(&:to_proto)
+        end
+      end
+
+      # @private Entities that need key ids assigned.
+      def auto_id_entities
+        shared_auto_ids
+      end
+
+      # @private All entities saved in the commit.
+      def entities
+        shared_entities
+      end
+
+      protected
+
+      ##
+      # @private List of Entity objects to be saved.
+      def shared_entities
+        @shared_entities
+      end
+
+      ##
+      # @private List of Entity objects that need auto_ids
+      def shared_auto_ids
+        @shared_auto_ids
+      end
+
+      ##
+      # @private List of Entity objects to be saved.
+      def shared_upserts
+        shared_entities - shared_auto_ids
+      end
+
+      ##
+      # @private List of Key objects to be deleted.
+      def shared_deletes
+        @shared_deletes
+      end
+    end
+  end
+end

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -16,6 +16,7 @@
 require "gcloud/gce"
 require "gcloud/datastore/connection"
 require "gcloud/datastore/credentials"
+require "gcloud/datastore/commit"
 require "gcloud/datastore/entity"
 require "gcloud/datastore/key"
 require "gcloud/datastore/query"
@@ -114,8 +115,7 @@ module Gcloud
       ##
       # Persist one or more entities to the Datastore.
       #
-      # @param [Entity] entities One or more entity objects to be saved without
-      #   `id` or `name` set.
+      # @param [Entity] entities One or more entity objects to be saved.
       #
       # @return [Array<Gcloud::Datastore::Entity>]
       #
@@ -123,11 +123,51 @@ module Gcloud
       #   dataset.save task1, task2
       #
       def save *entities
-        mutation = Proto.new_mutation
-        save_entities_to_mutation entities, mutation
-        response = connection.commit mutation
-        auto_id_assign_ids response.mutation_result.insert_auto_id_key
+        commit { |c| c.save(*entities) }
+      end
+
+      ##
+      # Remove entities from the Datastore.
+      #
+      # @param [Entity, Key] entities_or_keys One or more Entity or Key objects
+      #   to remove.
+      #
+      # @return [Boolean] Returns `true` if successful
+      #
+      # @example
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
+      #   dataset.delete entity1, entity2
+      #
+      def delete *entities_or_keys
+        commit { |c| c.delete(*entities_or_keys) }
+        true
+      end
+
+      ##
+      # Make multiple changes in a single commit.
+      #
+      # @yield [commit] a block for making changes
+      # @yieldparam [Commit] commit The object that changes are made on
+      #
+      # @return [Array<Gcloud::Datastore::Entity>] The entities that were
+      #   persisted.
+      #
+      # @example
+      #   dataset.commit do |c|
+      #     c.save task1, task2
+      #     c.delete entity1, entity2
+      #   end
+      #
+      def commit
+        return unless block_given?
+        c = Commit.new
+        yield c
+        response = connection.commit c.mutation
+        auto_id_assign_ids c.auto_id_entities,
+                           response.mutation_result.insert_auto_id_key
         # Make sure all entity keys are frozen so all show as persisted
+        entities = c.entities
         entities.each { |e| e.key.freeze unless e.persisted? }
         entities
       end
@@ -179,30 +219,6 @@ module Gcloud
         LookupResults.new entities, deferred, missing
       end
       alias_method :lookup, :find_all
-
-      ##
-      # Remove entities from the Datastore.
-      #
-      # @param [Entity, Key] entities_or_keys One or more Entity or Key objects
-      #   to remove.
-      #
-      # @return [Boolean] Returns `true` if successful
-      #
-      # @example
-      #   gcloud = Gcloud.new
-      #   dataset = gcloud.datastore
-      #   dataset.delete entity1, entity2
-      #
-      def delete *entities_or_keys
-        keys = entities_or_keys.map do |e_or_k|
-          e_or_k.respond_to?(:key) ? e_or_k.key.to_proto : e_or_k.to_proto
-        end
-        mutation = Proto.new_mutation.tap do |m|
-          m.delete = keys
-        end
-        connection.commit mutation
-        true
-      end
 
       ##
       # Retrieve entities specified by a Query.
@@ -412,34 +428,11 @@ module Gcloud
       end
 
       ##
-      # @private Save a key to be given an ID when comitted.
-      def auto_id_register entity
-        @_auto_id_entities ||= []
-        @_auto_id_entities << entity
-      end
-
-      ##
       # @private Update saved keys with new IDs post-commit.
-      def auto_id_assign_ids auto_ids
-        @_auto_id_entities ||= []
+      def auto_id_assign_ids entities, auto_ids
         Array(auto_ids).each_with_index do |key, index|
-          entity = @_auto_id_entities[index]
+          entity = entities[index]
           entity.key = Key.from_proto key
-        end
-        @_auto_id_entities = []
-      end
-
-      ##
-      # @private Add entities to a Mutation, and register they key to be
-      # updated with an auto ID if needed.
-      def save_entities_to_mutation entities, mutation
-        entities.each do |entity|
-          if entity.key.id.nil? && entity.key.name.nil?
-            mutation.insert_auto_id << entity.to_proto
-            auto_id_register entity
-          else
-            mutation.upsert << entity.to_proto
-          end
         end
       end
 

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -277,6 +277,28 @@ describe Gcloud::Datastore::Dataset do
     refute entities.no_more?
   end
 
+  it "commit will save and delete entities" do
+    dataset.connection.expect :commit,
+                              commit_response,
+                              [Gcloud::Datastore::Proto::Mutation]
+
+    entity_to_be_saved = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-saved"
+      e["name"] = "Gonna be saved"
+    end
+    entity_to_be_deleted = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-saved"
+      e["name"] = "Gonna be deleted"
+    end
+
+    entity_to_be_saved.wont_be :persisted?
+    dataset.commit do |c|
+      c.save entity_to_be_saved
+      c.delete entity_to_be_deleted
+    end
+    entity_to_be_saved.must_be :persisted?
+  end
+
   it "run_query will fulfill a query" do
     dataset.connection.expect :run_query,
                               run_query_response,


### PR DESCRIPTION
Add `Datastore::Commit` that will accept multiple changes for a single commit. Allowing this outside of a transaction for increased performance, as well as avoiding the limitations on the number of changes allowed in a transaction.

[closes #646]