### PR TITLE
Add chunk_size support to Gcloud::Bigquery::Table#load method

### DIFF
--- a/lib/gcloud/bigquery/table.rb
+++ b/lib/gcloud/bigquery/table.rb
@@ -64,6 +64,8 @@ module Gcloud
     #   table.insert row
     #
     class Table
+      DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024 # 10Mb
+
       ##
       # @private The Connection object.
       attr_accessor :connection
@@ -678,6 +680,10 @@ module Gcloud
       #   file that BigQuery will skip when loading the data. The default value
       #   is `0`. This property is useful if you have header rows in the file
       #   that should be skipped.
+      # @param [Integer] chunk_size The number of bytes per chunk in a resumable
+      #   upload. Must be divisible by 256KB. If it is not divisible by 265KB
+      #   then it will be lowered to the nearest acceptable value. If not set,
+      #   the default value is 10Mb.
       #
       # @return [Gcloud::Bigquery::LoadJob]
       #
@@ -748,13 +754,14 @@ module Gcloud
       def load file, format: nil, create: nil, write: nil,
                projection_fields: nil, jagged_rows: nil, quoted_newlines: nil,
                encoding: nil, delimiter: nil, ignore_unknown: nil,
-               max_bad_records: nil, quote: nil, skip_leading: nil, dryrun: nil
+               max_bad_records: nil, quote: nil, skip_leading: nil, dryrun: nil,
+               chunk_size: DEFAULT_CHUNK_SIZE
         ensure_connection!
         options = { format: format, create: create, write: write,
                     projection_fields: projection_fields,
                     jagged_rows: jagged_rows, quoted_newlines: quoted_newlines,
                     encoding: encoding, delimiter: delimiter,
-                    ignore_unknown: ignore_unknown,
+                    ignore_unknown: ignore_unknown, chunk_size: chunk_size,
                     max_bad_records: max_bad_records, quote: quote,
                     skip_leading: skip_leading, dryrun: dryrun }
         return load_storage(file, options) if storage_url? file


### PR DESCRIPTION
In the tests I'm checking that the file is resumable because otherwise we get a false positive.