### PR TITLE
Add ReadOptions support

### DIFF
--- a/acceptance/datastore/datastore_test.rb
+++ b/acceptance/datastore/datastore_test.rb
@@ -222,6 +222,21 @@ describe "Datastore", :datastore do
 
       dataset.delete post
     end
+
+    it "should find with specifying consistency" do
+      post.key = Gcloud::Datastore::Key.new "Post", "post1"
+      dataset.save post
+
+      refresh = dataset.find post.key, consistency: :eventual
+      refresh.key.kind.must_equal        post.key.kind
+      refresh.key.id.must_equal          post.key.id
+      refresh.key.name.must_equal        post.key.name
+      refresh.properties.to_h.must_equal post.properties.to_h
+
+      dataset.delete post.key
+      refresh = dataset.find post.key
+      refresh.must_be :nil?
+    end
   end
 
   it "should be able to save keys as a part of entity and query by key" do
@@ -494,6 +509,14 @@ describe "Datastore", :datastore do
       entities.count.must_equal 2
     end
 
+    it "should specify consistency" do
+      query = Gcloud::Datastore::Query.new.
+        kind("Character").ancestor(book).
+        where("appearances", ">=", 20)
+      entities = dataset.run query, consistency: :eventual
+      entities.count.must_equal 6
+    end
+
     after do
       dataset.delete *characters
     end
@@ -543,6 +566,18 @@ describe "Datastore", :datastore do
       entity.key.name.must_equal        obj.key.name
       entity.properties.to_h.must_equal obj.properties.to_h
       dataset.delete entity
+    end
+
+    it "should find within the transaction" do
+      dataset.save dataset.entity("Post", "post1")
+
+      tx = dataset.transaction do |tx|
+        in_tx_refresh = tx.find tx.key("Post", "post1")
+        tx.delete in_tx_refresh if in_tx_refresh
+      end
+
+      refresh = dataset.find "Post", "post1"
+      refresh.must_be :nil?
     end
   end
 end

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -66,6 +66,89 @@ module Gcloud
       end
 
       ##
+      # Retrieve an entity by providing key information. The lookup is run
+      # within the transaction.
+      #
+      # @param [Key, String] key_or_kind A Key object or `kind` string value.
+      #
+      # @return [Gcloud::Datastore::Entity, nil]
+      #
+      # @example Finding an entity with a key:
+      #   key = dataset.key "Task", 123456
+      #   task = dataset.find key
+      #
+      # @example Finding an entity with a `kind` and `id`/`name`:
+      #   task = dataset.find "Task", 123456
+      #
+      def find key_or_kind, id_or_name = nil
+        key = key_or_kind
+        unless key.is_a? Gcloud::Datastore::Key
+          key = Key.new key_or_kind, id_or_name
+        end
+        find_all(key).first
+      end
+      alias_method :get, :find
+
+      ##
+      # Retrieve the entities for the provided keys. The lookup is run within
+      # the transaction.
+      #
+      # @param [Key] keys One or more Key objects to find records for.
+      #
+      # @return [Gcloud::Datastore::Dataset::LookupResults]
+      #
+      # @example
+      #   gcloud = Gcloud.new
+      #   dataset = gcloud.datastore
+      #   key1 = dataset.key "Task", 123456
+      #   key2 = dataset.key "Task", 987654
+      #   tasks = dataset.find_all key1, key2
+      #
+      def find_all *keys
+        response = connection.lookup(*keys.map(&:to_proto),
+                                     transaction: @id)
+        entities = to_gcloud_entities response.found
+        deferred = to_gcloud_keys response.deferred
+        missing  = to_gcloud_entities response.missing
+        LookupResults.new entities, deferred, missing
+      end
+      alias_method :lookup, :find_all
+
+      ##
+      # Retrieve entities specified by a Query. The query is run within the
+      # transaction.
+      #
+      # @param [Query] query The Query object with the search criteria.
+      # @param [String] namespace The namespace the query is to run within.
+      #
+      # @return [Gcloud::Datastore::Dataset::QueryResults]
+      #
+      # @example
+      #   query = dataset.query("Task").
+      #     where("completed", "=", true)
+      #   dataset.transaction do |tx|
+      #     tasks = tx.run query
+      #   end
+      #
+      # @example Run the query within a namespace with the `namespace` option:
+      #   query = Gcloud::Datastore::Query.new.kind("Task").
+      #     where("completed", "=", true)
+      #   dataset.transaction do |tx|
+      #     tasks = tx.run query, namespace: "ns~todo-project"
+      #   end
+      #
+      def run query, namespace: nil
+        partition = optional_partition_id namespace
+        response = connection.run_query query.to_proto, partition,
+                                        transaction: @id
+        entities = to_gcloud_entities response.batch.entity_result
+        cursor = Proto.encode_cursor response.batch.end_cursor
+        more_results = Proto.to_more_results_string response.batch.more_results
+        QueryResults.new entities, cursor, more_results
+      end
+      alias_method :run_query, :run
+
+      ##
       # Begins a transaction.
       # This method is run when a new Transaction is created.
       def start

--- a/test/gcloud/datastore/connection_test.rb
+++ b/test/gcloud/datastore/connection_test.rb
@@ -38,7 +38,7 @@ describe Gcloud::Datastore::Connection do
     http_mock.expect :post, new_response_mock, [rpc_path("lookup")]
     key1 = Gcloud::Datastore::Key.new "User", "silvolu"
     key2 = Gcloud::Datastore::Key.new "User", "blowmage"
-    response = connection.lookup key1.to_proto, key2.to_proto
+    response = connection.lookup key1.to_proto, key2.to_proto, consistency: nil
     response.must_be_kind_of Gcloud::Datastore::Proto::LookupResponse
   end
 


### PR DESCRIPTION
Allow non-transactional lookup and queries to specify consistency.
Add ReadOptions to lookups and queries within transactions.

[closes #618]