### PR TITLE
Fix bug where blob values were double Base64 encoded

### DIFF
--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -101,11 +101,9 @@ module Gcloud
         elsif value.respond_to?(:to_time)
           return value
         elsif value.respond_to?(:read) && value.respond_to?(:rewind)
-          # shortcut creating a StringIO if it already is one.
-          return value if value.is_a? StringIO
           # Always convert an IO object to a StringIO when storing.
           value.rewind
-          return StringIO.new(value.read)
+          return StringIO.new(value.read.force_encoding("ASCII-8BIT"))
         elsif defined?(BigDecimal) && BigDecimal === value
           return value
         end

--- a/lib/gcloud/datastore/proto.rb
+++ b/lib/gcloud/datastore/proto.rb
@@ -16,7 +16,6 @@
 require "gcloud/proto/datastore_v1.pb"
 require "gcloud/datastore/errors"
 require "stringio"
-require "base64"
 
 module Gcloud
   module Datastore
@@ -56,7 +55,7 @@ module Gcloud
             from_proto_value item
           end
         elsif !proto_value.blob_value.nil?
-          return StringIO.new(Base64.decode64(proto_value.blob_value))
+          return StringIO.new(proto_value.blob_value.force_encoding("ASCII-8BIT"))
         else
           nil
         end
@@ -88,7 +87,7 @@ module Gcloud
           v.timestamp_microseconds_value = self.microseconds_from_time value.to_time
         elsif value.respond_to?(:read) && value.respond_to?(:rewind)
           value.rewind
-          v.blob_value = Base64.strict_encode64(value.read)
+          v.blob_value = value.read.force_encoding("ASCII-8BIT")
         else
           fail PropertyError, "A property of type #{value.class} is not supported."
         end

--- a/test/gcloud/datastore/proto/value_test.rb
+++ b/test/gcloud/datastore/proto/value_test.rb
@@ -17,7 +17,6 @@ require "gcloud/datastore/entity"
 require "gcloud/datastore/key"
 require "stringio"
 require "tempfile"
-require "base64"
 
 describe "Proto Value methods" do
   let(:time_obj) { Time.new(2014, 1, 1, 0, 0, 0, 0) }
@@ -279,7 +278,7 @@ describe "Proto Value methods" do
   it "encodes IO as blob" do
     raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png"
     value = Gcloud::Datastore::Proto.to_proto_value raw
-    value.blob_value.must_equal Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")
     value.timestamp_microseconds_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -293,7 +292,7 @@ describe "Proto Value methods" do
   it "encodes StringIO as blob" do
     raw = StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     value = Gcloud::Datastore::Proto.to_proto_value raw
-    value.blob_value.must_equal Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")
     value.timestamp_microseconds_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -309,7 +308,7 @@ describe "Proto Value methods" do
     raw.write(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     raw.rewind
     value = Gcloud::Datastore::Proto.to_proto_value raw
-    value.blob_value.must_equal Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")
     value.timestamp_microseconds_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -322,7 +321,7 @@ describe "Proto Value methods" do
 
   it "decodes blob to StringIO" do
     value = Gcloud::Datastore::Proto::Value.new
-    value.blob_value = Base64.strict_encode64(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value = File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")
     raw = Gcloud::Datastore::Proto.from_proto_value value
     raw.must_be_kind_of StringIO
     raw.read.must_equal StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")).read


### PR DESCRIPTION
Force blob values to ASCII-8BIT instead of Base64 encoding. The Google API Client already performs Base64 encoding, so gcloud was double encoding and storing encoded bytes in Datastore.

[fixes #666]