### PR TITLE
Add customer-supplied encryption keys to Storage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Metrics/PerceivedComplexity:
 Metrics/AbcSize:
   Max: 25
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
 Metrics/ParameterLists:
   Enabled: false
 Style/RescueModifier:

--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      "autotest-suffix", "~> 1.1"
   gem.add_development_dependency      "rdoc", "~> 4.0"
   gem.add_development_dependency      "rubocop", "<= 0.35.1"
+  gem.add_development_dependency      "parser", "<= 2.3.0.2" # rubocop dependency
   gem.add_development_dependency      "httpclient", "~> 2.5"
   gem.add_development_dependency      "simplecov", "~> 0.9"
   gem.add_development_dependency      "coveralls", "~> 0.7"

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -240,6 +240,45 @@ module Gcloud
   #                    "avatars/heidi/400x400.png"
   # ```
   #
+  # ### Customer-supplied encryption keys
+  #
+  # By default, Google Cloud Storage manages server-side encryption keys on
+  # your behalf. However, a [customer-supplied encryption
+  # key](https://cloud.google.com/storage/docs/encryption#customer-supplied)
+  # can be provided with the `encryption_key` and `encryption_key_sha256`
+  # options. If given, the same key and SHA256 hash also must be provided to
+  # subsequently download or copy the file. If you use customer-supplied
+  # encryption keys, you must securely manage your keys and ensure that they are
+  # not lost. Also, please note that file metadata is not encrypted, with the
+  # exception of the CRC32C checksum and MD5 hash. The names of files and
+  # buckets are also not encrypted, and you can read or update the metadata of
+  # an encrypted file without providing the encryption key.
+  #
+  # ```ruby
+  # require "gcloud"
+  # require "digest/sha2"
+  #
+  # gcloud = Gcloud.new
+  # storage = gcloud.storage
+  # bucket = storage.bucket "my-todo-app"
+  #
+  # # Key generation shown for example purposes only. Write your own.
+  # cipher = OpenSSL::Cipher.new "aes-256-cfb"
+  # cipher.encrypt
+  # key = cipher.random_key
+  # key_hash = Digest::SHA256.digest key
+  #
+  # bucket.create_file "/var/todo-app/avatars/heidi/400x400.png",
+  #                    "avatars/heidi/400x400.png",
+  #                    encryption_key: key,
+  #                    encryption_key_sha256: key_hash
+  #
+  # # Store your key and hash securely for later use.
+  # file = bucket.file "avatars/heidi/400x400.png",
+  #                    encryption_key: key,
+  #                    encryption_key_sha256: key_hash
+  # ```
+  #
   # ### A note about large uploads
   #
   # You may encounter a Broken pipe (Errno::EPIPE) error when attempting to

--- a/lib/gcloud/storage/errors.rb
+++ b/lib/gcloud/storage/errors.rb
@@ -45,9 +45,15 @@ module Gcloud
 
       # @private
       def self.from_response resp
-        new resp.data["error"]["message"],
-            resp.data["error"]["code"],
-            resp.data["error"]["errors"]
+        if resp.data && resp.data["error"]
+          new resp.data["error"]["message"],
+              resp.data["error"]["code"],
+              resp.data["error"]["errors"]
+        else
+          new resp.error_message,
+              resp.status,
+              nil
+        end
       end
     end
 


### PR DESCRIPTION
This implementation does not address a known issue in which the
service returns 411 when request sent with httpclient.

[closes #722]