### PR TITLE
Update Storage Verifier

### DIFF
--- a/lib/gcloud/storage/file/verifier.rb
+++ b/lib/gcloud/storage/file/verifier.rb
@@ -38,7 +38,7 @@ module Gcloud
           gcloud_digest = gcloud_file.crc32c
           local_digest = crc32c_for local_file
           if gcloud_digest != local_digest
-            fail FileVerificationError.for_md5(gcloud_digest, local_digest)
+            fail FileVerificationError.for_crc32c(gcloud_digest, local_digest)
           end
         end
 

--- a/lib/gcloud/storage/file/verifier.rb
+++ b/lib/gcloud/storage/file/verifier.rb
@@ -52,13 +52,13 @@ module Gcloud
 
         def self.md5_for local_file
           ::File.open(Pathname(local_file).to_path, "rb") do |f|
-            ::Digest::MD5.base64digest f.read
+            ::Digest::MD5.file(f).base64digest
           end
         end
 
         def self.crc32c_for local_file
           ::File.open(Pathname(local_file).to_path, "rb") do |f|
-            ::Digest::CRC32c.base64digest f.read
+            ::Digest::CRC32c.file(f).base64digest
           end
         end
       end


### PR DESCRIPTION
Avoid reading very large files into memory when calculating digests. Fix CRC32c errors message. 