### PR TITLE
Refactor default chunk_size

### DIFF
--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -515,7 +515,8 @@ module Gcloud
       #   response header to be returned when the file is downloaded.
       # @param [Integer] chunk_size The number of bytes per chunk in a resumable
       #   upload. Must be divisible by 256KB. If it is not divisible by 265KB
-      #   then it will be lowered to the nearest acceptable value.
+      #   then it will be lowered to the nearest acceptable value. If no value
+      #   is provided it will use {Gcloud::Upload.default_chunk_size}. Optional.
       # @param [String] crc32c The CRC32c checksum of the file data, as
       #   described in [RFC 4960, Appendix
       #   B](http://tools.ietf.org/html/rfc4960#appendix-B).

--- a/lib/gcloud/upload.rb
+++ b/lib/gcloud/upload.rb
@@ -40,12 +40,56 @@ module Gcloud
     end
 
     ##
-    # Sets a new resumable threshold value.
+    # Sets a new resumable threshold value in number of bytes.
     def self.resumable_threshold= new_resumable_threshold
       @@resumable_threshold = new_resumable_threshold.to_i
     end
 
-    # Set the default threshold to 5 MiB.
-    self.resumable_threshold = 5_000_000
+    ##
+    # Default chunk size used on resumable uploads.
+    #
+    # The default value is 10 MB (10,485,760 bytes).
+    def self.default_chunk_size
+      @@default_chunk_size
+    end
+
+    ##
+    # Sets a new default chunk_size value in number of bytes. Must be a multiple
+    # of 256KB (262,144).
+    def self.default_chunk_size= new_chunk_size
+      new_chunk_size = normalize_chunk_size new_chunk_size
+      @@default_chunk_size = new_chunk_size if new_chunk_size
+    end
+
+    ##
+    # @private Determines if a chunk_size is valid. Must be a multiple of 256KB.
+    # Returns lowest possible chunk_size if given a very small value.
+    def self.normalize_chunk_size chunk_size
+      chunk_size = chunk_size.to_i
+      chunk_mod = 256 * 1024 # 256KB
+      if (chunk_size.to_i % chunk_mod) != 0
+        chunk_size = (chunk_size / chunk_mod) * chunk_mod
+      end
+      return chunk_mod if chunk_size.zero?
+      chunk_size
+    end
+
+    ##
+    # @private Determines if a chunk_size is valid. Must be a multiple of 256KB.
+    # Returns the default chunk_size if one is not provided.
+    def self.verify_chunk_size chunk_size, file_size
+      if chunk_size.to_i.zero?
+        return nil if file_size < default_chunk_size
+        return default_chunk_size
+      else
+        chunk_size = normalize_chunk_size chunk_size
+        return nil if file_size < chunk_size
+        return chunk_size
+      end
+    end
+
+    # Set the default values for threshold and chunk_size.
+    self.resumable_threshold = 5_000_000  # 5 MiB
+    self.default_chunk_size  = 10_485_760 # 10 MB
   end
 end

--- a/test/gcloud/upload_test.rb
+++ b/test/gcloud/upload_test.rb
@@ -1,0 +1,164 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "gcloud/upload"
+
+describe Gcloud::Upload do
+  let(:minimum_chunk_size) { 256*1024 }
+
+  it "sets the defaults properly" do
+    Gcloud::Upload.resumable_threshold.must_equal 5000000
+    Gcloud::Upload.default_chunk_size.must_equal  10485760
+  end
+
+  describe :default_chunk_size do
+    before do
+      @original_chunk_size = Gcloud::Upload.default_chunk_size
+    end
+
+    after do
+      Gcloud::Upload.default_chunk_size = @original_chunk_size
+    end
+
+    it "can't set chunk_size to less than 256KB" do
+      Gcloud::Upload.default_chunk_size = (256*1024)-1
+      Gcloud::Upload.default_chunk_size.must_equal minimum_chunk_size
+    end
+
+    it "can set chunk_size to larger than 256KB" do
+      Gcloud::Upload.default_chunk_size = (256*1024)+1
+      Gcloud::Upload.default_chunk_size.must_equal minimum_chunk_size
+    end
+
+    it "can set chunk_size to 16MB" do
+      Gcloud::Upload.default_chunk_size = (16*1024*1024)
+      Gcloud::Upload.default_chunk_size.must_equal (16*1024*1024)
+    end
+
+    it "can verifies the chunk_size is a multiple of 256KB" do
+      Gcloud::Upload.default_chunk_size = ((8*minimum_chunk_size) - minimum_chunk_size/2)
+      Gcloud::Upload.default_chunk_size.must_equal (7*minimum_chunk_size)
+    end
+  end
+
+  # This is the internal API
+  describe :verify_chunk_size do
+    describe "file size is less than default chunk size" do
+      let(:file_size) { 6*minimum_chunk_size }
+
+      it "gives the default chunk_size when given nil" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size nil, file_size
+          my_chunk_size.must_be :nil?
+        end
+      end
+
+      it "gives the default chunk_size when given 0" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size 0, file_size
+          my_chunk_size.must_be :nil?
+        end
+      end
+
+      it "verifies chunk_size less than 256KB" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size minimum_chunk_size-1, file_size
+          my_chunk_size.must_equal minimum_chunk_size
+        end
+      end
+
+      it "verifies chunk_size larger than 256KB" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size minimum_chunk_size+1, file_size
+          my_chunk_size.must_equal minimum_chunk_size
+        end
+      end
+
+      it "verifies chunk_size smaller than file size" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size 5*minimum_chunk_size, file_size
+          my_chunk_size.must_equal 5*minimum_chunk_size
+        end
+      end
+
+      it "verifies chunk_size larger than file size" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size 16*minimum_chunk_size, file_size
+          my_chunk_size.must_be :nil?
+        end
+      end
+
+      it "verifies the chunk_size is a multiple of 256KB" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size ((4*minimum_chunk_size) - minimum_chunk_size/2), file_size
+          my_chunk_size.must_equal (3*minimum_chunk_size)
+        end
+      end
+    end
+
+    describe "file size is larger than default chunk size" do
+      let(:file_size) { 10*minimum_chunk_size }
+
+      it "gives the default chunk_size when given nil" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size nil, file_size
+          my_chunk_size.must_equal Gcloud::Upload.default_chunk_size
+        end
+      end
+
+      it "gives the default chunk_size when given 0" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size 0, file_size
+          my_chunk_size.must_equal Gcloud::Upload.default_chunk_size
+        end
+      end
+
+      it "verifies chunk_size less than 256KB" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size minimum_chunk_size-1, file_size
+          my_chunk_size.must_equal minimum_chunk_size
+        end
+      end
+
+      it "verifies chunk_size larger than 256KB" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size minimum_chunk_size+1, file_size
+          my_chunk_size.must_equal minimum_chunk_size
+        end
+      end
+
+      it "verifies chunk_size smaller than file size" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size 9*minimum_chunk_size, file_size
+          my_chunk_size.must_equal 9*minimum_chunk_size
+        end
+      end
+
+      it "verifies chunk_size larger than file size" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size 16*minimum_chunk_size, file_size
+          my_chunk_size.must_be :nil?
+        end
+      end
+
+      it "verifies the chunk_size is a multiple of 256KB" do
+        Gcloud::Upload.stub :default_chunk_size, 8*minimum_chunk_size do
+          my_chunk_size = Gcloud::Upload.verify_chunk_size ((4*minimum_chunk_size) - minimum_chunk_size/2), file_size
+          my_chunk_size.must_equal (3*minimum_chunk_size)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make `default_chunk_size` configurable on `Gcloud::Upload`.
Use `Gcloud::Upload.default_chunk_size` in BigQuery and Storage.
Add additional tests for `default_chunk_size` behavior.
Add documentation on usage of `default_chunk_size`.

[refs #701]