### PR TITLE
Add Datastore serialized_size

### DIFF
--- a/lib/gcloud/datastore/entity.rb
+++ b/lib/gcloud/datastore/entity.rb
@@ -351,6 +351,12 @@ module Gcloud
       end
 
       ##
+      # The number of bytes the Entity will take to serialize during API calls.
+      def serialized_size
+        to_grpc.to_proto.length
+      end
+
+      ##
       # @private Convert the Entity to a Google::Datastore::V1beta3::Entity
       # object.
       def to_grpc

--- a/lib/gcloud/datastore/key.rb
+++ b/lib/gcloud/datastore/key.rb
@@ -233,6 +233,12 @@ module Gcloud
       end
 
       ##
+      # The number of bytes the Key will take to serialize during API calls.
+      def serialized_size
+        to_grpc.to_proto.length
+      end
+
+      ##
       # @private Convert the Key to a Google::Datastore::V1beta3::Key object.
       def to_grpc
         grpc_path = path.map do |pe_kind, pe_id_or_name|

--- a/test/gcloud/datastore/entity_test.rb
+++ b/test/gcloud/datastore/entity_test.rb
@@ -149,4 +149,9 @@ describe Gcloud::Datastore::Entity do
       entity_from_grpc.key.id = 456789
     end
   end
+
+  it "knows its serialized side" do
+    # Don't care about the exact value, just want a number and no error
+    entity.serialized_size.must_be_kind_of Integer
+  end
 end

--- a/test/gcloud/datastore/key_test.rb
+++ b/test/gcloud/datastore/key_test.rb
@@ -200,4 +200,10 @@ describe Gcloud::Datastore::Key do
     key.namespace.must_equal "custom-ns"
     key.must_be :frozen?
   end
+
+  it "knows its serialized side" do
+    # Don't care about the exact value, just want a number and no error
+    key = Gcloud::Datastore::Key.new "ThisThing", 1234
+    key.serialized_size.must_be_kind_of Integer
+  end
 end


### PR DESCRIPTION
Add the method `serialized_size` to give the number of bytes the Entity or Key take when being serialized during API calls. (See #687)