### PR TITLE
Support Datastore Emulator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,14 +92,6 @@ $ gcloud auth login
 $ gcloud preview datastore create-indexes acceptance/data/
 ```
 
-##### Local Datastore Devserver
-
-You can run the Datstore acceptance tests against a devserver running locally. To switch to the devserver set the `DATASTORE_HOST` environment variable with the location of the local devserver.
-
-``` sh
-$ DATASTORE_HOST=http://127.0.0.1:8080 rake test:acceptance:datastore
-```
-
 #### DNS Acceptance Tests
 
 To run the DNS acceptance tests you must give your service account permissions to a domain name in [Webmaster Central](https://www.google.com/webmasters/verification) and set the `GCLOUD_TEST_DNS_DOMAIN` environment variable to the fully qualified domain name. (e.g. "example.com.")

--- a/acceptance/datastore_helper.rb
+++ b/acceptance/datastore_helper.rb
@@ -5,7 +5,7 @@ module Acceptance
   ##
   # Test class for running against a Datastore instance.
   # Ensures that there is an active connection for the tests to use.
-  # Can be used to run tests against a hosted datastore or local devserver.
+  # Can be used to run tests against a hosted datastore or emulator.
   #
   # This class can be used with the spec DSL.
   # To do so, add :datastore to describe:

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -520,6 +520,49 @@ module Gcloud
   # end
   # ```
   #
+  # ## The Datastore Emulator
+  #
+  # As of this release, the Datastore emulator that is part of the gcloud SDK is
+  # no longer compatible with gcloud-ruby. This is because the gcloud SDK's
+  # Datastore emulator does not yet support gRPC as a transport layer.
+  #
+  # A gRPC-compatible emulator is available until the gcloud SDK Datastore
+  # emulator supports gRPC. To use it you must [download the gRPC
+  # emulator](https://storage.googleapis.com/gcd/tools/gcd-grpc-1.0.0.zip) and
+  # use the `gcd.sh` script.
+  #
+  # When you run the gRPC emulator you will see a message similar to the
+  # following printed:
+  #
+  # ```
+  # If you are using a library that supports the DATASTORE_EMULATOR_HOST
+  # environment variable, run:
+  #
+  # export DATASTORE_EMULATOR_HOST=localhost:8978
+  # ```
+  #
+  # Now you can connect to the emulator using the `DATASTORE_EMULATOR_HOST`
+  # environment variable:
+  #
+  # ```ruby
+  # require "gcloud"
+  #
+  # # Make Datastore use the emulator
+  # ENV["DATASTORE_EMULATOR_HOST"] = "localhost:8978"
+  #
+  # gcloud = Gcloud.new "emulator-project-id"
+  # datastore = gcloud.datastore
+  #
+  # task = datastore.entity "Task", "emulatorTask" do |t|
+  #   t["type"] = "Testing"
+  #   t["done"] = false
+  #   t["priority"] = 5
+  #   t["description"] = "Use Datastore Emulator"
+  # end
+  #
+  # datastore.save task
+  # ```
+  #
   module Datastore
   end
 end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -59,6 +59,11 @@ module Gcloud
   #
   def self.datastore project = nil, keyfile = nil, scope: nil
     project ||= Gcloud::Datastore::Dataset.default_project
+    if ENV["DATASTORE_EMULATOR_HOST"]
+      ds = Gcloud::Datastore::Dataset.new project, :this_channel_is_insecure
+      ds.service.host = ENV["DATASTORE_EMULATOR_HOST"]
+      return ds
+    end
     if keyfile.nil?
       credentials = Gcloud::Datastore::Credentials.default scope: scope
     else

--- a/lib/gcloud/datastore/service.rb
+++ b/lib/gcloud/datastore/service.rb
@@ -23,32 +23,20 @@ module Gcloud
     # @private Represents the gRPC Datastore service, including all the API
     # methods.
     class Service
-      DEFAULT_HOST = "datastore.googleapis.com"
-      attr_accessor :project, :credentials
+      attr_accessor :project, :credentials, :host
 
       ##
       # Creates a new Service instance.
       def initialize project, credentials
         @project = project
         @credentials = credentials
+        @host = "datastore.googleapis.com"
       end
 
       def creds
+        return credentials if insecure?
         GRPC::Core::ChannelCredentials.new.compose \
           GRPC::Core::CallCredentials.new credentials.client.updater_proc
-      end
-
-      ##
-      # The Datastore API URL.
-      def host
-        @host || ENV["DATASTORE_HOST"] || DEFAULT_HOST
-      end
-
-      ##
-      # Update the Datastore API URL.
-      def host= new_host
-        @datastore = nil # Reset the GRPC object when host is set
-        @host = new_host
       end
 
       def datastore
@@ -57,6 +45,10 @@ module Gcloud
           host, creds)
       end
       attr_accessor :mocked_datastore
+
+      def insecure?
+        credentials == :this_channel_is_insecure
+      end
 
       ##
       # Allocate IDs for incomplete keys.


### PR DESCRIPTION
- [x] Support `DATASTORE_EMULATOR_HOST` environment variable
- [x] Skip authentication when connecting to emulator
- [x] Document emulator usage

[closes #676, closes #615, closes #604]