### PR TITLE
Add Datastore insert and update support

### DIFF
--- a/lib/gcloud/datastore/commit.rb
+++ b/lib/gcloud/datastore/commit.rb
@@ -52,7 +52,8 @@ module Gcloud
       #   end
       #
       def save *entities
-        entities.each { |entity| @shared_upserts << entity }
+        entities = Array(entities).flatten
+        @shared_upserts += entities unless entities.empty?
         # Do not save yet
         entities
       end
@@ -71,7 +72,8 @@ module Gcloud
       #   end
       #
       def insert *entities
-        entities.each { |entity| @shared_inserts << entity }
+        entities = Array(entities).flatten
+        @shared_inserts += entities unless entities.empty?
         # Do not insert yet
         entities
       end
@@ -89,7 +91,8 @@ module Gcloud
       #   end
       #
       def update *entities
-        entities.each { |entity| @shared_updates << entity }
+        entities = Array(entities).flatten
+        @shared_updates += entities unless entities.empty?
         # Do not update yet
         entities
       end
@@ -108,10 +111,10 @@ module Gcloud
       #   end
       #
       def delete *entities_or_keys
-        keys = entities_or_keys.map do |e_or_k|
+        keys = Array(entities_or_keys).flatten.map do |e_or_k|
           e_or_k.respond_to?(:key) ? e_or_k.key : e_or_k
         end
-        keys.each { |k| @shared_deletes << k }
+        @shared_deletes += keys unless keys.empty?
         # Do not delete yet
         true
       end

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -158,6 +158,70 @@ module Gcloud
       def save *entities
         commit { |c| c.save(*entities) }
       end
+      alias_method :upsert, :save
+
+      ##
+      # Insert one or more entities to the Datastore. An InvalidArgumentError
+      # will raised if the entities cannot be inserted.
+      #
+      # @param [Entity] entities One or more entity objects to be inserted.
+      #
+      # @return [Array<Gcloud::Datastore::Entity>]
+      #
+      # @example Insert a new entity:
+      #   task = datastore.entity "Task" do |t|
+      #     t["type"] = "Personal"
+      #     t["done"] = false
+      #     t["priority"] = 4
+      #     t["description"] = "Learn Cloud Datastore"
+      #   end
+      #   task.key.id #=> nil
+      #   datastore.insert task
+      #   task.key.id #=> 123456
+      #
+      # @example Insert multiple new entities in a batch:
+      #   task1 = datastore.entity "Task" do |t|
+      #     t["type"] = "Personal"
+      #     t["done"] = false
+      #     t["priority"] = 4
+      #     t["description"] = "Learn Cloud Datastore"
+      #   end
+      #
+      #   task2 = datastore.entity "Task" do |t|
+      #     t["type"] = "Personal"
+      #     t["done"] = false
+      #     t["priority"] = 5
+      #     t["description"] = "Integrate Cloud Datastore"
+      #   end
+      #
+      #   task_key1, task_key2 = datastore.insert(task1, task2).map(&:key)
+      #
+      def insert *entities
+        commit { |c| c.insert(*entities) }
+      end
+
+      ##
+      # Update one or more entities to the Datastore. An InvalidArgumentError
+      # will raised if the entities cannot be updated.
+      #
+      # @param [Entity] entities One or more entity objects to be updated.
+      #
+      # @return [Array<Gcloud::Datastore::Entity>]
+      #
+      # @example Update an existing entity:
+      #   task = datastore.find "Task", "sampleTask"
+      #   task["done"] = true
+      #   datastore.save task
+      #
+      # @example update multiple new entities in a batch:
+      #   query = datastore.query("Task").where("done", "=", false)
+      #   tasks = datastore.run query
+      #   tasks.each { |t| t["done"] = true }
+      #   datastore.update tasks
+      #
+      def update *entities
+        commit { |c| c.update(*entities) }
+      end
 
       ##
       # Remove entities from the Datastore.

--- a/lib/gcloud/datastore/transaction.rb
+++ b/lib/gcloud/datastore/transaction.rb
@@ -90,6 +90,56 @@ module Gcloud
         # Do not save yet
         entities
       end
+      alias_method :upsert, :save
+
+      ##
+      # Insert entities in a transaction. An InvalidArgumentError will raised if
+      # the entities cannot be inserted.
+      #
+      # @example Transactional insert:
+      #   task_key = datastore.key "Task", "sampleTask"
+      #
+      #   task = nil
+      #   datastore.transaction do |tx|
+      #     task = tx.find task_key
+      #     if task.nil?
+      #       task = datastore.entity task_key do |t|
+      #         t["type"] = "Personal"
+      #         t["done"] = false
+      #         t["priority"] = 4
+      #         t["description"] = "Learn Cloud Datastore"
+      #       end
+      #       tx.insert task
+      #     end
+      #   end
+      #
+      def insert *entities
+        @commit.insert(*entities)
+        # Do not insert yet
+        entities
+      end
+
+      ##
+      # Update entities in a transaction. An InvalidArgumentError will raised if
+      # the entities cannot be updated.
+      #
+      # @example Transactional update:
+      #   task_key = datastore.key "Task", "sampleTask"
+      #
+      #   task = nil
+      #   datastore.transaction do |tx|
+      #     task = tx.find task_key
+      #     if task
+      #       task["done"] = true
+      #       tx.update task
+      #     end
+      #   end
+      #
+      def update *entities
+        @commit.update(*entities)
+        # Do not update yet
+        entities
+      end
 
       ##
       # Remove entities in a transaction.

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -54,11 +54,19 @@ describe Gcloud::Datastore::Dataset do
       end
     )
   end
-
   let(:commit_res) do
     Google::Datastore::V1beta3::CommitResponse.new(
       mutation_results: [
         Google::Datastore::V1beta3::MutationResult.new(key: Gcloud::Datastore::Key.new("ds-test", "thingie").to_grpc)
+      ]
+    )
+  end
+
+  let(:multiple_commit_res) do
+    Google::Datastore::V1beta3::CommitResponse.new(
+      mutation_results: [
+        Google::Datastore::V1beta3::MutationResult.new(key: Gcloud::Datastore::Key.new("ds-test", "thingie").to_grpc),
+        Google::Datastore::V1beta3::MutationResult.new(key: Gcloud::Datastore::Key.new("ds-test", "thangie").to_grpc)
       ]
     )
   end
@@ -197,6 +205,74 @@ describe Gcloud::Datastore::Dataset do
     entity.must_be :persisted?
   end
 
+  it "save will persist multiple entities" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      upsert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      upsert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+        e["name"] = "thungamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    entity1.wont_be :persisted?
+    entity2.wont_be :persisted?
+    dataset.save entity1, entity2
+    entity1.must_be :persisted?
+    entity2.must_be :persisted?
+  end
+
+  it "save will persist multiple entities in an array" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      upsert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      upsert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+        e["name"] = "thungamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    entity1.wont_be :persisted?
+    entity2.wont_be :persisted?
+    dataset.save [entity1, entity2]
+    entity1.must_be :persisted?
+    entity2.must_be :persisted?
+  end
+
   it "insert will persist complete entities" do
     # Remove key from response
     commit_res.mutation_results.first.key = nil
@@ -247,6 +323,74 @@ describe Gcloud::Datastore::Dataset do
     entity.must_be :persisted?
   end
 
+  it "insert will persist multiple entities" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      insert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      insert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+        e["name"] = "thungamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    entity1.wont_be :persisted?
+    entity2.wont_be :persisted?
+    dataset.insert entity1, entity2
+    entity1.must_be :persisted?
+    entity2.must_be :persisted?
+  end
+
+  it "insert will persist multiple entities in an array" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      insert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      insert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+        e["name"] = "thungamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    entity1.wont_be :persisted?
+    entity2.wont_be :persisted?
+    dataset.insert [entity1, entity2]
+    entity1.must_be :persisted?
+    entity2.must_be :persisted?
+  end
+
   it "update will persist entities" do
     # Remove key from response
     commit_res.mutation_results.first.key = nil
@@ -271,6 +415,78 @@ describe Gcloud::Datastore::Dataset do
     dataset.update entity
     entity.key.must_be :complete?
     entity.must_be :persisted?
+  end
+
+  it "update will persist multiple entities" do
+    # Remove keys from response
+    multiple_commit_res.mutation_results.each { |m| m.key = nil }
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      update: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      update: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+        e["name"] = "thungamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    entity1.wont_be :persisted?
+    entity2.wont_be :persisted?
+    dataset.update entity1, entity2
+    entity1.must_be :persisted?
+    entity2.must_be :persisted?
+  end
+
+  it "update will persist multiple entities in an array" do
+    # Remove keys from response
+    multiple_commit_res.mutation_results.each { |m| m.key = nil }
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      update: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      update: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+        e["name"] = "thungamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    entity1.wont_be :persisted?
+    entity2.wont_be :persisted?
+    dataset.update [entity1, entity2]
+    entity1.must_be :persisted?
+    entity2.must_be :persisted?
   end
 
   it "find can take a kind and id" do
@@ -488,6 +704,54 @@ describe Gcloud::Datastore::Dataset do
     dataset.delete entity
   end
 
+  it "delete with multiple entity will call commit" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thingie").to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thangie").to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    dataset.delete entity1, entity2
+  end
+
+  it "delete with multiple entity in an array will call commit" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thingie").to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thangie").to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    dataset.delete [entity1, entity2]
+  end
+
   it "delete with key will call commit" do
     mutation = Google::Datastore::V1beta3::Mutation.new(
       delete: Gcloud::Datastore::Key.new("ds-test", "thingie").to_grpc
@@ -501,6 +765,54 @@ describe Gcloud::Datastore::Dataset do
 
     key = Gcloud::Datastore::Key.new "ds-test", "thingie"
     dataset.delete key
+  end
+
+  it "delete with multiple keys will call commit" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thingie").to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thangie").to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    dataset.delete entity1.key, entity2.key
+  end
+
+  it "delete with multiple keys in an array will call commit" do
+    mutation1 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thingie").to_grpc)
+    mutation2 = Google::Datastore::V1beta3::Mutation.new(
+      delete: Gcloud::Datastore::Key.new("ds-test", "thangie").to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation1, mutation2]
+    )
+
+    dataset.service.mocked_datastore.expect :commit, multiple_commit_res, [commit_req]
+
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    dataset.delete [entity1.key, entity2.key]
   end
 
   it "run will fulfill a query" do

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -147,6 +147,132 @@ describe Gcloud::Datastore::Dataset do
     entity.must_be :persisted?
   end
 
+  it "save will persist complete entities with upsert alias" do
+    # Remove key from response
+    commit_res.mutation_results.first.key = nil
+    mutation = Google::Datastore::V1beta3::Mutation.new(
+      upsert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation]
+    )
+    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity.key.must_be :complete?
+    entity.wont_be :persisted?
+    dataset.upsert entity
+    entity.key.must_be :complete?
+    entity.must_be :persisted?
+  end
+
+  it "save will persist incomplete entities with upsert alias" do
+    mutation = Google::Datastore::V1beta3::Mutation.new(
+      upsert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation]
+    )
+    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test"
+      e["name"] = "thingamajig"
+    end
+    entity.key.wont_be :complete?
+    entity.wont_be :persisted?
+    dataset.upsert entity
+    entity.key.must_be :complete?
+    entity.must_be :persisted?
+  end
+
+  it "insert will persist complete entities" do
+    # Remove key from response
+    commit_res.mutation_results.first.key = nil
+    mutation = Google::Datastore::V1beta3::Mutation.new(
+      insert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation]
+    )
+    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity.key.must_be :complete?
+    entity.wont_be :persisted?
+    dataset.insert entity
+    entity.key.must_be :complete?
+    entity.must_be :persisted?
+  end
+
+  it "insert will persist incomplete entities" do
+    mutation = Google::Datastore::V1beta3::Mutation.new(
+      insert: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation]
+    )
+    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test"
+      e["name"] = "thingamajig"
+    end
+    entity.key.wont_be :complete?
+    entity.wont_be :persisted?
+    dataset.insert entity
+    entity.key.must_be :complete?
+    entity.must_be :persisted?
+  end
+
+  it "update will persist entities" do
+    # Remove key from response
+    commit_res.mutation_results.first.key = nil
+    mutation = Google::Datastore::V1beta3::Mutation.new(
+      update: Gcloud::Datastore::Entity.new.tap do |e|
+        e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+        e["name"] = "thingamajig"
+      end.to_grpc)
+    commit_req = Google::Datastore::V1beta3::CommitRequest.new(
+      project_id: project,
+      mode: :NON_TRANSACTIONAL,
+      mutations: [mutation]
+    )
+    dataset.service.mocked_datastore.expect :commit, commit_res, [commit_req]
+
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity.key.must_be :complete?
+    entity.wont_be :persisted?
+    dataset.update entity
+    entity.key.must_be :complete?
+    entity.must_be :persisted?
+  end
+
   it "find can take a kind and id" do
     lookup_req = Google::Datastore::V1beta3::LookupRequest.new(
       project_id: project,

--- a/test/gcloud/datastore/transaction_test.rb
+++ b/test/gcloud/datastore/transaction_test.rb
@@ -76,7 +76,41 @@ describe Gcloud::Datastore::Transaction do
       e["name"] = "thingamajig"
     end
     transaction.save entity
-    transaction.instance_variable_get("@commit").send(:shared_upserts).must_include entity
+    # Testing implementation like we are writing Java!
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity
+  end
+
+  it "save does not persist entities with upsert alias" do
+    begin_tx_res.wont_equal "poop"
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    transaction.upsert entity
+    # Testing implementation like we are writing Java!
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity
+  end
+
+  it "insert does not persist entities" do
+    begin_tx_res.wont_equal "poop"
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    transaction.insert entity
+    # Testing implementation like we are writing Java!
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity
+  end
+
+  it "update does not persist entities" do
+    begin_tx_res.wont_equal "poop"
+    entity = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    transaction.update entity
+    # Testing implementation like we are writing Java!
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity
   end
 
   it "delete does not persist entities" do
@@ -85,7 +119,8 @@ describe Gcloud::Datastore::Transaction do
       e["name"] = "thingamajig"
     end
     transaction.delete entity
-    transaction.instance_variable_get("@commit").send(:shared_deletes).must_include entity.key
+    # Testing implementation is bad, mkay?
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity.key
   end
 
   it "delete does not persist keys" do
@@ -94,7 +129,8 @@ describe Gcloud::Datastore::Transaction do
       e["name"] = "thingamajig"
     end
     transaction.delete entity.key
-    transaction.instance_variable_get("@commit").send(:shared_deletes).must_include entity.key
+    # Testing implementation like a BOSS!
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity.key
   end
 
   it "commit will save and delete entities" do
@@ -112,6 +148,14 @@ describe Gcloud::Datastore::Transaction do
           e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-saved"
           e["name"] = "Gonna be saved"
         end.to_grpc), Google::Datastore::V1beta3::Mutation.new(
+        insert: Gcloud::Datastore::Entity.new.tap do |e|
+          e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-inserted"
+          e["name"] = "Gonna be inserted"
+        end.to_grpc), Google::Datastore::V1beta3::Mutation.new(
+        update: Gcloud::Datastore::Entity.new.tap do |e|
+          e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-updated"
+          e["name"] = "Gonna be updated"
+        end.to_grpc), Google::Datastore::V1beta3::Mutation.new(
           delete: Gcloud::Datastore::Key.new("ds-test", "to-be-deleted").to_grpc)]
     )
     transaction.service.mocked_datastore.expect :commit, commit_res, [commit_req]
@@ -119,6 +163,14 @@ describe Gcloud::Datastore::Transaction do
     entity_to_be_saved = Gcloud::Datastore::Entity.new.tap do |e|
       e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-saved"
       e["name"] = "Gonna be saved"
+    end
+    entity_to_be_inserted = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-inserted"
+      e["name"] = "Gonna be inserted"
+    end
+    entity_to_be_updated = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-updated"
+      e["name"] = "Gonna be updated"
     end
     entity_to_be_deleted = Gcloud::Datastore::Entity.new.tap do |e|
       e.key = Gcloud::Datastore::Key.new "ds-test", "to-be-deleted"
@@ -128,6 +180,8 @@ describe Gcloud::Datastore::Transaction do
     entity_to_be_saved.wont_be :persisted?
     transaction.commit do |c|
       c.save entity_to_be_saved
+      c.insert entity_to_be_inserted
+      c.update entity_to_be_updated
       c.delete entity_to_be_deleted
     end
     entity_to_be_saved.must_be :persisted?

--- a/test/gcloud/datastore/transaction_test.rb
+++ b/test/gcloud/datastore/transaction_test.rb
@@ -91,6 +91,36 @@ describe Gcloud::Datastore::Transaction do
     transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity
   end
 
+  it "save does not persist multiple entities" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.save entity1, entity2
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity1
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity2
+  end
+
+  it "save does not persist multiple entities in an array" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.save [entity1, entity2]
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity1
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_upserts").must_include entity2
+  end
+
   it "insert does not persist entities" do
     begin_tx_res.wont_equal "poop"
     entity = Gcloud::Datastore::Entity.new.tap do |e|
@@ -100,6 +130,36 @@ describe Gcloud::Datastore::Transaction do
     transaction.insert entity
     # Testing implementation like we are writing Java!
     transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity
+  end
+
+  it "insert does not persist multiple entities" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.insert entity1, entity2
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity1
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity2
+  end
+
+  it "insert does not persist multiple entities in an array" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.insert [entity1, entity2]
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity1
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_inserts").must_include entity2
   end
 
   it "update does not persist entities" do
@@ -113,6 +173,36 @@ describe Gcloud::Datastore::Transaction do
     transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity
   end
 
+  it "update does not persist multiple entities" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.update entity1, entity2
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity1
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity2
+  end
+
+  it "update does not persist multiple entities in an array" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.update [entity1, entity2]
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity1
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_updates").must_include entity2
+  end
+
   it "delete does not persist entities" do
     entity = Gcloud::Datastore::Entity.new.tap do |e|
       e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
@@ -123,6 +213,36 @@ describe Gcloud::Datastore::Transaction do
     transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity.key
   end
 
+  it "delete does not persist multiple entities" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.delete entity1, entity2
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
+  end
+
+  it "delete does not persist multiple entities in an array" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.delete [entity1, entity2]
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
+  end
+
   it "delete does not persist keys" do
     entity = Gcloud::Datastore::Entity.new.tap do |e|
       e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
@@ -131,6 +251,36 @@ describe Gcloud::Datastore::Transaction do
     transaction.delete entity.key
     # Testing implementation like a BOSS!
     transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity.key
+  end
+
+  it "delete does not persist multiple keys" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.delete entity1.key, entity2.key
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
+  end
+
+  it "delete does not persist multiple keys in an array" do
+    begin_tx_res.wont_equal "poop"
+    entity1 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thingie"
+      e["name"] = "thingamajig"
+    end
+    entity2 = Gcloud::Datastore::Entity.new.tap do |e|
+      e.key = Gcloud::Datastore::Key.new "ds-test", "thangie"
+      e["name"] = "thungamajig"
+    end
+    transaction.delete [entity1.key, entity2.key]
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity1.key
+    transaction.instance_variable_get("@commit").instance_variable_get("@shared_deletes").must_include entity2.key
   end
 
   it "commit will save and delete entities" do


### PR DESCRIPTION
Allow end users to specify if entities should be inserted or updated.
Allow the Datastore API to raise an error when the entities can't be saved or updated.

[closes #648]