### PR TITLE
Merge Pub/Sub Policy support from IAM topic branch

### DIFF
--- a/lib/gcloud/pubsub/policy.rb
+++ b/lib/gcloud/pubsub/policy.rb
@@ -1,0 +1,101 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "gcloud/errors"
+
+module Gcloud
+  module Pubsub
+    ##
+    # # Policy
+    #
+    # Represents a Cloud IAM Policy for the Pub/Sub service.
+    #
+    # A common pattern for updating a resource's metadata, such as its Policy,
+    # is to read the current data from the service, update the data locally, and
+    # then send the modified data for writing. This pattern may result in a
+    # conflict if two or more processes attempt the sequence simultaneously. IAM
+    # solves this problem with the {Gcloud::Pubsub::Policy#etag} property, which
+    # is used to verify whether the policy has changed since the last request.
+    # When you make a request to with an `etag` value, Cloud IAM compares the
+    # `etag` value in the request with the existing `etag` value associated with
+    # the policy. It writes the policy only if the `etag` values match.
+    #
+    # When you update a policy, first read the policy (and its current `etag`)
+    # from the service, then modify the policy locally, and then write the
+    # modified policy to the service. See {Gcloud::Pubsub::Topic#policy} and
+    # {Gcloud::Pubsub::Topic#policy=}.
+    #
+    # @see https://cloud.google.com/iam/docs/managing-policies Managing policies
+    # @see https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#iampolicy
+    #   google.iam.v1.IAMPolicy
+    #
+    # @attr [String] etag Used to verify whether the policy has changed since
+    #   the last request. The policy will be written only if the `etag` values
+    #   match.
+    # @attr [Hash{String => Array<String>}] roles The bindings that associate
+    #   roles with an array of members. See
+    #   [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
+    #   for a listing of values and patterns for members.
+    #
+    # @example
+    #   require "gcloud"
+    #
+    #   gcloud = Gcloud.new
+    #   pubsub = gcloud.pubsub
+    #   topic = pubsub.topic "my-topic"
+    #
+    #   policy = topic.policy # API call
+    #
+    #   policy.roles["roles/owner"] << "user:owner@example.com" # Local mod
+    #   policy.roles["roles/viewer"] = ["allUsers"] # Local mod
+    #
+    #   topic.policy = policy # API call
+    #
+    class Policy
+      attr_reader :etag, :roles
+
+      ##
+      # @private Creates a Policy object.
+      def initialize etag, roles
+        @etag = etag
+        @roles = roles
+      end
+
+      ##
+      # @private Convert the Policy to a Google::Iam::V1::Policy object.
+      def to_grpc
+        Google::Iam::V1::Policy.new(
+          etag: etag,
+          bindings: roles.keys.map do |role|
+            next if roles[role].empty?
+            Google::Iam::V1::Binding.new(
+              role: role,
+              members: roles[role]
+            )
+          end
+        )
+      end
+
+      ##
+      # @private New Policy from a Google::Iam::V1::Policy object.
+      def self.from_grpc grpc
+        roles = grpc.bindings.each_with_object({}) do |binding, memo|
+          memo[binding.role] = binding.members.to_a
+        end
+        new grpc.etag, roles
+      end
+    end
+  end
+end

--- a/lib/gcloud/pubsub/policy.rb
+++ b/lib/gcloud/pubsub/policy.rb
@@ -163,6 +163,20 @@ module Gcloud
       end
 
       ##
+      # Returns a deep copy of the policy.
+      #
+      # @return [Policy]
+      #
+      def deep_dup
+        dup.tap do |p|
+          roles_dup = p.roles.each_with_object({}) do |(k, v), memo|
+            memo[k] = v.dup rescue value
+          end
+          p.instance_variable_set "@roles", roles_dup
+        end
+      end
+
+      ##
       # @private Convert the Policy to a Google::Iam::V1::Policy object.
       def to_grpc
         Google::Iam::V1::Policy.new(

--- a/lib/gcloud/pubsub/policy.rb
+++ b/lib/gcloud/pubsub/policy.rb
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All rights reserved.
+# Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,8 +45,10 @@ module Gcloud
     #   the last request. The policy will be written only if the `etag` values
     #   match.
     # @attr [Hash{String => Array<String>}] roles The bindings that associate
-    #   roles with an array of members. See
-    #   [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
+    #   roles with an array of members. See [Understanding
+    #   Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+    #   listing of primitive and curated roles.
+    #   See [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
     #   for a listing of values and patterns for members.
     #
     # @example
@@ -58,8 +60,9 @@ module Gcloud
     #
     #   policy = topic.policy # API call
     #
-    #   policy.roles["roles/owner"] << "user:owner@example.com" # Local mod
-    #   policy.roles["roles/viewer"] = ["allUsers"] # Local mod
+    #   policy.remove "roles/owner", "user:owner@example.com" # Local call
+    #   policy.add "roles/owner", "user:newowner@example.com" # Local call
+    #   policy.roles["roles/viewer"] = ["allUsers"] # Local call
     #
     #   topic.policy = policy # API call
     #
@@ -71,6 +74,64 @@ module Gcloud
       def initialize etag, roles
         @etag = etag
         @roles = roles
+      end
+
+      ##
+      # Convenience method for adding a member to a binding on this policy.
+      # See [Understanding
+      # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+      # listing of primitive and curated roles.
+      # See [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
+      # for a listing of values and patterns for members.
+      #
+      # @param [String] role A Cloud IAM role, such as `"roles/pubsub.admin"`.
+      # @param [String] member A Cloud IAM identity, such as
+      #   `"user:owner@example.com"`.
+      #
+      # @example
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
+      #   topic = pubsub.topic "my-topic"
+      #
+      #   policy = topic.policy # API call
+      #
+      #   policy.add "roles/owner", "user:newowner@example.com" # Local call
+      #
+      #   topic.policy = policy # API call
+      #
+      def add role, member
+        roles[role] << member
+      end
+
+      ##
+      # Convenience method for removing a member from a binding on this policy.
+      # See [Understanding
+      # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+      # listing of primitive and curated roles.
+      # See [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
+      # for a listing of values and patterns for members.
+      #
+      # @param [String] role A Cloud IAM role, such as `"roles/pubsub.admin"`.
+      # @param [String] member A Cloud IAM identity, such as
+      #   `"user:owner@example.com"`.
+      #
+      # @example
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
+      #   topic = pubsub.topic "my-topic"
+      #
+      #   policy = topic.policy # API call
+      #
+      #   policy.remove "roles/owner", "user:owner@example.com" # Local call
+      #
+      #   topic.policy = policy # API call
+      #
+      def remove role, member
+        roles[role].delete member
       end
 
       ##

--- a/lib/gcloud/pubsub/policy.rb
+++ b/lib/gcloud/pubsub/policy.rb
@@ -84,7 +84,8 @@ module Gcloud
       # See [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
       # for a listing of values and patterns for members.
       #
-      # @param [String] role A Cloud IAM role, such as `"roles/pubsub.admin"`.
+      # @param [String] role_name A Cloud IAM role, such as
+      #   `"roles/pubsub.admin"`.
       # @param [String] member A Cloud IAM identity, such as
       #   `"user:owner@example.com"`.
       #
@@ -101,8 +102,8 @@ module Gcloud
       #
       #   topic.policy = policy # API call
       #
-      def add role, member
-        roles[role] << member
+      def add role_name, member
+        role(role_name) << member
       end
 
       ##
@@ -113,7 +114,8 @@ module Gcloud
       # See [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
       # for a listing of values and patterns for members.
       #
-      # @param [String] role A Cloud IAM role, such as `"roles/pubsub.admin"`.
+      # @param [String] role_name A Cloud IAM role, such as
+      #   `"roles/pubsub.admin"`.
       # @param [String] member A Cloud IAM identity, such as
       #   `"user:owner@example.com"`.
       #
@@ -130,8 +132,34 @@ module Gcloud
       #
       #   topic.policy = policy # API call
       #
-      def remove role, member
-        roles[role].delete member
+      def remove role_name, member
+        role(role_name).delete member
+      end
+
+      ##
+      # Convenience method returning the array of members bound to a role in
+      # this policy, or an empty array if no value is present for the role in
+      # {#roles}. See [Understanding
+      # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+      # listing of primitive and curated roles. See
+      # [Binding](https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#binding)
+      # for a listing of values and patterns for members.
+      #
+      # @return [Array<String>] The members strings, or an empty array.
+      #
+      # @example
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
+      #   topic = pubsub.topic "my-topic"
+      #
+      #   policy = topic.policy
+      #
+      #   policy.role("roles/viewer") << "user:viewer@example.com"
+      #
+      def role role_name
+        roles[role_name] ||= []
       end
 
       ##
@@ -139,11 +167,11 @@ module Gcloud
       def to_grpc
         Google::Iam::V1::Policy.new(
           etag: etag,
-          bindings: roles.keys.map do |role|
-            next if roles[role].empty?
+          bindings: roles.keys.map do |role_name|
+            next if roles[role_name].empty?
             Google::Iam::V1::Binding.new(
-              role: role,
-              members: roles[role]
+              role: role_name,
+              members: roles[role_name]
             )
           end
         )

--- a/lib/gcloud/pubsub/service.rb
+++ b/lib/gcloud/pubsub/service.rb
@@ -279,7 +279,7 @@ module Gcloud
       def set_subscription_policy subscription_name, new_policy, options = {}
         set_req = Google::Iam::V1::SetIamPolicyRequest.new(
           resource: subscription_path(subscription_name, options),
-          policy: Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
+          policy: new_policy
         )
 
         backoff { iam.set_iam_policy set_req }

--- a/lib/gcloud/pubsub/service.rb
+++ b/lib/gcloud/pubsub/service.rb
@@ -253,7 +253,7 @@ module Gcloud
       def set_topic_policy topic_name, new_policy, options = {}
         set_req = Google::Iam::V1::SetIamPolicyRequest.new(
           resource: topic_path(topic_name, options),
-          policy: Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
+          policy: new_policy
         )
 
         backoff { iam.set_iam_policy set_req }

--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -463,7 +463,7 @@ module Gcloud
       #
       #   policy = sub.policy # API call
       #
-      #   policy.roles["roles/owner"] << "user:owner@example.com"
+      #   policy.add "roles/owner", "user:owner@example.com"
       #
       #   sub.policy = policy # API call
       #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -367,7 +367,7 @@ module Gcloud
       #
       #   policy = topic.policy # API call
       #
-      #   policy.roles["roles/owner"] << "user:owner@example.com"
+      #   policy.add "roles/owner", "user:owner@example.com"
       #
       #   topic.policy = policy # API call
       #

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -17,6 +17,7 @@ require "gcloud/errors"
 require "gcloud/pubsub/topic/batch"
 require "gcloud/pubsub/topic/list"
 require "gcloud/pubsub/subscription"
+require "gcloud/pubsub/policy"
 
 module Gcloud
   module Pubsub
@@ -301,85 +302,79 @@ module Gcloud
       end
 
       ##
-      # Gets the access control policy.
+      # Gets the [Cloud IAM](https://cloud.google.com/iam/) access control
+      # policy for this topic.
+      #
+      # @see https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#iampolicy
+      #   google.iam.v1.IAMPolicy
       #
       # @param [Boolean] force Force the latest policy to be retrieved from the
       #   Pub/Sub service when `true`. Otherwise the policy will be memoized to
       #   reduce the number of API calls made to the Pub/Sub service. The
       #   default is `false`.
       #
-      # @return [Hash] Returns a hash that conforms to the following structure:
-      #
-      #   {
-      #     "etag"=>"CAE=",
-      #     "bindings" => [{
-      #       "role" => "roles/viewer",
-      #       "members" => ["serviceAccount:your-service-account"]
-      #     }]
-      #   }
+      # @return [Policy] the current Cloud IAM Policy for this topic
       #
       # @example Policy values are memoized to reduce the number of API calls:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
-      #
       #   topic = pubsub.topic "my-topic"
-      #   puts topic.policy["bindings"]
-      #   puts topic.policy["rules"]
+      #
+      #   policy = topic.policy # API call
+      #   policy_2 = topic.policy # No API call
       #
       # @example Use `force` to retrieve the latest policy from the service:
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
-      #
       #   topic = pubsub.topic "my-topic"
-      #   policy = topic.policy force: true
+      #
+      #   policy = topic.policy force: true # API call
+      #   policy_2 = topic.policy force: true # API call
       #
       def policy force: nil
         @policy = nil if force
         @policy ||= begin
           ensure_service!
           grpc = service.get_topic_policy name
-          JSON.parse(Google::Iam::V1::Policy.encode_json(grpc))
+          Policy.from_grpc grpc
         rescue GRPC::BadStatus => e
           raise Error.from_error(e)
         end
       end
 
       ##
-      # Sets the access control policy.
+      # Updates the [Cloud IAM](https://cloud.google.com/iam/) access control
+      # policy for this topic. The policy should be read from {#policy}. See
+      # {Gcloud::Pubsub::Policy} for an explanation of the policy `etag`
+      # property and how to modify policies.
       #
-      # @param [String] new_policy A hash that conforms to the following
-      #   structure:
+      # @see https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#iampolicy
+      #   google.iam.v1.IAMPolicy
       #
-      #     {
-      #       "bindings" => [{
-      #         "role" => "roles/viewer",
-      #         "members" => ["serviceAccount:your-service-account"]
-      #       }]
-      #     }
+      # @param [Policy] new_policy a new or modified Cloud IAM Policy for this
+      #   topic
       #
       # @example
       #   require "gcloud"
       #
       #   gcloud = Gcloud.new
       #   pubsub = gcloud.pubsub
-      #
-      #   viewer_policy = {
-      #     "bindings" => [{
-      #       "role" => "roles/viewer",
-      #       "members" => ["serviceAccount:your-service-account"]
-      #     }]
-      #   }
       #   topic = pubsub.topic "my-topic"
-      #   topic.policy = viewer_policy
+      #
+      #   policy = topic.policy # API call
+      #
+      #   policy.roles["roles/owner"] << "user:owner@example.com"
+      #
+      #   topic.policy = policy # API call
       #
       def policy= new_policy
         ensure_service!
-        grpc = service.set_topic_policy name, new_policy
-        @policy = JSON.parse(Google::Iam::V1::Policy.encode_json(grpc))
+        grpc = service.set_topic_policy name, new_policy.to_grpc
+        @policy = Policy.from_grpc grpc
       rescue GRPC::BadStatus => e
         raise Error.from_error(e)
       end

--- a/lib/gcloud/pubsub/topic.rb
+++ b/lib/gcloud/pubsub/topic.rb
@@ -313,6 +313,11 @@ module Gcloud
       #   reduce the number of API calls made to the Pub/Sub service. The
       #   default is `false`.
       #
+      # @yield [policy] A block for updating the policy. The latest policy will
+      #   be read from the Pub/Sub service and passed to the block. After the
+      #   block completes, the modified policy will be written to the service.
+      # @yieldparam [Policy] policy the current Cloud IAM Policy for this topic
+      #
       # @return [Policy] the current Cloud IAM Policy for this topic
       #
       # @example Policy values are memoized to reduce the number of API calls:
@@ -335,8 +340,19 @@ module Gcloud
       #   policy = topic.policy force: true # API call
       #   policy_2 = topic.policy force: true # API call
       #
+      # @example Update the policy by passing a block:
+      #   require "gcloud"
+      #
+      #   gcloud = Gcloud.new
+      #   pubsub = gcloud.pubsub
+      #   topic = pubsub.topic "my-topic"
+      #
+      #   policy = topic.policy do |p|
+      #     p.add "roles/owner", "user:owner@example.com"
+      #   end # 2 API calls
+      #
       def policy force: nil
-        @policy = nil if force
+        @policy = nil if force || block_given?
         @policy ||= begin
           ensure_service!
           grpc = service.get_topic_policy name
@@ -344,6 +360,10 @@ module Gcloud
         rescue GRPC::BadStatus => e
           raise Error.from_error(e)
         end
+        return @policy unless block_given?
+        p = @policy.deep_dup
+        yield p
+        self.policy = p
       end
 
       ##
@@ -351,6 +371,9 @@ module Gcloud
       # policy for this topic. The policy should be read from {#policy}. See
       # {Gcloud::Pubsub::Policy} for an explanation of the policy `etag`
       # property and how to modify policies.
+      #
+      # You can also update the policy by passing a block to {#policy}, which
+      # will call this method internally after the block completes.
       #
       # @see https://cloud.google.com/pubsub/reference/rpc/google.iam.v1#iampolicy
       #   google.iam.v1.IAMPolicy

--- a/test/gcloud/pubsub/policy_test.rb
+++ b/test/gcloud/pubsub/policy_test.rb
@@ -1,0 +1,37 @@
+ # Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Gcloud::Pubsub::Policy, :mock_pubsub do
+  let(:etag)       { "etag-1" }
+  let(:roles) { { "roles/viewer" => ["allUsers"] } }
+  let(:policy)    { Gcloud::Pubsub::Policy.new etag, roles }
+
+  it "knows its etag" do
+    policy.roles.must_equal roles
+  end
+
+  it "knows its roles" do
+    policy.roles.keys.sort.must_equal   roles.keys.sort
+    policy.roles.values.sort.must_equal roles.values.sort
+  end
+
+  it "returns an empty array for missing role" do
+    role = policy.role "roles/does-not-exist"
+    role.must_be_kind_of Array
+    role.must_be :empty?
+    role.frozen?.must_equal false
+  end
+end

--- a/test/gcloud/pubsub/subscription/policy_test.rb
+++ b/test/gcloud/pubsub/subscription/policy_test.rb
@@ -30,7 +30,7 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
         "members" => [
           "user:viewer@example.com",
           "serviceAccount:1234567890@developer.gserviceaccount.com"
-        ],
+        ]
       }]
     }.to_json
 
@@ -46,16 +46,17 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy.must_be_kind_of Hash
-    policy["bindings"].count.must_equal 1
-    policy["bindings"].first["role"].must_equal "roles/viewer"
-    policy["bindings"].first["members"].count.must_equal 2
-    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
-    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be_kind_of Array
+    policy.roles["roles/viewer"].count.must_equal 2
+    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "memoizes policy" do
-    policy_hash = {
+    existing_policy_json = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/viewer",
@@ -64,22 +65,24 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
         ],
       }]
-    }
+    }.to_json
 
-    subscription.instance_variable_set "@policy", policy_hash
+    existing_policy = Gcloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
+    subscription.instance_variable_set "@policy", existing_policy
 
     # No mocks, no errors, no HTTP calls are made
     policy = subscription.policy
-    policy.must_be_kind_of Hash
-    policy["bindings"].count.must_equal 1
-    policy["bindings"].first["role"].must_equal "roles/viewer"
-    policy["bindings"].first["members"].count.must_equal 2
-    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
-    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be_kind_of Array
+    policy.roles["roles/viewer"].count.must_equal 2
+    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "makes API calls when forced, even if already memoized" do
-    policy_hash = {
+    existing_policy_json = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/viewer",
@@ -88,7 +91,7 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
         ],
       }]
-    }
+    }.to_json
 
     policy_json = {
       "etag"=>"CAE=",
@@ -97,7 +100,7 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
         "members" => [
           "user:owner@example.com",
           "serviceAccount:0987654321@developer.gserviceaccount.com"
-        ],
+         ]
       }]
     }.to_json
 
@@ -109,36 +112,53 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
     mock.expect :get_iam_policy, get_res, [get_req]
     subscription.service.mocked_iam = mock
 
-    subscription.instance_variable_set "@policy", policy_hash
+    existing_policy = Gcloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
+    subscription.instance_variable_set "@policy", existing_policy
     returned_policy = subscription.policy
-    returned_policy.must_be_kind_of Hash
-    returned_policy["bindings"].count.must_equal 1
-    returned_policy["bindings"].first["role"].must_equal "roles/viewer"
-    returned_policy["bindings"].first["members"].count.must_equal 2
-    returned_policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
-    returned_policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    returned_policy.must_be_kind_of Gcloud::Pubsub::Policy
+    returned_policy.roles.must_be_kind_of Hash
+    returned_policy.roles.size.must_equal 1
+    returned_policy.roles["roles/viewer"].must_be_kind_of Array
+    returned_policy.roles["roles/viewer"].count.must_equal 2
+    returned_policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    returned_policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
 
     policy = subscription.policy force: true
 
     mock.verify
 
-    policy.must_be_kind_of Hash
-    policy["bindings"].count.must_equal 1
-    policy["bindings"].first["role"].must_equal "roles/owner"
-    policy["bindings"].first["members"].count.must_equal 2
-    policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
-    policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be :nil?
+    policy.roles["roles/owner"].must_be_kind_of Array
+    policy.roles["roles/owner"].count.must_equal 2
+    policy.roles["roles/owner"].first.must_equal "user:owner@example.com"
+    policy.roles["roles/owner"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
   end
 
   it "sets the IAM Policy" do
+    policy_json = {
+      "etag"=>"CAE=",
+      "bindings"=>[]
+    }.to_json
+
+    get_req = Google::Iam::V1::GetIamPolicyRequest.new(
+      resource: "projects/#{project}/subscriptions/#{sub_name}"
+    )
+    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [get_req]
+
     new_policy = {
+      "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
         "members" => [
           "user:owner@example.com",
           "serviceAccount:0987654321@developer.gserviceaccount.com"
-        ],
-      }],
+        ]
+      }]
     }
 
     set_req = Google::Iam::V1::SetIamPolicyRequest.new(
@@ -146,20 +166,26 @@ describe Gcloud::Pubsub::Subscription, :policy, :mock_pubsub do
       policy: Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
     )
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock = Minitest::Mock.new
     mock.expect :set_iam_policy, set_res, [set_req]
     subscription.service.mocked_iam = mock
 
-    subscription.policy = new_policy
+    policy = subscription.policy
+
+    policy.roles["roles/owner"] = ["user:owner@example.com", "serviceAccount:0987654321@developer.gserviceaccount.com"]
+    subscription.policy = policy
 
     mock.verify
 
     # Setting the policy also memoizes the policy
-    subscription.policy["bindings"].count.must_equal 1
-    subscription.policy["bindings"].first["role"].must_equal "roles/owner"
-    subscription.policy["bindings"].first["members"].count.must_equal 2
-    subscription.policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
-    subscription.policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy = subscription.policy
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be :nil?
+    policy.roles["roles/owner"].must_be_kind_of Array
+    policy.roles["roles/owner"].count.must_equal 2
+    policy.roles["roles/owner"].first.must_equal "user:owner@example.com"
+    policy.roles["roles/owner"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
   end
 
   it "tests the available permissions" do

--- a/test/gcloud/pubsub/topic/policy_test.rb
+++ b/test/gcloud/pubsub/topic/policy_test.rb
@@ -154,8 +154,8 @@ describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
         "members" => [
           "user:owner@example.com",
           "serviceAccount:0987654321@developer.gserviceaccount.com"
-        ],
-      }],
+        ]
+      }]
     }
 
     set_req = Google::Iam::V1::SetIamPolicyRequest.new(

--- a/test/gcloud/pubsub/topic/policy_test.rb
+++ b/test/gcloud/pubsub/topic/policy_test.rb
@@ -43,16 +43,17 @@ describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
 
     mock.verify
 
-    policy.must_be_kind_of Hash
-    policy["bindings"].count.must_equal 1
-    policy["bindings"].first["role"].must_equal "roles/viewer"
-    policy["bindings"].first["members"].count.must_equal 2
-    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
-    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be_kind_of Array
+    policy.roles["roles/viewer"].count.must_equal 2
+    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "memoizes policy" do
-    policy_hash = {
+    existing_policy_json = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/viewer",
@@ -61,22 +62,24 @@ describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
         ],
       }]
-    }
+    }.to_json
 
-    topic.instance_variable_set "@policy", policy_hash
+    existing_policy = Gcloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
+    topic.instance_variable_set "@policy", existing_policy
 
     # No mocks, no errors, no HTTP calls are made
     policy = topic.policy
-    policy.must_be_kind_of Hash
-    policy["bindings"].count.must_equal 1
-    policy["bindings"].first["role"].must_equal "roles/viewer"
-    policy["bindings"].first["members"].count.must_equal 2
-    policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
-    policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be_kind_of Array
+    policy.roles["roles/viewer"].count.must_equal 2
+    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "makes API calls when forced, even if already memoized" do
-    policy_hash = {
+    existing_policy_json = {
       "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/viewer",
@@ -85,7 +88,7 @@ describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
           "serviceAccount:1234567890@developer.gserviceaccount.com"
         ],
       }]
-    }
+    }.to_json
 
     policy_json = {
       "etag"=>"CAE=",
@@ -106,29 +109,46 @@ describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
     mock.expect :get_iam_policy, get_res, [get_req]
     topic.service.mocked_iam = mock
 
-    topic.instance_variable_set "@policy", policy_hash
+    existing_policy = Gcloud::Pubsub::Policy.from_grpc Google::Iam::V1::Policy.decode_json(existing_policy_json)
+    topic.instance_variable_set "@policy", existing_policy
     returned_policy = topic.policy
-    returned_policy.must_be_kind_of Hash
-    returned_policy["bindings"].count.must_equal 1
-    returned_policy["bindings"].first["role"].must_equal "roles/viewer"
-    returned_policy["bindings"].first["members"].count.must_equal 2
-    returned_policy["bindings"].first["members"].first.must_equal "user:viewer@example.com"
-    returned_policy["bindings"].first["members"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    returned_policy.must_be_kind_of Gcloud::Pubsub::Policy
+    returned_policy.roles.must_be_kind_of Hash
+    returned_policy.roles.size.must_equal 1
+    returned_policy.roles["roles/viewer"].must_be_kind_of Array
+    returned_policy.roles["roles/viewer"].count.must_equal 2
+    returned_policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
+    returned_policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
 
     policy = topic.policy force: true
 
     mock.verify
 
-    policy.must_be_kind_of Hash
-    policy["bindings"].count.must_equal 1
-    policy["bindings"].first["role"].must_equal "roles/owner"
-    policy["bindings"].first["members"].count.must_equal 2
-    policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
-    policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be :nil?
+    policy.roles["roles/owner"].must_be_kind_of Array
+    policy.roles["roles/owner"].count.must_equal 2
+    policy.roles["roles/owner"].first.must_equal "user:owner@example.com"
+    policy.roles["roles/owner"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
   end
 
   it "sets the IAM Policy" do
+    policy_json = {
+      "etag"=>"CAE=",
+      "bindings"=>[]
+    }.to_json
+
+    get_req = Google::Iam::V1::GetIamPolicyRequest.new(
+      resource: "projects/#{project}/topics/#{topic_name}"
+    )
+    get_res = Google::Iam::V1::Policy.decode_json policy_json
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [get_req]
+
     new_policy = {
+      "etag"=>"CAE=",
       "bindings" => [{
         "role" => "roles/owner",
         "members" => [
@@ -143,20 +163,34 @@ describe Gcloud::Pubsub::Topic, :policy, :mock_pubsub do
       policy: Google::Iam::V1::Policy.decode_json(JSON.dump(new_policy))
     )
     set_res = Google::Iam::V1::Policy.decode_json JSON.dump(new_policy)
-    mock = Minitest::Mock.new
     mock.expect :set_iam_policy, set_res, [set_req]
     topic.service.mocked_iam = mock
 
-    topic.policy = new_policy
+    policy = topic.policy
+
+    policy.roles["roles/owner"] = ["user:owner@example.com", "serviceAccount:0987654321@developer.gserviceaccount.com"]
+    topic.policy = policy
+
+    #TODO
+    # policy.add "roles/owner", "user:owner@example.com", "serviceAccount:0987654321@developer.gserviceaccount.com"
+    # policy.remove "roles/owner", "user:owner@example.com"
+    #
+    # policy.roles.size.must_equal 1
+    # policy.etag
+    #TODO
 
     mock.verify
 
     # Setting the policy also memoizes the policy
-    topic.policy["bindings"].count.must_equal 1
-    topic.policy["bindings"].first["role"].must_equal "roles/owner"
-    topic.policy["bindings"].first["members"].count.must_equal 2
-    topic.policy["bindings"].first["members"].first.must_equal "user:owner@example.com"
-    topic.policy["bindings"].first["members"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    policy = topic.policy
+    policy.must_be_kind_of Gcloud::Pubsub::Policy
+    policy.roles.must_be_kind_of Hash
+    policy.roles.size.must_equal 1
+    policy.roles["roles/viewer"].must_be :nil?
+    policy.roles["roles/owner"].must_be_kind_of Array
+    policy.roles["roles/owner"].count.must_equal 2
+    policy.roles["roles/owner"].first.must_equal "user:owner@example.com"
+    policy.roles["roles/owner"].last.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
   end
 
   it "tests the available permissions" do


### PR DESCRIPTION
This PR adds to `master` from `iam` an object, Policy, that holds the etag value for use in updates.

[closes #587, closes #593]