### PR TITLE
Pin google-protobuf dependency

### DIFF
--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
                           "--exclude", "lib/google/"]
 
   gem.add_dependency                  "grpc", "~> 0.13.1"
-  gem.add_dependency                  "google-protobuf", "~> 3.0.0.alpha.5.0.5"
+  gem.add_dependency                  "google-protobuf", "= 3.0.0.alpha.5.0.5.1"
   gem.add_dependency                  "google-api-client", "~> 0.8.3"
   gem.add_dependency                  "mime-types", "~> 2.4"
   gem.add_dependency                  "digest-crc", "~> 0.4"


### PR DESCRIPTION
We didn't expect "~> 3.0.0.alpha.5.0.5" to match "3.0.0.alpha.6.0.0".
Make the dependency explicit on "3.0.0.alpha.5.0.5.1" as a result.