### PR TITLE
Add Backoff to all google-api-client requests 

### DIFF
--- a/lib/gcloud/backoff.rb
+++ b/lib/gcloud/backoff.rb
@@ -33,26 +33,26 @@ module Gcloud
       ##
       # The number of times a retriable API call should be retried.
       #
-      # The default value is 3.
+      # The default value is `3`.
       attr_accessor :retries
 
       ##
       # The GRPC Status Codes that should be retried.
       #
-      # The default values are 14.
+      # The default values are `14`.
       attr_accessor :grpc_codes
 
       ##
       # The HTTP Status Codes that should be retried.
       #
-      # The default values are 500 and 503.
+      # The default values are `500` and `503`.
       attr_accessor :http_codes
 
       ##
       # The Google API error reasons that should be retried.
       #
-      # The default values are rateLimitExceeded and
-      # userRateLimitExceeded.
+      # The default values are `rateLimitExceeded` and
+      # `userRateLimitExceeded`.
       attr_accessor :reasons
 
       ##

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -386,6 +386,30 @@ module Gcloud
   # BigQuery](https://cloud.google.com/bigquery/exporting-data-from-bigquery)
   # for details.
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
+  # See the [BigQuery error
+  # table](https://cloud.google.com/bigquery/troubleshooting-errors#errortable)
+  # for a list of error conditions.
+  #
   module Bigquery
   end
 end

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -15,6 +15,7 @@
 
 require "pathname"
 require "gcloud/version"
+require "gcloud/backoff"
 require "google/api_client"
 require "digest/md5"
 

--- a/lib/gcloud/bigquery/connection.rb
+++ b/lib/gcloud/bigquery/connection.rb
@@ -50,7 +50,7 @@ module Gcloud
                    maxResults: options.delete(:max)
                  }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @bigquery.datasets.list,
           parameters: params
         )
@@ -59,7 +59,7 @@ module Gcloud
       ##
       # Returns the dataset specified by datasetID.
       def get_dataset dataset_id
-        @client.execute(
+        execute(
           api_method: @bigquery.datasets.get,
           parameters: { projectId: @project, datasetId: dataset_id }
         )
@@ -68,7 +68,7 @@ module Gcloud
       ##
       # Creates a new empty dataset.
       def insert_dataset dataset_id, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.datasets.insert,
           parameters: { projectId: @project },
           body_object: insert_dataset_request(dataset_id, options)
@@ -81,7 +81,7 @@ module Gcloud
       def patch_dataset dataset_id, options = {}
         project_id = options[:project_id] || @project
 
-        @client.execute(
+        execute(
           api_method: @bigquery.datasets.patch,
           parameters: { projectId: project_id, datasetId: dataset_id },
           body_object: patch_dataset_request(options)
@@ -95,7 +95,7 @@ module Gcloud
       # Immediately after deletion, you can create another dataset with
       # the same name.
       def delete_dataset dataset_id, force = nil
-        @client.execute(
+        execute(
           api_method: @bigquery.datasets.delete,
           parameters: { projectId: @project, datasetId: dataset_id,
                         deleteContents: force
@@ -113,14 +113,14 @@ module Gcloud
                    maxResults: options.delete(:max)
                  }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @bigquery.tables.list,
           parameters: params
         )
       end
 
       def get_project_table project_id, dataset_id, table_id
-        @client.execute(
+        execute(
           api_method: @bigquery.tables.get,
           parameters: { projectId: project_id, datasetId: dataset_id,
                         tableId: table_id }
@@ -139,7 +139,7 @@ module Gcloud
       ##
       # Creates a new, empty table in the dataset.
       def insert_table dataset_id, table_id, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.tables.insert,
           parameters: { projectId: @project, datasetId: dataset_id },
           body_object: insert_table_request(dataset_id, table_id, options)
@@ -150,7 +150,7 @@ module Gcloud
       # Updates information in an existing table, replacing fields that
       # are provided in the submitted table resource.
       def patch_table dataset_id, table_id, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.tables.patch,
           parameters: { projectId: @project, datasetId: dataset_id,
                         tableId: table_id },
@@ -162,7 +162,7 @@ module Gcloud
       # Deletes the table specified by tableId from the dataset.
       # If the table contains data, all the data will be deleted.
       def delete_table dataset_id, table_id
-        @client.execute(
+        execute(
           api_method: @bigquery.tables.delete,
           parameters: { projectId: @project, datasetId: dataset_id,
                         tableId: table_id }
@@ -179,14 +179,14 @@ module Gcloud
                    startIndex: options.delete(:start)
                  }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @bigquery.tabledata.list,
           parameters: params
         )
       end
 
       def insert_tabledata dataset_id, table_id, rows, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.tabledata.insert_all,
           parameters: { projectId: @project,
                         datasetId: dataset_id,
@@ -199,7 +199,7 @@ module Gcloud
       # Lists all jobs in the specified project to which you have
       # been granted the READER job role.
       def list_jobs options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.list,
           parameters: list_jobs_params(options)
         )
@@ -208,14 +208,14 @@ module Gcloud
       ##
       # Returns the job specified by jobID.
       def get_job job_id
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.get,
           parameters: { projectId: @project, jobId: job_id }
         )
       end
 
       def insert_job config
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.insert,
           parameters: { projectId: @project },
           body_object: { "configuration" => config }
@@ -223,7 +223,7 @@ module Gcloud
       end
 
       def query_job query, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.insert,
           parameters: { projectId: @project },
           body_object: query_table_config(query, options)
@@ -231,7 +231,7 @@ module Gcloud
       end
 
       def query query, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.query,
           parameters: { projectId: @project },
           body_object: query_config(query, options)
@@ -248,14 +248,14 @@ module Gcloud
                    timeoutMs: options.delete(:timeout)
                  }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.get_query_results,
           parameters: params
         )
       end
 
       def copy_table source, target, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.insert,
           parameters: { projectId: @project },
           body_object: copy_table_config(source, target, options)
@@ -263,7 +263,7 @@ module Gcloud
       end
 
       def link_table table, urls, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.insert,
           parameters: { projectId: @project },
           body_object: link_table_config(table, urls, options)
@@ -271,7 +271,7 @@ module Gcloud
       end
 
       def extract_table table, storage_files, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.insert,
           parameters: { projectId: @project },
           body_object: extract_table_config(table, storage_files, options)
@@ -279,7 +279,7 @@ module Gcloud
       end
 
       def load_table table, storage_url, options = {}
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.insert,
           parameters: { projectId: @project },
           body_object: load_table_config(table, storage_url,
@@ -290,7 +290,7 @@ module Gcloud
       def load_multipart table, file, options = {}
         media = load_media file
 
-        @client.execute(
+        execute(
           api_method: @bigquery.jobs.insert,
           media: media,
           parameters: { projectId: @project, uploadType: "multipart" },
@@ -301,14 +301,14 @@ module Gcloud
       def load_resumable table, file, chunk_size = nil, options = {}
         media = load_media file, chunk_size
 
-        result = @client.execute(
+        result = execute(
           api_method: @bigquery.jobs.insert,
           media: media,
           parameters: { projectId: @project, uploadType: "resumable" },
           body_object: load_table_config(table, nil, file, options)
         )
         upload = result.resumable_upload
-        result = @client.execute upload while upload.resumable?
+        result = execute upload while upload.resumable?
         result
       end
 
@@ -611,6 +611,12 @@ module Gcloud
         media = Google::APIClient::UploadIO.new local_path, mime_type
         media.chunk_size = chunk_size unless chunk_size.nil?
         media
+      end
+
+      def execute options
+        Gcloud::Backoff.new.execute_gapi do
+          @client.execute options
+        end
       end
     end
   end

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -507,6 +507,30 @@ module Gcloud
   # end
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
+  # See the [Datastore error
+  # codes](https://cloud.google.com/datastore/docs/concepts/errors#error_codes)
+  # for a list of error conditions.
+  #
   # ## The Datastore Emulator
   #
   # As of this release, the Datastore emulator that is part of the gcloud SDK is

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -301,6 +301,26 @@ module Gcloud
   # zone.export "path/to/db.example.com"
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
   module Dns
   end
 end

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -302,6 +302,25 @@ module Gcloud
   # logger.info "Job started."
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
   #
   module Logging
   end

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -389,6 +389,29 @@ module Gcloud
   # end
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
+  # See the [Pub/Sub error codes](https://cloud.google.com/pubsub/error-codes)
+  # for a list of error conditions.
+  #
   # ## Working Across Projects
   #
   # All calls to the Pub/Sub service use the same project and credentials

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -201,6 +201,30 @@ module Gcloud
   # resource_manager.undelete "tokyo-rain-123"
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
+  # See the [Resource Manager error
+  # messages](https://cloud.google.com/resource-manager/docs/core_errors)
+  # for a list of error conditions.
+  #
   # ## Managing IAM Policies
   #
   # Google Cloud Identity and Access Management ([Cloud

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -405,6 +405,30 @@ module Gcloud
   # file.acl.public!
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
+  # See the [Storage status and error
+  # codes](https://cloud.google.com/storage/docs/json_api/v1/status-codes)
+  # for a list of error conditions.
+  #
   module Storage
   end
 end

--- a/lib/gcloud/storage/bucket.rb
+++ b/lib/gcloud/storage/bucket.rb
@@ -326,11 +326,7 @@ module Gcloud
       # The bucket must be empty before it can be deleted.
       #
       # The API call to delete the bucket may be retried under certain
-      # conditions. See {Gcloud::Backoff} to control this behavior, or
-      # specify the wanted behavior using the `retries` option.
-      #
-      # @param [Integer] retries The number of times the API call should be
-      #   retried. Default is Gcloud::Backoff.retries.
+      # conditions. See {Gcloud::Backoff} to control this behavior.
       #
       # @return [Boolean] Returns `true` if the bucket was deleted.
       #
@@ -343,19 +339,9 @@ module Gcloud
       #   bucket = storage.bucket "my-bucket"
       #   bucket.delete
       #
-      # @example Specify the number of retries to attempt:
-      #   require "gcloud"
-      #
-      #   gcloud = Gcloud.new
-      #   storage = gcloud.storage
-      #
-      #   bucket = storage.bucket "my-bucket"
-      #   bucket.delete retries: 5
-      #
-      def delete retries: nil
+      def delete
         ensure_connection!
-        options = { retries: retries }
-        resp = connection.delete_bucket name, options
+        resp = connection.delete_bucket name
         if resp.success?
           true
         else

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -74,7 +74,7 @@ module Gcloud
                    predefinedDefaultObjectAcl: options[:default_acl]
                  }.delete_if { |_, v| v.nil? }
 
-        incremental_backoff options do
+        incremental_backoff do
           @client.execute(
             api_method: @storage.buckets.insert,
             parameters: params,
@@ -100,8 +100,8 @@ module Gcloud
 
       ##
       # Permanently deletes an empty bucket.
-      def delete_bucket bucket_name, opts = {}
-        incremental_backoff opts do
+      def delete_bucket bucket_name
+        incremental_backoff do
           @client.execute(
             api_method: @storage.buckets.delete,
             parameters: { bucket: bucket_name }
@@ -410,8 +410,8 @@ module Gcloud
         }.delete_if { |_, v| v.nil? }
       end
 
-      def incremental_backoff options = {}
-        Gcloud::Backoff.new(options).execute_gapi do
+      def incremental_backoff
+        Gcloud::Backoff.new.execute_gapi do
           yield
         end
       end

--- a/lib/gcloud/storage/connection.rb
+++ b/lib/gcloud/storage/connection.rb
@@ -52,7 +52,7 @@ module Gcloud
         params["pageToken"]  = options[:token]  if options[:token]
         params["maxResults"] = options[:max]    if options[:max]
 
-        @client.execute(
+        execute(
           api_method: @storage.buckets.list,
           parameters: params
         )
@@ -61,7 +61,7 @@ module Gcloud
       ##
       # Retrieves bucket by name.
       def get_bucket bucket_name
-        @client.execute(
+        execute(
           api_method: @storage.buckets.get,
           parameters: { bucket: bucket_name }
         )
@@ -74,13 +74,11 @@ module Gcloud
                    predefinedDefaultObjectAcl: options[:default_acl]
                  }.delete_if { |_, v| v.nil? }
 
-        incremental_backoff do
-          @client.execute(
-            api_method: @storage.buckets.insert,
-            parameters: params,
-            body_object: insert_bucket_request(bucket_name, options)
-          )
-        end
+        execute(
+          api_method: @storage.buckets.insert,
+          parameters: params,
+          body_object: insert_bucket_request(bucket_name, options)
+        )
       end
 
       ##
@@ -91,7 +89,7 @@ module Gcloud
                    predefinedDefaultObjectAcl: options[:predefined_default_acl]
                  }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @storage.buckets.patch,
           parameters: params,
           body_object: patch_bucket_request(options)
@@ -101,18 +99,16 @@ module Gcloud
       ##
       # Permanently deletes an empty bucket.
       def delete_bucket bucket_name
-        incremental_backoff do
-          @client.execute(
-            api_method: @storage.buckets.delete,
-            parameters: { bucket: bucket_name }
-          )
-        end
+        execute(
+          api_method: @storage.buckets.delete,
+          parameters: { bucket: bucket_name }
+        )
       end
 
       ##
       # Retrieves a list of ACLs for the given bucket.
       def list_bucket_acls bucket_name
-        @client.execute(
+        execute(
           api_method: @storage.bucket_access_controls.list,
           parameters: { bucket: bucket_name }
         )
@@ -121,7 +117,7 @@ module Gcloud
       ##
       # Creates a new bucket ACL.
       def insert_bucket_acl bucket_name, entity, role
-        @client.execute(
+        execute(
           api_method: @storage.bucket_access_controls.insert,
           parameters: { bucket: bucket_name },
           body_object: { entity: entity, role: role }
@@ -131,7 +127,7 @@ module Gcloud
       ##
       # Permanently deletes a bucket ACL.
       def delete_bucket_acl bucket_name, entity
-        @client.execute(
+        execute(
           api_method: @storage.bucket_access_controls.delete,
           parameters: { bucket: bucket_name, entity: entity }
         )
@@ -140,7 +136,7 @@ module Gcloud
       ##
       # Retrieves a list of default ACLs for the given bucket.
       def list_default_acls bucket_name
-        @client.execute(
+        execute(
           api_method: @storage.default_object_access_controls.list,
           parameters: { bucket: bucket_name }
         )
@@ -149,7 +145,7 @@ module Gcloud
       ##
       # Creates a new default ACL.
       def insert_default_acl bucket_name, entity, role
-        @client.execute(
+        execute(
           api_method: @storage.default_object_access_controls.insert,
           parameters: { bucket: bucket_name },
           body_object: { entity: entity, role: role }
@@ -159,7 +155,7 @@ module Gcloud
       ##
       # Permanently deletes a default ACL.
       def delete_default_acl bucket_name, entity
-        @client.execute(
+        execute(
           api_method: @storage.default_object_access_controls.delete,
           parameters: { bucket: bucket_name, entity: entity }
         )
@@ -177,7 +173,7 @@ module Gcloud
           versions:   options[:versions]
         }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @storage.objects.list,
           parameters: params
         )
@@ -198,7 +194,7 @@ module Gcloud
         result = insert_file resumable, bucket_name, upload_path, media, options
         return result unless resumable
         upload = result.resumable_upload
-        result = @client.execute upload while upload.resumable?
+        result = execute upload while upload.resumable?
         result
       end
 
@@ -208,7 +204,7 @@ module Gcloud
         query = { bucket: bucket_name, object: file_path }
         query[:generation] = options[:generation] if options[:generation]
 
-        @client.execute(
+        execute(
           api_method: @storage.objects.get,
           parameters: query
         )
@@ -218,7 +214,7 @@ module Gcloud
       # destination bucket/object.
       def copy_file source_bucket_name, source_file_path,
                     destination_bucket_name, destination_file_path, options = {}
-        @client.execute(
+        execute(
           api_method: @storage.objects.copy,
           parameters: { sourceBucket: source_bucket_name,
                         sourceObject: source_file_path,
@@ -232,7 +228,7 @@ module Gcloud
       ##
       # Download contents of a file.
       def download_file bucket_name, file_path
-        @client.execute(
+        execute(
           api_method: @storage.objects.get,
           parameters: { bucket: bucket_name,
                         object: file_path,
@@ -248,7 +244,7 @@ module Gcloud
                    predefinedAcl: options[:predefined_acl]
                  }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @storage.objects.patch,
           parameters: params,
           body_object: patch_file_request(options)
@@ -258,7 +254,7 @@ module Gcloud
       ##
       # Permanently deletes a file.
       def delete_file bucket_name, file_path
-        @client.execute(
+        execute(
           api_method: @storage.objects.delete,
           parameters: { bucket: bucket_name,
                         object: file_path }
@@ -268,7 +264,7 @@ module Gcloud
       ##
       # Retrieves a list of ACLs for the given file.
       def list_file_acls bucket_name, file_name
-        @client.execute(
+        execute(
           api_method: @storage.object_access_controls.list,
           parameters: { bucket: bucket_name, object: file_name }
         )
@@ -280,7 +276,7 @@ module Gcloud
         query = { bucket: bucket_name, object: file_name }
         query[:generation] = options[:generation] if options[:generation]
 
-        @client.execute(
+        execute(
           api_method: @storage.object_access_controls.insert,
           parameters: query,
           body_object: { entity: entity, role: role }
@@ -293,7 +289,7 @@ module Gcloud
         query = { bucket: bucket_name, object: file_name, entity: entity }
         query[:generation] = options[:generation] if options[:generation]
 
-        @client.execute(
+        execute(
           api_method: @storage.object_access_controls.delete,
           parameters: query
         )
@@ -374,10 +370,12 @@ module Gcloud
                    predefinedAcl: options[:acl]
         }.delete_if { |_, v| v.nil? }
 
-        @client.execute api_method: @storage.objects.insert,
-                        media: media,
-                        parameters: params,
-                        body_object: insert_file_request(options)
+        execute(
+          api_method: @storage.objects.insert,
+          media: media,
+          parameters: params,
+          body_object: insert_file_request(options)
+        )
       end
 
       def file_media local_path, options, resumable
@@ -410,9 +408,9 @@ module Gcloud
         }.delete_if { |_, v| v.nil? }
       end
 
-      def incremental_backoff
+      def execute options
         Gcloud::Backoff.new.execute_gapi do
-          yield
+          @client.execute options
         end
       end
     end

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -176,8 +176,7 @@ module Gcloud
       # bucket. See {Bucket::Cors} for details.
       #
       # The API call to create the bucket may be retried under certain
-      # conditions. See {Gcloud::Backoff} to control this behavior, or
-      # specify the wanted behavior in the call with the `:retries:` option.
+      # conditions. See {Gcloud::Backoff} to control this behavior.
       #
       # You can pass [website
       # settings](https://cloud.google.com/storage/docs/website-configuration)
@@ -241,8 +240,6 @@ module Gcloud
       #   . By default, the object prefix is the name of the bucket for which
       #   the logs are enabled. For more information, see [Access
       #   Logs](https://cloud.google.com/storage/docs/access-logs).
-      # @param [Integer] retries The number of times the API call should be
-      #   retried. Default is {Gcloud::Backoff.retries}.
       # @param [Symbol, String] storage_class Defines how objects in the bucket
       #   are stored and determines the SLA and the cost of storage. Values
       #   include `:standard`, `:nearline`, and `:dra` (Durable Reduced
@@ -276,14 +273,6 @@ module Gcloud
       #
       #   bucket = storage.create_bucket "my-bucket"
       #
-      # @example Specify the number of retries to attempt:
-      #   require "gcloud"
-      #
-      #   gcloud = Gcloud.new
-      #   storage = gcloud.storage
-      #
-      #   bucket = storage.create_bucket "my-bucket", retries: 5
-      #
       # @example Add CORS rules in a block:
       #   require "gcloud"
       #
@@ -303,13 +292,13 @@ module Gcloud
       #
       def create_bucket bucket_name, acl: nil, default_acl: nil, cors: nil,
                         location: nil, logging_bucket: nil, logging_prefix: nil,
-                        retries: nil, storage_class: nil, versioning: nil,
-                        website_main: nil, website_404: nil
+                        storage_class: nil, versioning: nil, website_main: nil,
+                        website_404: nil
         opts = { acl: acl_rule(acl), default_acl: acl_rule(default_acl),
                  cors: cors, location: location, logging_bucket: logging_bucket,
-                 logging_prefix: logging_prefix, retries: retries,
-                 storage_class: storage_class, versioning: versioning,
-                 website_main: website_main, website_404: website_404 }
+                 logging_prefix: logging_prefix, storage_class: storage_class,
+                 versioning: versioning, website_main: website_main,
+                 website_404: website_404 }
         if block_given?
           cors_builder = Bucket::Cors.new
           yield cors_builder

--- a/lib/gcloud/translate.rb
+++ b/lib/gcloud/translate.rb
@@ -231,6 +231,26 @@ module Gcloud
   # languages[0].name #=> "Afrikaans"
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
   module Translate
   end
 end

--- a/lib/gcloud/translate/connection.rb
+++ b/lib/gcloud/translate/connection.rb
@@ -14,6 +14,7 @@
 
 
 require "gcloud/version"
+require "gcloud/backoff"
 require "google/api_client"
 
 module Gcloud
@@ -45,14 +46,14 @@ module Gcloud
                    prettyprint: false
                  }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @translate.translations.list,
           parameters: params
         )
       end
 
       def detect text
-        @client.execute(
+        execute(
           api_method: @translate.detections.list,
           parameters: { q: Array(text), prettyprint: false }
         )
@@ -62,7 +63,7 @@ module Gcloud
         params = { target:      language,
                    prettyprint: false }.delete_if { |_, v| v.nil? }
 
-        @client.execute(
+        execute(
           api_method: @translate.languages.list,
           parameters: params
         )
@@ -70,6 +71,14 @@ module Gcloud
 
       def inspect
         "#{self.class}(#{@project})"
+      end
+
+      protected
+
+      def execute options
+        Gcloud::Backoff.new.execute_gapi do
+          @client.execute options
+        end
       end
     end
   end

--- a/lib/gcloud/vision.rb
+++ b/lib/gcloud/vision.rb
@@ -239,6 +239,26 @@ module Gcloud
   # annotation = vision.annotate image, faces: 5
   # ```
   #
+  # ## Configuring Backoff
+  #
+  # The {Gcloud::Backoff} class allows users to globally configure how Cloud API
+  # requests are automatically retried in the case of some errors, such as a
+  # `500` or `503` status code, or a specific internal error code such as
+  # `rateLimitExceeded`.
+  #
+  # If an API call fails, the response will be inspected to see if the call
+  # should be retried. If the response matches the criteria, then the request
+  # will be retried after a delay. If another error occurs, the delay will be
+  # increased incrementally before a subsequent attempt. The first retry will be
+  # delayed one second, the second retry two seconds, and so on.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "gcloud/backoff"
+  #
+  # Gcloud::Backoff.retries = 5 # Raise the maximum number of retries from 3
+  # ```
+  #
   module Vision
     class << self
       ##

--- a/lib/gcloud/vision/connection.rb
+++ b/lib/gcloud/vision/connection.rb
@@ -14,6 +14,7 @@
 
 
 require "gcloud/version"
+require "gcloud/backoff"
 require "google/api_client"
 
 module Gcloud
@@ -40,7 +41,7 @@ module Gcloud
       end
 
       def annotate requests
-        @client.execute(
+        execute(
           api_method: @vision.images.annotate,
           body_object: { requests: requests }
         )
@@ -48,6 +49,14 @@ module Gcloud
 
       def inspect
         "#{self.class}(#{@project})"
+      end
+
+      protected
+
+      def execute options
+        Gcloud::Backoff.new.execute_gapi do
+          @client.execute options
+        end
       end
     end
   end

--- a/test/gcloud/bigquery/backoff_test.rb
+++ b/test/gcloud/bigquery/backoff_test.rb
@@ -1,0 +1,58 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe "Gcloud Bigquery Backoff", :mock_bigquery do
+
+  it "lists datasets with backoff" do
+    num_datasets = 3
+    2.times do
+      mock_connection.get "/bigquery/v2/projects/#{project}/datasets" do |env|
+        [500, {"Content-Type"=>"application/json"}, nil]
+      end
+    end
+    mock_connection.get "/bigquery/v2/projects/#{project}/datasets" do |env|
+      [200, {"Content-Type"=>"application/json"},
+       list_datasets_json(num_datasets)]
+    end
+    assert_backoff_sleep 1, 2 do
+      datasets = bigquery.datasets
+      datasets.size.must_equal num_datasets
+      datasets.each { |ds| ds.must_be_kind_of Gcloud::Bigquery::Dataset }
+    end
+  end
+
+  def list_datasets_json count = 2, token = nil
+    datasets = count.times.map { random_dataset_small_hash }
+    hash = {"kind"=>"bigquery#datasetList", "datasets"=>datasets}
+    hash["nextPageToken"] = token unless token.nil?
+    hash.to_json
+  end
+
+  def assert_backoff_sleep *args
+    mock = Minitest::Mock.new
+    args.each { |intv| mock.expect :sleep, nil, [intv] }
+    callback = ->(retries) { mock.sleep retries }
+    backoff = Gcloud::Backoff.new backoff: callback
+
+    Gcloud::Backoff.stub :new, backoff do
+      yield
+    end
+
+    mock.verify
+  end
+end

--- a/test/gcloud/dns/backoff_test.rb
+++ b/test/gcloud/dns/backoff_test.rb
@@ -1,0 +1,62 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe "Gcloud Dns Backoff", :mock_dns do
+
+  it "lists zones with backoff" do
+    num_zones = 3
+    2.times do
+      mock_connection.get "/dns/v1/projects/#{project}/managedZones" do |env|
+        [500, {"Content-Type" => "application/json"}, nil]
+      end
+    end
+    mock_connection.get "/dns/v1/projects/#{project}/managedZones" do |env|
+      [200, {"Content-Type" => "application/json"},
+       list_zones_json(num_zones)]
+    end
+
+    assert_backoff_sleep 1, 2 do
+      zones = dns.zones
+      zones.size.must_equal num_zones
+      zones.each { |z| z.must_be_kind_of Gcloud::Dns::Zone }
+    end
+  end
+
+  def list_zones_json count = 2, token = nil
+    zones = count.times.map do
+      seed = rand 99999
+      random_zone_hash "example-#{seed}-zone", "example-#{seed}.com."
+    end
+    hash = { "kind" => "dns#managedZonesListResponse", "managedZones" => zones }
+    hash["nextPageToken"] = token unless token.nil?
+    hash.to_json
+  end
+
+  def assert_backoff_sleep *args
+    mock = Minitest::Mock.new
+    args.each { |intv| mock.expect :sleep, nil, [intv] }
+    callback = ->(retries) { mock.sleep retries }
+    backoff = Gcloud::Backoff.new backoff: callback
+
+    Gcloud::Backoff.stub :new, backoff do
+      yield
+    end
+
+    mock.verify
+  end
+end

--- a/test/gcloud/resource_manager/backoff_test.rb
+++ b/test/gcloud/resource_manager/backoff_test.rb
@@ -1,0 +1,63 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe "Gcloud ResourceManager Backoff", :mock_res_man do
+
+  it "lists projects with backoff" do
+    num_projects = 3
+    2.times do
+      mock_connection.get "/v1beta1/projects" do |env|
+        env.params.wont_include "maxResults"
+        env.params.wont_include "filter"
+        [500, {"Content-Type" => "application/json"}, nil]
+      end
+    end
+    mock_connection.get "/v1beta1/projects" do |env|
+      env.params.wont_include "maxResults"
+      env.params.wont_include "filter"
+      [200, {"Content-Type" => "application/json"},
+       list_projects_json(num_projects)]
+    end
+
+    assert_backoff_sleep 1, 2 do
+      projects = resource_manager.projects
+      projects.size.must_equal num_projects
+      projects.each { |z| z.must_be_kind_of Gcloud::ResourceManager::Project }
+    end
+  end
+
+  def list_projects_json count = 2, token = nil
+    projects = count.times.map { random_project_hash }
+    hash = { "projects" => projects }
+    hash["nextPageToken"] = token unless token.nil?
+    hash.to_json
+  end
+
+  def assert_backoff_sleep *args
+    mock = Minitest::Mock.new
+    args.each { |intv| mock.expect :sleep, nil, [intv] }
+    callback = ->(retries) { mock.sleep retries }
+    backoff = Gcloud::Backoff.new backoff: callback
+
+    Gcloud::Backoff.stub :new, backoff do
+      yield
+    end
+
+    mock.verify
+  end
+end

--- a/test/gcloud/translate/backoff_test.rb
+++ b/test/gcloud/translate/backoff_test.rb
@@ -1,0 +1,57 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe "Gcloud Translate Backoff", :mock_translate do
+
+  it "translates a single input with backoff" do
+    2.times do
+      mock_connection.get "/language/translate/v2" do |env|
+        env.params["key"].must_equal key
+        env.params["q"].must_equal   "Hello"
+        env.params["target"].must_equal "es"
+        [500, { "Content-Type" => "application/json" }, nil]
+      end
+    end
+    mock_connection.get "/language/translate/v2" do |env|
+      env.params["key"].must_equal key
+      env.params["q"].must_equal   "Hello"
+      env.params["target"].must_equal "es"
+      [200, { "Content-Type" => "application/json" },
+       translate_json("Hola", "en")]
+    end
+
+    assert_backoff_sleep 1, 2 do
+      translation = translate.translate "Hello", to: "es"
+      translation.text.must_equal "Hola"
+      translation.source.must_equal "en"
+    end
+  end
+
+  def assert_backoff_sleep *args
+    mock = Minitest::Mock.new
+    args.each { |intv| mock.expect :sleep, nil, [intv] }
+    callback = ->(retries) { mock.sleep retries }
+    backoff = Gcloud::Backoff.new backoff: callback
+
+    Gcloud::Backoff.stub :new, backoff do
+      yield
+    end
+
+    mock.verify
+  end
+end

--- a/test/gcloud/vision/backoff_test.rb
+++ b/test/gcloud/vision/backoff_test.rb
@@ -1,0 +1,69 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "json"
+require "uri"
+
+describe "Gcloud Vision Backoff", :mock_vision do
+  let(:filepath) { "acceptance/data/face.jpg" }
+
+  it "annotates an image with backoff" do
+    2.times do
+      mock_connection.post "/v1/images:annotate" do |env|
+        requests = JSON.parse(env.body)["requests"]
+        requests.count.must_equal 1
+        requests.first["features"].count.must_equal 1
+        requests.first["features"].first["type"].must_equal "FACE_DETECTION"
+        requests.first["features"].first["maxResults"].must_equal 10
+        [500, {"Content-Type" => "application/json"}, nil]
+      end
+    end
+    mock_connection.post "/v1/images:annotate" do |env|
+      requests = JSON.parse(env.body)["requests"]
+      requests.count.must_equal 1
+      requests.first["features"].count.must_equal 1
+      requests.first["features"].first["type"].must_equal "FACE_DETECTION"
+      requests.first["features"].first["maxResults"].must_equal 10
+      [200, {"Content-Type" => "application/json"},
+       faces_response_json]
+    end
+
+    assert_backoff_sleep 1, 2 do
+      annotation = vision.annotate filepath, faces: 10
+      annotation.face.wont_be :nil?
+    end
+  end
+
+  def faces_response_json
+    {
+      responses: [{
+        faceAnnotations: [face_annotation_response]
+      }]
+    }.to_json
+  end
+
+  def assert_backoff_sleep *args
+    mock = Minitest::Mock.new
+    args.each { |intv| mock.expect :sleep, nil, [intv] }
+    callback = ->(retries) { mock.sleep retries }
+    backoff = Gcloud::Backoff.new backoff: callback
+
+    Gcloud::Backoff.stub :new, backoff do
+      yield
+    end
+
+    mock.verify
+  end
+end


### PR DESCRIPTION
Since we apply backoff to all gRPC requests, and also because a lack of backoff retry logic has been raised as an issue with Storage (#714), apply this behavior to all google-api-client requests.

This PR also introduces a breaking change by removing the `retries` option from Storage `Project#create_bucket` and `Bucket#delete`. The number of retries should now be configured directly on `Backoff`.

[closes #714]