### PR TITLE
Update Pub/Sub publish

### DIFF
--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -235,7 +235,7 @@ module Gcloud
       # without a subscription will be lost.
       #
       # @param [String] topic_name Name of a topic.
-      # @param [String] data The message data.
+      # @param [String, File] data The message data.
       # @param [Hash] attributes Optional attributes for the message.
       # @option attributes [Boolean] :autocreate Flag to control whether the
       #   provided topic will be created if it does not exist.
@@ -253,6 +253,14 @@ module Gcloud
       #   pubsub = gcloud.pubsub
       #
       #   msg = pubsub.publish "my-topic", "new-message"
+      #
+      # @example A message can be published using a File object:
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
+      #
+      #   msg = pubsub.publish "my-topic", File.open("message.txt")
       #
       # @example Additionally, a message can be published with attributes:
       #   require "gcloud"

--- a/lib/gcloud/pubsub/service.rb
+++ b/lib/gcloud/pubsub/service.rb
@@ -122,9 +122,7 @@ module Gcloud
           topic: topic_path(topic),
           messages: messages.map do |data, attributes|
             Google::Pubsub::V1::PubsubMessage.new(
-              data: String(data).encode("ASCII-8BIT"),
-              attributes: attributes
-            )
+              data: data, attributes: attributes)
           end
         )
 

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -248,7 +248,7 @@ module Gcloud
       ##
       # Publishes one or more messages to the topic.
       #
-      # @param [String] data The message data.
+      # @param [String, File] data The message data.
       # @param [Hash] attributes Optional attributes for the message.
       # @yield [batch] a block for publishing multiple messages in one request
       # @yieldparam [Topic::Batch] batch the batch object
@@ -265,6 +265,15 @@ module Gcloud
       #
       #   topic = pubsub.topic "my-topic"
       #   msg = topic.publish "new-message"
+      #
+      # @example A message can be published using a File object:
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   msg = topic.publish File.open("message.txt")
       #
       # @example Additionally, a message can be published with attributes:
       #   require "gcloud"

--- a/lib/gcloud/pubsub/topic/batch.rb
+++ b/lib/gcloud/pubsub/topic/batch.rb
@@ -38,6 +38,11 @@ module Gcloud
         # All messages added will be published at once.
         # See {Gcloud::Pubsub::Topic#publish}
         def publish data, attributes = {}
+          # Convert IO-ish objects to strings
+          if data.respond_to?(:read) && data.respond_to?(:rewind)
+            data.rewind
+            data = data.read
+          end
           # Convert data to encoded byte array to match the protobuf definition
           data = String(data).force_encoding("ASCII-8BIT")
           # Convert attributes to strings to match the protobuf definition

--- a/lib/gcloud/pubsub/topic/batch.rb
+++ b/lib/gcloud/pubsub/topic/batch.rb
@@ -38,6 +38,8 @@ module Gcloud
         # All messages added will be published at once.
         # See {Gcloud::Pubsub::Topic#publish}
         def publish data, attributes = {}
+          # Convert data to encoded byte array to match the protobuf definition
+          data = String(data).force_encoding("ASCII-8BIT")
           # Convert attributes to strings to match the protobuf definition
           attributes = Hash[attributes.map { |k, v| [String(k), String(v)] }]
           @messages << [data, attributes]
@@ -47,10 +49,9 @@ module Gcloud
         # @private Create Message objects with message ids.
         def to_gcloud_messages message_ids
           msgs = @messages.zip(Array(message_ids)).map do |arr, id|
-            Message.from_grpc(Google::Pubsub::V1::PubsubMessage.new(
-                                data: String(arr[0]).encode("ASCII-8BIT"),
-                                attributes: arr[1],
-                                message_id: id))
+            Message.from_grpc(
+              Google::Pubsub::V1::PubsubMessage.new(
+                data: arr[0], attributes: arr[1], message_id: id))
           end
           # Return just one Message if a single publish,
           # otherwise return the array of Messages.

--- a/test/gcloud/pubsub/topic/publish_test.rb
+++ b/test/gcloud/pubsub/topic/publish_test.rb
@@ -66,6 +66,33 @@ describe Gcloud::Pubsub::Topic, :publish, :mock_pubsub do
     msg.message_id.must_equal "msg1"
   end
 
+  it "publishes a message using an IO-ish object" do
+    publish_req = Google::Pubsub::V1::PublishRequest.new(
+      topic: topic_path(topic_name),
+      messages: [
+        Google::Pubsub::V1::PubsubMessage.new(data: "\xE3\x81\x82".force_encoding("ASCII-8BIT"))
+      ]
+    )
+    publish_res = Google::Pubsub::V1::PublishResponse.decode_json({ message_ids: ["msg1"] }.to_json)
+    mock = Minitest::Mock.new
+    mock.expect :publish, publish_res, [publish_req]
+    topic.service.mocked_publisher = mock
+
+    msg = nil
+    Tempfile.open ["message", "txt"] do |tmpfile|
+      tmpfile.binmode
+      tmpfile.write "あ"
+      tmpfile.rewind
+
+      msg = topic.publish tmpfile
+    end
+    mock.verify
+
+    msg.must_be_kind_of Gcloud::Pubsub::Message
+    msg.data.must_equal "\xE3\x81\x82".force_encoding("ASCII-8BIT")
+    msg.message_id.must_equal "msg1"
+  end
+
   it "publishes a message with attributes" do
     publish_req = Google::Pubsub::V1::PublishRequest.new(
       topic: topic_path(topic_name),


### PR DESCRIPTION
A couple of changes to Pub/Sub. The first addresses a bug when publishing multi-byte strings. The second is an enhancement allowing users to publish message data using an IO-ish object like File, StringIO, Tempfile, etc.