### PR TITLE
Vision Updates

### DIFF
--- a/lib/gcloud/vision/image.rb
+++ b/lib/gcloud/vision/image.rb
@@ -371,7 +371,7 @@ module Gcloud
       ##
       # @private New Image from a source object.
       def self.from_source source, vision = nil
-        if source.is_a?(IO) || source.is_a?(StringIO)
+        if source.respond_to?(:read) && source.respond_to?(:rewind)
           return from_io(source, vision)
         end
         # Convert Storage::File objects to the URL
@@ -393,8 +393,7 @@ module Gcloud
       ##
       # @private New Image from an IO object.
       def self.from_io io, vision
-        if !io.is_a?(IO) && !io.is_a?(StringIO)
-          puts io.inspect
+        if !io.respond_to?(:read) && !io.respond_to?(:rewind)
           fail ArgumentError, "Cannot create an Image without an IO object"
         end
         new.tap do |i|

--- a/test/gcloud/vision/image/faces_test.rb
+++ b/test/gcloud/vision/image/faces_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Vision::Image, :faces, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       face = requests.first
-      face["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      face["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       face["features"].count.must_equal 1
       face["features"].first["type"].must_equal "FACE_DETECTION"
       face["features"].first["maxResults"].must_equal 10
@@ -41,7 +41,7 @@ describe Gcloud::Vision::Image, :faces, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       face = requests.first
-      face["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      face["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       face["features"].count.must_equal 1
       face["features"].first["type"].must_equal "FACE_DETECTION"
       face["features"].first["maxResults"].must_equal 100
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Image, :faces, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       face = requests.first
-      face["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      face["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       face["features"].count.must_equal 1
       face["features"].first["type"].must_equal "FACE_DETECTION"
       face["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/image/labels_test.rb
+++ b/test/gcloud/vision/image/labels_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Vision::Image, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal 10
@@ -41,7 +41,7 @@ describe Gcloud::Vision::Image, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal 100
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Image, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/image/landmarks_test.rb
+++ b/test/gcloud/vision/image/landmarks_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Vision::Image, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal 10
@@ -41,7 +41,7 @@ describe Gcloud::Vision::Image, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal 100
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Image, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/image/logos_test.rb
+++ b/test/gcloud/vision/image/logos_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Vision::Image, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal 10
@@ -41,7 +41,7 @@ describe Gcloud::Vision::Image, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal 100
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Image, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/image/properties_test.rb
+++ b/test/gcloud/vision/image/properties_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Vision::Image, :properties, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       properties = requests.first
-      properties["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      properties["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       properties["features"].count.must_equal 1
       properties["features"].first["type"].must_equal "IMAGE_PROPERTIES"
       properties["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/image/safe_search_test.rb
+++ b/test/gcloud/vision/image/safe_search_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Vision::Image, :safe_search, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       safe_search = requests.first
-      safe_search["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      safe_search["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       safe_search["features"].count.must_equal 1
       safe_search["features"].first["type"].must_equal "SAFE_SEARCH_DETECTION"
       safe_search["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/image/text_test.rb
+++ b/test/gcloud/vision/image/text_test.rb
@@ -24,7 +24,7 @@ describe Gcloud::Vision::Image, :text, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       text = requests.first
-      text["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      text["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       text["features"].count.must_equal 1
       text["features"].first["type"].must_equal "TEXT_DETECTION"
       text["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/image_test.rb
+++ b/test/gcloud/vision/image_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Image, :mock_vision do
     image = vision.image filepath
 
     image.must_be_kind_of Gcloud::Vision::Image
-    image.must_be :content?
+    image.must_be :io?
     image.wont_be :url?
   end
 
@@ -30,7 +30,7 @@ describe Gcloud::Vision::Image, :mock_vision do
     image = vision.image Pathname.new(filepath)
 
     image.must_be_kind_of Gcloud::Vision::Image
-    image.must_be :content?
+    image.must_be :io?
     image.wont_be :url?
   end
 
@@ -38,7 +38,7 @@ describe Gcloud::Vision::Image, :mock_vision do
     image = vision.image File.open(filepath, "rb")
 
     image.must_be_kind_of Gcloud::Vision::Image
-    image.must_be :content?
+    image.must_be :io?
     image.wont_be :url?
   end
 
@@ -46,7 +46,7 @@ describe Gcloud::Vision::Image, :mock_vision do
     image = vision.image StringIO.new(File.read(filepath, mode: "rb"))
 
     image.must_be_kind_of Gcloud::Vision::Image
-    image.must_be :content?
+    image.must_be :io?
     image.wont_be :url?
   end
 
@@ -60,7 +60,7 @@ describe Gcloud::Vision::Image, :mock_vision do
     end
 
     image.must_be_kind_of Gcloud::Vision::Image
-    image.must_be :content?
+    image.must_be :io?
     image.wont_be :url?
   end
 
@@ -68,7 +68,7 @@ describe Gcloud::Vision::Image, :mock_vision do
     image = vision.image "gs://test/file.ext"
 
     image.must_be_kind_of Gcloud::Vision::Image
-    image.wont_be :content?
+    image.wont_be :io?
     image.must_be :url?
   end
 
@@ -77,7 +77,7 @@ describe Gcloud::Vision::Image, :mock_vision do
     image = vision.image gs_img
 
     image.must_be_kind_of Gcloud::Vision::Image
-    image.wont_be :content?
+    image.wont_be :io?
     image.must_be :url?
   end
 

--- a/test/gcloud/vision/image_test.rb
+++ b/test/gcloud/vision/image_test.rb
@@ -50,6 +50,20 @@ describe Gcloud::Vision::Image, :mock_vision do
     image.wont_be :url?
   end
 
+  it "can create from a Tempfile object" do
+    image = nil
+    Tempfile.open ["image", "png"] do |tmpfile|
+      tmpfile.binmode
+      tmpfile.write File.read(filepath, mode: "rb")
+
+      image = vision.image tmpfile
+    end
+
+    image.must_be_kind_of Gcloud::Vision::Image
+    image.must_be :content?
+    image.wont_be :url?
+  end
+
   it "can create from a Google Storage URL" do
     image = vision.image "gs://test/file.ext"
 

--- a/test/gcloud/vision/project/annotate_faces_test.rb
+++ b/test/gcloud/vision/project/annotate_faces_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Project, :annotate, :faces, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       face = requests.first
-      face["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      face["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       face["features"].count.must_equal 1
       face["features"].first["type"].must_equal "FACE_DETECTION"
       face["features"].first["maxResults"].must_equal 1
@@ -40,7 +40,7 @@ describe Gcloud::Vision::Project, :annotate, :faces, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       face = requests.first
-      face["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      face["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       face["features"].count.must_equal 1
       face["features"].first["type"].must_equal "FACE_DETECTION"
       face["features"].first["maxResults"].must_equal 1
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Project, :annotate, :faces, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       face = requests.first
-      face["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      face["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       face["features"].count.must_equal 1
       face["features"].first["type"].must_equal "FACE_DETECTION"
       face["features"].first["maxResults"].must_equal 1
@@ -75,11 +75,11 @@ describe Gcloud::Vision::Project, :annotate, :faces, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 1
       requests.first["features"].first["type"].must_equal "FACE_DETECTION"
       requests.first["features"].first["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "FACE_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 1
@@ -97,7 +97,7 @@ describe Gcloud::Vision::Project, :annotate, :faces, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "FACE_DETECTION"
       requests.last["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_faces
@@ -113,7 +113,7 @@ describe Gcloud::Vision::Project, :annotate, :faces, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "FACE_DETECTION"
       requests.last["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_faces
@@ -129,7 +129,7 @@ describe Gcloud::Vision::Project, :annotate, :faces, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "FACE_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 25

--- a/test/gcloud/vision/project/annotate_labels_test.rb
+++ b/test/gcloud/vision/project/annotate_labels_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Project, :annotate, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal 1
@@ -40,7 +40,7 @@ describe Gcloud::Vision::Project, :annotate, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal 1
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Project, :annotate, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal 1
@@ -75,11 +75,11 @@ describe Gcloud::Vision::Project, :annotate, :labels, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 1
       requests.first["features"].first["type"].must_equal "LABEL_DETECTION"
       requests.first["features"].first["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "LABEL_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 1
@@ -98,7 +98,7 @@ describe Gcloud::Vision::Project, :annotate, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_labels
@@ -116,7 +116,7 @@ describe Gcloud::Vision::Project, :annotate, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_labels
@@ -134,7 +134,7 @@ describe Gcloud::Vision::Project, :annotate, :labels, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       label = requests.first
-      label["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      label["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       label["features"].count.must_equal 1
       label["features"].first["type"].must_equal "LABEL_DETECTION"
       label["features"].first["maxResults"].must_equal 25

--- a/test/gcloud/vision/project/annotate_landmarks_test.rb
+++ b/test/gcloud/vision/project/annotate_landmarks_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal 1
@@ -40,7 +40,7 @@ describe Gcloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal 1
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal 1
@@ -75,11 +75,11 @@ describe Gcloud::Vision::Project, :annotate, :landmarks, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 1
       requests.first["features"].first["type"].must_equal "LANDMARK_DETECTION"
       requests.first["features"].first["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "LANDMARK_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 1
@@ -98,7 +98,7 @@ describe Gcloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_landmarks
@@ -116,7 +116,7 @@ describe Gcloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_landmarks
@@ -134,7 +134,7 @@ describe Gcloud::Vision::Project, :annotate, :landmarks, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       landmark = requests.first
-      landmark["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      landmark["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       landmark["features"].count.must_equal 1
       landmark["features"].first["type"].must_equal "LANDMARK_DETECTION"
       landmark["features"].first["maxResults"].must_equal 25

--- a/test/gcloud/vision/project/annotate_logos_test.rb
+++ b/test/gcloud/vision/project/annotate_logos_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Project, :annotate, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal 1
@@ -40,7 +40,7 @@ describe Gcloud::Vision::Project, :annotate, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal 1
@@ -58,7 +58,7 @@ describe Gcloud::Vision::Project, :annotate, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal 1
@@ -75,11 +75,11 @@ describe Gcloud::Vision::Project, :annotate, :logos, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 1
       requests.first["features"].first["type"].must_equal "LOGO_DETECTION"
       requests.first["features"].first["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "LOGO_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 1
@@ -98,7 +98,7 @@ describe Gcloud::Vision::Project, :annotate, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_logos
@@ -116,7 +116,7 @@ describe Gcloud::Vision::Project, :annotate, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal Gcloud::Vision.default_max_logos
@@ -134,7 +134,7 @@ describe Gcloud::Vision::Project, :annotate, :logos, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       logo = requests.first
-      logo["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      logo["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       logo["features"].count.must_equal 1
       logo["features"].first["type"].must_equal "LOGO_DETECTION"
       logo["features"].first["maxResults"].must_equal 25

--- a/test/gcloud/vision/project/annotate_properties_test.rb
+++ b/test/gcloud/vision/project/annotate_properties_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Project, :annotate, :properties, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       properties = requests.first
-      properties["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      properties["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       properties["features"].count.must_equal 1
       properties["features"].first["type"].must_equal "IMAGE_PROPERTIES"
       properties["features"].first["maxResults"].must_equal 1
@@ -57,7 +57,7 @@ describe Gcloud::Vision::Project, :annotate, :properties, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       properties = requests.first
-      properties["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      properties["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       properties["features"].count.must_equal 1
       properties["features"].first["type"].must_equal "IMAGE_PROPERTIES"
       properties["features"].first["maxResults"].must_equal 1
@@ -92,7 +92,7 @@ describe Gcloud::Vision::Project, :annotate, :properties, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       properties = requests.first
-      properties["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      properties["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       properties["features"].count.must_equal 1
       properties["features"].first["type"].must_equal "IMAGE_PROPERTIES"
       properties["features"].first["maxResults"].must_equal 1
@@ -126,11 +126,11 @@ describe Gcloud::Vision::Project, :annotate, :properties, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 1
       requests.first["features"].first["type"].must_equal "IMAGE_PROPERTIES"
       requests.first["features"].first["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "IMAGE_PROPERTIES"
       requests.last["features"].first["maxResults"].must_equal 1
@@ -183,7 +183,7 @@ describe Gcloud::Vision::Project, :annotate, :properties, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       properties = requests.first
-      properties["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      properties["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       properties["features"].count.must_equal 1
       properties["features"].first["type"].must_equal "IMAGE_PROPERTIES"
       properties["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/project/annotate_safe_search_test.rb
+++ b/test/gcloud/vision/project/annotate_safe_search_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Project, :annotate, :safe_search, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       safe_search = requests.first
-      safe_search["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      safe_search["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       safe_search["features"].count.must_equal 1
       safe_search["features"].first["type"].must_equal "SAFE_SEARCH_DETECTION"
       safe_search["features"].first["maxResults"].must_equal 1
@@ -45,7 +45,7 @@ describe Gcloud::Vision::Project, :annotate, :safe_search, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       safe_search = requests.first
-      safe_search["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      safe_search["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       safe_search["features"].count.must_equal 1
       safe_search["features"].first["type"].must_equal "SAFE_SEARCH_DETECTION"
       safe_search["features"].first["maxResults"].must_equal 1
@@ -68,7 +68,7 @@ describe Gcloud::Vision::Project, :annotate, :safe_search, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       safe_search = requests.first
-      safe_search["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      safe_search["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       safe_search["features"].count.must_equal 1
       safe_search["features"].first["type"].must_equal "SAFE_SEARCH_DETECTION"
       safe_search["features"].first["maxResults"].must_equal 1
@@ -90,11 +90,11 @@ describe Gcloud::Vision::Project, :annotate, :safe_search, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 1
       requests.first["features"].first["type"].must_equal "SAFE_SEARCH_DETECTION"
       requests.first["features"].first["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "SAFE_SEARCH_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 1
@@ -123,7 +123,7 @@ describe Gcloud::Vision::Project, :annotate, :safe_search, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       safe_search = requests.first
-      safe_search["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      safe_search["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       safe_search["features"].count.must_equal 1
       safe_search["features"].first["type"].must_equal "SAFE_SEARCH_DETECTION"
       safe_search["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/project/annotate_text_test.rb
+++ b/test/gcloud/vision/project/annotate_text_test.rb
@@ -22,7 +22,7 @@ describe Gcloud::Vision::Project, :annotate, :text, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       text = requests.first
-      text["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      text["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       text["features"].count.must_equal 1
       text["features"].first["type"].must_equal "TEXT_DETECTION"
       text["features"].first["maxResults"].must_equal 1
@@ -47,7 +47,7 @@ describe Gcloud::Vision::Project, :annotate, :text, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       text = requests.first
-      text["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      text["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       text["features"].count.must_equal 1
       text["features"].first["type"].must_equal "TEXT_DETECTION"
       text["features"].first["maxResults"].must_equal 1
@@ -65,7 +65,7 @@ describe Gcloud::Vision::Project, :annotate, :text, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       text = requests.first
-      text["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      text["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       text["features"].count.must_equal 1
       text["features"].first["type"].must_equal "TEXT_DETECTION"
       text["features"].first["maxResults"].must_equal 1
@@ -82,11 +82,11 @@ describe Gcloud::Vision::Project, :annotate, :text, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 1
       requests.first["features"].first["type"].must_equal "TEXT_DETECTION"
       requests.first["features"].first["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 1
       requests.last["features"].first["type"].must_equal "TEXT_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 1
@@ -105,7 +105,7 @@ describe Gcloud::Vision::Project, :annotate, :text, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       text = requests.first
-      text["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      text["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       text["features"].count.must_equal 1
       text["features"].first["type"].must_equal "TEXT_DETECTION"
       text["features"].first["maxResults"].must_equal 1

--- a/test/gcloud/vision/project_test.rb
+++ b/test/gcloud/vision/project_test.rb
@@ -29,7 +29,7 @@ describe Gcloud::Vision::Project, :mock_vision do
 
     image.wont_be :nil?
     image.must_be_kind_of Gcloud::Vision::Image
-    image.must_be :content?
+    image.must_be :io?
     image.wont_be :url?
   end
 
@@ -37,13 +37,13 @@ describe Gcloud::Vision::Project, :mock_vision do
     mock_connection.post "/v1/images:annotate" do |env|
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 2
-      requests.first["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.first["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.first["features"].count.must_equal 2
       requests.first["features"].first["type"].must_equal "FACE_DETECTION"
       requests.first["features"].first["maxResults"].must_equal 10
       requests.first["features"].last["type"].must_equal "TEXT_DETECTION"
       requests.first["features"].last["maxResults"].must_equal 1
-      requests.last["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      requests.last["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       requests.last["features"].count.must_equal 2
       requests.last["features"].first["type"].must_equal "LANDMARK_DETECTION"
       requests.last["features"].first["maxResults"].must_equal 20
@@ -67,7 +67,7 @@ describe Gcloud::Vision::Project, :mock_vision do
       requests = JSON.parse(env.body)["requests"]
       requests.count.must_equal 1
       request = requests.first
-      request["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+      request["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
       request["features"].count.must_equal 7
       request["features"][0]["type"].must_equal "FACE_DETECTION"
       request["features"][0]["maxResults"].must_equal 100
@@ -136,7 +136,7 @@ describe Gcloud::Vision::Project, :mock_vision do
         requests = JSON.parse(env.body)["requests"]
         requests.count.must_equal 1
         request = requests.first
-        request["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+        request["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
         request["features"].count.must_equal 2
         request["features"].first["type"].must_equal "FACE_DETECTION"
         request["features"].first["maxResults"].must_equal 10
@@ -158,7 +158,7 @@ describe Gcloud::Vision::Project, :mock_vision do
         requests = JSON.parse(env.body)["requests"]
         requests.count.must_equal 1
         request = requests.first
-        request["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+        request["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
         request["features"].count.must_equal 2
         request["features"].first["type"].must_equal "FACE_DETECTION"
         request["features"].first["maxResults"].must_equal 10
@@ -181,7 +181,7 @@ describe Gcloud::Vision::Project, :mock_vision do
         requests = JSON.parse(env.body)["requests"]
         requests.count.must_equal 1
         request = requests.first
-        request["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+        request["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
         request["features"].count.must_equal 2
         request["features"].first["type"].must_equal "FACE_DETECTION"
         request["features"].first["maxResults"].must_equal 10
@@ -210,7 +210,7 @@ describe Gcloud::Vision::Project, :mock_vision do
         requests = JSON.parse(env.body)["requests"]
         requests.count.must_equal 1
         request = requests.first
-        request["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+        request["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
         request["features"].count.must_equal 2
         request["features"].first["type"].must_equal "FACE_DETECTION"
         request["features"].first["maxResults"].must_equal 10
@@ -237,7 +237,7 @@ describe Gcloud::Vision::Project, :mock_vision do
         requests = JSON.parse(env.body)["requests"]
         requests.count.must_equal 1
         request = requests.first
-        request["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+        request["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
         request["features"].count.must_equal 2
         request["features"].first["type"].must_equal "FACE_DETECTION"
         request["features"].first["maxResults"].must_equal 10
@@ -263,7 +263,7 @@ describe Gcloud::Vision::Project, :mock_vision do
         requests = JSON.parse(env.body)["requests"]
         requests.count.must_equal 1
         request = requests.first
-        request["image"]["content"].must_equal Base64.encode64(File.read(filepath, mode: "rb"))
+        request["image"]["content"].must_equal Base64.strict_encode64(File.read(filepath, mode: "rb"))
         request["features"].count.must_equal 2
         request["features"].first["type"].must_equal "FACE_DETECTION"
         request["features"].first["maxResults"].must_equal 10


### PR DESCRIPTION
Small correction to allow Vision to use Tempfiles. Brings Vision inline with how gcloud treats IO-ish objects in the other services.

Another small correction to avoid reading IO contents into memory.