### PR TITLE
Force encoding of binary data

### DIFF
--- a/lib/gcloud/datastore/grpc_utils.rb
+++ b/lib/gcloud/datastore/grpc_utils.rb
@@ -71,7 +71,7 @@ module Gcloud
       elsif !grpc_value.geo_point_value.nil?
         return grpc_value.geo_point_value.to_hash
       elsif !grpc_value.blob_value.nil?
-        return StringIO.new(decode_bytes(grpc_value.blob_value))
+        return StringIO.new(grpc_value.blob_value.force_encoding("ASCII-8BIT"))
       else
         nil
       end
@@ -112,7 +112,7 @@ module Gcloud
         v.geo_point_value = Google::Type::LatLng.new(value)
       elsif value.respond_to?(:read) && value.respond_to?(:rewind)
         value.rewind
-        v.blob_value = encode_bytes(value.read)
+        v.blob_value = value.read.force_encoding("ASCII-8BIT")
       else
         fail Gcloud::Datastore::PropertyError,
              "A property of type #{value.class} is not supported."

--- a/lib/gcloud/datastore/properties.rb
+++ b/lib/gcloud/datastore/properties.rb
@@ -114,11 +114,9 @@ module Gcloud
         elsif value.respond_to?(:to_hash) && value.keys.sort == [:latitude, :longitude]
           return value
         elsif value.respond_to?(:read) && value.respond_to?(:rewind)
-          # shortcut creating a StringIO if it already is one.
-          return value if value.is_a? StringIO
           # Always convert an IO object to a StringIO when storing.
           value.rewind
-          return StringIO.new(value.read)
+          return StringIO.new(value.read.force_encoding("ASCII-8BIT"))
         elsif defined?(BigDecimal) && BigDecimal === value
           return value
         end

--- a/test/gcloud/datastore/properties_test.rb
+++ b/test/gcloud/datastore/properties_test.rb
@@ -300,7 +300,7 @@ describe Gcloud::Datastore::Properties do
   it "encodes IO as blob" do
     raw = File.open "acceptance/data/CloudPlatform_128px_Retina.png"
     value = Gcloud::GRPCUtils.to_value raw
-    value.blob_value.must_equal Gcloud::GRPCUtils.encode_bytes(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
     value.timestamp_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -315,7 +315,7 @@ describe Gcloud::Datastore::Properties do
   it "encodes StringIO as blob" do
     raw = StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     value = Gcloud::GRPCUtils.to_value raw
-    value.blob_value.must_equal Gcloud::GRPCUtils.encode_bytes(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
     value.timestamp_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -332,7 +332,7 @@ describe Gcloud::Datastore::Properties do
     raw.write(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
     raw.rewind
     value = Gcloud::GRPCUtils.to_value raw
-    value.blob_value.must_equal Gcloud::GRPCUtils.encode_bytes(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value.must_equal File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
     value.timestamp_value.must_be :nil?
     value.key_value.must_be :nil?
     value.entity_value.must_be :nil?
@@ -346,7 +346,7 @@ describe Gcloud::Datastore::Properties do
 
   it "decodes blob to StringIO" do
     value = Google::Datastore::V1beta3::Value.new
-    value.blob_value = Gcloud::GRPCUtils.encode_bytes(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb"))
+    value.blob_value = File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb").force_encoding("ASCII-8BIT")
     raw = Gcloud::GRPCUtils.from_value value
     raw.must_be_kind_of StringIO
     raw.read.must_equal StringIO.new(File.read("acceptance/data/CloudPlatform_128px_Retina.png", mode: "rb")).read


### PR DESCRIPTION
This matches the newer behavior as of 0.8.2. Binary strings should be binary.