### PR TITLE
Remove calls to instance_eval

### DIFF
--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -54,10 +54,8 @@ module Gcloud
   #
   def self.new project = nil, keyfile = nil
     gcloud = Object.new
-    gcloud.instance_eval do
-      @project = project
-      @keyfile = keyfile
-    end
+    gcloud.instance_variable_set "@project", project
+    gcloud.instance_variable_set "@keyfile", keyfile
     gcloud.extend Gcloud
     gcloud
   end

--- a/lib/gcloud/bigquery/dataset/list.rb
+++ b/lib/gcloud/bigquery/dataset/list.rb
@@ -41,10 +41,8 @@ module Gcloud
           datasets = List.new(Array(resp.data["datasets"]).map do |gapi_object|
             Dataset.from_gapi gapi_object, conn
           end)
-          datasets.instance_eval do
-            @token = resp.data["nextPageToken"]
-            @etag = resp.data["etag"]
-          end
+          datasets.instance_variable_set "@token", resp.data["nextPageToken"]
+          datasets.instance_variable_set "@etag",  resp.data["etag"]
           datasets
         end
       end

--- a/lib/gcloud/bigquery/job/list.rb
+++ b/lib/gcloud/bigquery/job/list.rb
@@ -44,11 +44,9 @@ module Gcloud
           jobs = List.new(Array(resp.data["jobs"]).map do |gapi_object|
             Job.from_gapi gapi_object, conn
           end)
-          jobs.instance_eval do
-            @token = resp.data["nextPageToken"]
-            @etag = resp.data["etag"]
-            @total = resp.data["totalItems"]
-          end
+          jobs.instance_variable_set "@token", resp.data["nextPageToken"]
+          jobs.instance_variable_set "@etag",  resp.data["etag"]
+          jobs.instance_variable_set "@total", resp.data["totalItems"]
           jobs
         end
       end

--- a/lib/gcloud/bigquery/table/list.rb
+++ b/lib/gcloud/bigquery/table/list.rb
@@ -44,11 +44,9 @@ module Gcloud
           tables = List.new(Array(resp.data["tables"]).map do |gapi_object|
             Table.from_gapi gapi_object, conn
           end)
-          tables.instance_eval do
-            @token = resp.data["nextPageToken"]
-            @etag = resp.data["etag"]
-            @total = resp.data["totalItems"]
-          end
+          tables.instance_variable_set "@token", resp.data["nextPageToken"]
+          tables.instance_variable_set "@etag",  resp.data["etag"]
+          tables.instance_variable_set "@total", resp.data["totalItems"]
           tables
         end
       end

--- a/lib/gcloud/dns/change/list.rb
+++ b/lib/gcloud/dns/change/list.rb
@@ -52,10 +52,8 @@ module Gcloud
           changes = new(Array(resp.data["changes"]).map do |gapi_object|
             Change.from_gapi gapi_object, zone
           end)
-          changes.instance_eval do
-            @token = resp.data["nextPageToken"]
-            @zone = zone
-          end
+          changes.instance_variable_set "@token", resp.data["nextPageToken"]
+          changes.instance_variable_set "@zone",  zone
           changes
         end
 

--- a/lib/gcloud/dns/record/list.rb
+++ b/lib/gcloud/dns/record/list.rb
@@ -73,10 +73,8 @@ module Gcloud
           records = new(Array(resp.data["rrsets"]).map do |gapi_object|
             Record.from_gapi gapi_object
           end)
-          records.instance_eval do
-            @token = resp.data["nextPageToken"]
-            @zone = zone
-          end
+          records.instance_variable_set "@token", resp.data["nextPageToken"]
+          records.instance_variable_set "@zone",  zone
           records
         end
 

--- a/lib/gcloud/dns/zone/list.rb
+++ b/lib/gcloud/dns/zone/list.rb
@@ -57,10 +57,8 @@ module Gcloud
           zones = new(Array(resp.data["managedZones"]).map do |gapi_object|
             Zone.from_gapi gapi_object, conn
           end)
-          zones.instance_eval do
-            @token = resp.data["nextPageToken"]
-            @connection = conn
-          end
+          zones.instance_variable_set "@token",      resp.data["nextPageToken"]
+          zones.instance_variable_set "@connection", conn
           zones
         end
 

--- a/lib/gcloud/logging/entry.rb
+++ b/lib/gcloud/logging/entry.rb
@@ -228,11 +228,11 @@ module Gcloud
           e.insert_id = grpc.insert_id
           e.labels = map_to_hash(grpc.labels)
           e.payload = extract_payload(grpc)
-          e.instance_eval do
-            @resource = Resource.from_grpc grpc.resource
-            @http_request = HttpRequest.from_grpc grpc.http_request
-            @operation = Operation.from_grpc grpc.operation
-          end
+          e.instance_variable_set "@resource", Resource.from_grpc(grpc.resource)
+          e.instance_variable_set "@http_request",
+                                  HttpRequest.from_grpc(grpc.http_request)
+          e.instance_variable_set "@operation",
+                                  Operation.from_grpc(grpc.operation)
         end
       end
 

--- a/lib/gcloud/logging/entry/list.rb
+++ b/lib/gcloud/logging/entry/list.rb
@@ -85,15 +85,14 @@ module Gcloud
           entries = new(Array(grpc_list.entries).map do |grpc_entry|
             Entry.from_grpc grpc_entry
           end)
-          entries.instance_eval do
-            @token = grpc_list.next_page_token
-            @token = nil if @token == ""
-            @service = service
-            @projects = projects
-            @filter = filter
-            @order = order
-            @max = max
-          end
+          token = grpc_list.next_page_token
+          token = nil if token == ""
+          entries.instance_variable_set "@token", token
+          entries.instance_variable_set "@service", service
+          entries.instance_variable_set "@projects", projects
+          entries.instance_variable_set "@filter", filter
+          entries.instance_variable_set "@order", order
+          entries.instance_variable_set "@max", max
           entries
         end
 

--- a/lib/gcloud/logging/metric/list.rb
+++ b/lib/gcloud/logging/metric/list.rb
@@ -76,11 +76,10 @@ module Gcloud
           metrics = new(Array(grpc_list.metrics).map do |grpc_metric|
             Metric.from_grpc grpc_metric, service
           end)
-          metrics.instance_eval do
-            @token = grpc_list.next_page_token
-            @token = nil if @token == ""
-            @service = service
-          end
+          token = grpc_list.next_page_token
+          token = nil if token == ""
+          metrics.instance_variable_set "@token", token
+          metrics.instance_variable_set "@service", service
           metrics
         end
 

--- a/lib/gcloud/logging/resource_descriptor.rb
+++ b/lib/gcloud/logging/resource_descriptor.rb
@@ -74,14 +74,13 @@ module Gcloud
       # Google::Api::MonitoredResourceDescriptor object.
       def self.from_grpc grpc
         r = new
-        r.instance_eval do
-          @type        = grpc.type
-          @name        = grpc.display_name
-          @description = grpc.description
-          @labels      = Array(grpc.labels).map do |g|
-            LabelDescriptor.from_grpc g
-          end
+        r.instance_variable_set "@type", grpc.type
+        r.instance_variable_set "@name", grpc.display_name
+        r.instance_variable_set "@description", grpc.description
+        labels = Array(grpc.labels).map do |g|
+          LabelDescriptor.from_grpc g
         end
+        r.instance_variable_set "@labels", labels
         r
       end
 
@@ -127,11 +126,9 @@ module Gcloud
                        BOOL:   :boolean,
                        INT64:  :integer }[grpc.value_type]
           l = new
-          l.instance_eval do
-            @key         = grpc.key
-            @type        = type_sym
-            @description = grpc.description
-          end
+          l.instance_variable_set "@key", grpc.key
+          l.instance_variable_set "@type", type_sym
+          l.instance_variable_set "@description", grpc.description
           l
         end
       end

--- a/lib/gcloud/logging/resource_descriptor/list.rb
+++ b/lib/gcloud/logging/resource_descriptor/list.rb
@@ -57,11 +57,10 @@ module Gcloud
           sinks = new(Array(grpc_list.resource_descriptors).map do |grpc|
             ResourceDescriptor.from_grpc grpc
           end)
-          sinks.instance_eval do
-            @token = grpc_list.next_page_token
-            @token = nil if @token == ""
-            @service = service
-          end
+          token = grpc_list.next_page_token
+          token = nil if token == ""
+          sinks.instance_variable_set "@token", token
+          sinks.instance_variable_set "@service", service
           sinks
         end
 

--- a/lib/gcloud/logging/sink/list.rb
+++ b/lib/gcloud/logging/sink/list.rb
@@ -76,11 +76,10 @@ module Gcloud
           sinks = new(Array(grpc_list.sinks).map do |grpc|
             Sink.from_grpc grpc, service
           end)
-          sinks.instance_eval do
-            @token = grpc_list.next_page_token
-            @token = nil if @token == ""
-            @service = service
-          end
+          token = grpc_list.next_page_token
+          token = nil if token == ""
+          sinks.instance_variable_set "@token", token
+          sinks.instance_variable_set "@service", service
           sinks
         end
 

--- a/lib/gcloud/pubsub/message.rb
+++ b/lib/gcloud/pubsub/message.rb
@@ -86,9 +86,7 @@ module Gcloud
       # @private New Message from a Google::Pubsub::V1::PubsubMessage object.
       def self.from_grpc grpc
         new.tap do |m|
-          m.instance_eval do
-            @grpc = grpc
-          end
+          m.instance_variable_set "@grpc", grpc
         end
       end
     end

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -56,14 +56,12 @@ module Gcloud
       ##
       # @private New lazy {Topic} object without making an HTTP request.
       def self.new_lazy name, service, options = {}
-        sub = new.tap do |f|
-          f.grpc = nil
-          f.service = service
+        new.tap do |s|
+          s.grpc = nil
+          s.service = service
+          s.instance_variable_set "@name",
+                                  service.subscription_path(name, options)
         end
-        sub.instance_eval do
-          @name = service.subscription_path(name, options)
-        end
-        sub
       end
 
       ##

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -58,9 +58,7 @@ module Gcloud
         new.tap do |t|
           t.grpc = nil
           t.service = service
-          t.instance_eval do
-            @name = service.topic_path(name, options)
-          end
+          t.instance_variable_set "@name", service.topic_path(name, options)
         end
       end
 

--- a/lib/gcloud/resource_manager/project/list.rb
+++ b/lib/gcloud/resource_manager/project/list.rb
@@ -70,10 +70,8 @@ module Gcloud
           projects = new(Array(resp.data["projects"]).map do |gapi_object|
             Project.from_gapi gapi_object, manager.connection
           end)
-          projects.instance_eval do
-            @token = resp.data["nextPageToken"]
-            @manager = manager
-          end
+          projects.instance_variable_set "@token",   resp.data["nextPageToken"]
+          projects.instance_variable_set "@manager", manager
           projects
         end
 

--- a/test/gcloud/bigquery/query_data_test.rb
+++ b/test/gcloud/bigquery/query_data_test.rb
@@ -104,9 +104,7 @@ describe Gcloud::Bigquery::QueryData, :mock_bigquery do
   end
 
   it "can hold a job object and not make HTTP API calls to return it" do
-    query_data.instance_eval do
-      @job = "I AM A STUBBED JOB"
-    end
+    query_data.instance_variable_set "@job", "I AM A STUBBED JOB"
 
     job = query_data.job
     job.must_equal "I AM A STUBBED JOB"


### PR DESCRIPTION
This is a performance optimization. Use `instance_variable_set` instead of `instance_eval`. We don't want to bust the method cache every time we create an object. Thanks tenderlove!