### PR TITLE
Support Datastore Blob values

### DIFF
--- a/acceptance/datastore/datastore_test.rb
+++ b/acceptance/datastore/datastore_test.rb
@@ -177,7 +177,8 @@ describe "Datastore", :datastore do
 
       entity = dataset.find post.key
 
-      entity["avatar"].rewind
+      # Rewind not needed because the StringIO poistion is always at the beginning whe retrieved from Datastore.
+      # entity["avatar"].rewind
       post["avatar"].rewind
       entity["avatar"].size.must_equal post["avatar"].size
       entity["avatar"].read.must_equal post["avatar"].read

--- a/acceptance/datastore/datastore_test.rb
+++ b/acceptance/datastore/datastore_test.rb
@@ -167,6 +167,37 @@ describe "Datastore", :datastore do
       dataset.delete post
     end
 
+    it "should save and read blob values" do
+      avatar = File.open("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")
+      post.key  = Gcloud::Datastore::Key.new "Post", "blob_support"
+      post["avatar"] = avatar
+      post.exclude_from_indexes! "avatar", true
+
+      dataset.save post
+      avatar.rewind
+
+      entity = dataset.find post.key
+
+      entity["avatar"].read.must_equal post["avatar"].read
+      entity["avatar"].rewind
+      post["avatar"].rewind
+
+      entity["avatar"].read.must_equal avatar.read
+      entity["avatar"].rewind
+      avatar.rewind
+
+      Tempfile.open ["avatar", "png"] do |tmpfile|
+        tmpfile.write entity["avatar"].read
+
+        tmpfile.rewind
+        entity["avatar"].rewind
+        avatar.rewind
+
+        tmpfile.size.must_equal avatar.size
+      end
+
+      dataset.delete post
+    end
   end
 
   it "should be able to save keys as a part of entity and query by key" do

--- a/acceptance/datastore/datastore_test.rb
+++ b/acceptance/datastore/datastore_test.rb
@@ -174,26 +174,23 @@ describe "Datastore", :datastore do
       post.exclude_from_indexes! "avatar", true
 
       dataset.save post
-      avatar.rewind
 
       entity = dataset.find post.key
 
-      entity["avatar"].read.must_equal post["avatar"].read
       entity["avatar"].rewind
       post["avatar"].rewind
-
-      entity["avatar"].read.must_equal avatar.read
-      entity["avatar"].rewind
-      avatar.rewind
+      entity["avatar"].size.must_equal post["avatar"].size
+      entity["avatar"].read.must_equal post["avatar"].read
 
       Tempfile.open ["avatar", "png"] do |tmpfile|
+        tmpfile.binmode
+        entity["avatar"].rewind
         tmpfile.write entity["avatar"].read
 
         tmpfile.rewind
-        entity["avatar"].rewind
         avatar.rewind
-
         tmpfile.size.must_equal avatar.size
+        tmpfile.read.must_equal avatar.read
       end
 
       dataset.delete post

--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -46,6 +46,9 @@ module Gcloud
       ##
       # Retrieve a property value by providing the name.
       #
+      # Property values are converted from the Datastore value type
+      # automatically. Blob properties are returned as StringIO objects.
+      #
       # @param [String, Symbol] prop_name The name of the property.
       #
       # @return [Object, nil] Returns `nil` if the property doesn't exist
@@ -66,12 +69,26 @@ module Gcloud
       #   user = dataset.find "User", "heidi@example.com"
       #   user[:name] #=> "Heidi Henderson"
       #
+      # @example Getting a blob value returns a StringIO object:
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
+      #   user = dataset.find "User", "heidi@example.com"
+      #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
+      #
       def [] prop_name
         @properties[prop_name]
       end
 
       ##
       # Set a property value by name.
+      #
+      # Property values are converted to use the proper Datastore value type
+      # automatically. Use an IO-compatible object (File, StringIO, Tempfile) to
+      # indicate the property value should be stored as a Datastore `blob`.
+      # IO-compatible objects are converted to StringIO objects when they are
+      # set.
       #
       # @param [String, Symbol] prop_name The name of the property.
       # @param [Object] prop_value The value of the property.
@@ -91,6 +108,15 @@ module Gcloud
       #   dataset = gcloud.datastore
       #   user = dataset.find "User", "heidi@example.com"
       #   user[:name] = "Heidi H. Henderson"
+      #
+      # @example Setting a blob value using an IO:
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
+      #   user = dataset.find "User", "heidi@example.com"
+      #   user["avatar"] = File.open "/avatars/heidi.png"
+      #   user["avatar"] #=> StringIO("\x89PNG\r\n\x1A...")
       #
       def []= prop_name, prop_value
         @properties[prop_name] = prop_value

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -97,7 +97,7 @@ module Gcloud
            String                    === value ||
            Array                     === value
           return value
-        elsif value.respond_to?(:read)
+        elsif value.respond_to?(:read) && value.respond_to?(:rewind)
           return value
         elsif defined?(BigDecimal) && BigDecimal === value
           return value

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -97,6 +97,8 @@ module Gcloud
            String                    === value ||
            Array                     === value
           return value
+        elsif value.respond_to?(:read)
+          return value
         elsif defined?(BigDecimal) && BigDecimal === value
           return value
         end

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+require "stringio"
+
 module Gcloud
   module Datastore
     ##
@@ -98,7 +100,11 @@ module Gcloud
            Array                     === value
           return value
         elsif value.respond_to?(:read) && value.respond_to?(:rewind)
-          return value
+          # shortcut creating a StringIO if it already is one.
+          return value if value.is_a? StringIO
+          # Always convert an IO object to a StringIO when storing.
+          value.rewind
+          return StringIO.new(value.read)
         elsif defined?(BigDecimal) && BigDecimal === value
           return value
         end

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -15,6 +15,8 @@
 
 require "gcloud/proto/datastore_v1.pb"
 require "gcloud/datastore/errors"
+require "stringio"
+require "base64"
 
 module Gcloud
   module Datastore
@@ -53,6 +55,8 @@ module Gcloud
           return Array(proto_value.list_value).map do |item|
             from_proto_value item
           end
+        elsif !proto_value.blob_value.nil?
+          return StringIO.new(Base64.decode64(proto_value.blob_value))
         else
           nil
         end
@@ -82,6 +86,8 @@ module Gcloud
           v.string_value = value
         elsif Array === value
           v.list_value = value.map { |item| to_proto_value item }
+        elsif value.respond_to?(:read)
+          v.blob_value = Base64.encode64(value.read)
         else
           fail PropertyError, "A property of type #{value.class} is not supported."
         end

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -88,7 +88,7 @@ module Gcloud
           v.list_value = value.map { |item| to_proto_value item }
         elsif value.respond_to?(:read) && value.respond_to?(:rewind)
           value.rewind
-          v.blob_value = Base64.encode64(value.read)
+          v.blob_value = Base64.strict_encode64(value.read)
         else
           fail PropertyError, "A property of type #{value.class} is not supported."
         end

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -86,7 +86,8 @@ module Gcloud
           v.string_value = value
         elsif Array === value
           v.list_value = value.map { |item| to_proto_value item }
-        elsif value.respond_to?(:read)
+        elsif value.respond_to?(:read) && value.respond_to?(:rewind)
+          value.rewind
           v.blob_value = Base64.encode64(value.read)
         else
           fail PropertyError, "A property of type #{value.class} is not supported."

--- a/test/gcloud/datastore/proto/value_test.rb
+++ b/test/gcloud/datastore/proto/value_test.rb
@@ -15,6 +15,9 @@
 require "helper"
 require "gcloud/datastore/entity"
 require "gcloud/datastore/key"
+require "stringio"
+require "tempfile"
+require "base64"
 
 describe "Proto Value methods" do
   let(:time_obj) { Time.new(2014, 1, 1, 0, 0, 0, 0) }
@@ -245,5 +248,57 @@ describe "Proto Value methods" do
     raw[0].must_equal "string"
     raw[1].must_equal 123
     raw[2].must_equal true
+  end
+
+  it "encodes IO as blob" do
+    raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png"
+    value = Gcloud::Datastore::Proto.to_proto_value raw
+    value.blob_value.must_equal Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.timestamp_microseconds_value.must_be :nil?
+    value.key_value.must_be :nil?
+    value.entity_value.must_be :nil?
+    value.boolean_value.must_be :nil?
+    value.double_value.must_be :nil?
+    value.integer_value.must_be :nil?
+    value.string_value.must_be :nil?
+    value.list_value.must_be :nil?
+  end
+
+  it "encodes StringIO as blob" do
+    raw = StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value = Gcloud::Datastore::Proto.to_proto_value raw
+    value.blob_value.must_equal Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.timestamp_microseconds_value.must_be :nil?
+    value.key_value.must_be :nil?
+    value.entity_value.must_be :nil?
+    value.boolean_value.must_be :nil?
+    value.double_value.must_be :nil?
+    value.integer_value.must_be :nil?
+    value.string_value.must_be :nil?
+    value.list_value.must_be :nil?
+  end
+
+  it "encodes Temfile as blob" do
+    raw = Tempfile.new "raw"
+    raw.write(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    raw.rewind
+    value = Gcloud::Datastore::Proto.to_proto_value raw
+    value.blob_value.must_equal Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.timestamp_microseconds_value.must_be :nil?
+    value.key_value.must_be :nil?
+    value.entity_value.must_be :nil?
+    value.boolean_value.must_be :nil?
+    value.double_value.must_be :nil?
+    value.integer_value.must_be :nil?
+    value.string_value.must_be :nil?
+    value.list_value.must_be :nil?
+  end
+
+  it "decodes blob to StringIO" do
+    value = Gcloud::Datastore::Proto::Value.new
+    value.blob_value = Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    raw = Gcloud::Datastore::Proto.from_proto_value value
+    raw.must_be_kind_of StringIO
+    raw.read.must_equal StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")).read
   end
 end

--- a/test/gcloud/datastore/proto/value_test.rb
+++ b/test/gcloud/datastore/proto/value_test.rb
@@ -253,7 +253,7 @@ describe "Proto Value methods" do
   it "encodes IO as blob" do
     raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png"
     value = Gcloud::Datastore::Proto.to_proto_value raw
-    value.blob_value.must_equal Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     value.timestamp_microseconds_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -267,7 +267,7 @@ describe "Proto Value methods" do
   it "encodes StringIO as blob" do
     raw = StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     value = Gcloud::Datastore::Proto.to_proto_value raw
-    value.blob_value.must_equal Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     value.timestamp_microseconds_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -283,7 +283,7 @@ describe "Proto Value methods" do
     raw.write(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     raw.rewind
     value = Gcloud::Datastore::Proto.to_proto_value raw
-    value.blob_value.must_equal Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     value.timestamp_microseconds_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -296,7 +296,7 @@ describe "Proto Value methods" do
 
   it "decodes blob to StringIO" do
     value = Gcloud::Datastore::Proto::Value.new
-    value.blob_value = Base64.encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value = Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     raw = Gcloud::Datastore::Proto.from_proto_value value
     raw.must_be_kind_of StringIO
     raw.read.must_equal StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")).read


### PR DESCRIPTION
Byte arrays are represented in Google API Client as base64 encoded strings. Allow IO-like objects to be saves as blobs, and blobs to be returned as StringIO objects.

[closes #644]