### PR TITLE
Remove unneeded scope

### DIFF
--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -74,10 +74,9 @@ module Gcloud
   #   OAuth 2.0 to Access Google
   #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
-  #   The default scopes are:
+  #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/datastore`
-  #   * `https://www.googleapis.com/auth/userinfo.email`
   #
   # @return [Gcloud::Datastore::Dataset]
   #

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -36,10 +36,9 @@ module Gcloud
   #   OAuth 2.0 to Access Google
   #   APIs](https://developers.google.com/identity/protocols/OAuth2).
   #
-  #   The default scopes are:
+  #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/datastore`
-  #   * `https://www.googleapis.com/auth/userinfo.email`
   #
   # @return [Gcloud::Datastore::Dataset]
   #

--- a/lib/gcloud/datastore/credentials.rb
+++ b/lib/gcloud/datastore/credentials.rb
@@ -26,8 +26,7 @@ module Gcloud
     #
     # @see https://developers.google.com/accounts/docs/application-default-credentials
     class Credentials < Gcloud::Credentials
-      SCOPE = ["https://www.googleapis.com/auth/datastore",
-               "https://www.googleapis.com/auth/userinfo.email"]
+      SCOPE = ["https://www.googleapis.com/auth/datastore"]
       PATH_ENV_VARS = %w(DATASTORE_KEYFILE GCLOUD_KEYFILE GOOGLE_CLOUD_KEYFILE)
       JSON_ENV_VARS = %w(DATASTORE_KEYFILE_JSON GCLOUD_KEYFILE_JSON
                          GOOGLE_CLOUD_KEYFILE_JSON)


### PR DESCRIPTION
Datastore v1beta3 removes the requirement on the `userinfo.email` scope.