### PR TITLE
Move retries to parameter

### DIFF
--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -42,6 +42,8 @@ module Gcloud
   #   connecting to.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
   #   path the file must be readable.
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud]
   #
@@ -53,10 +55,11 @@ module Gcloud
   #   pubsub  = gcloud.pubsub
   #   storage = gcloud.storage
   #
-  def self.new project = nil, keyfile = nil
+  def self.new project = nil, keyfile = nil, retries: nil
     gcloud = Object.new
     gcloud.instance_variable_set "@project", project
     gcloud.instance_variable_set "@keyfile", keyfile
+    gcloud.instance_variable_set "@retries", retries
     gcloud.extend Gcloud
     gcloud
   end
@@ -76,6 +79,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/datastore`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Datastore::Dataset]
   #
@@ -101,9 +106,10 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   datastore = gcloud.datastore scope: platform_scope
   #
-  def datastore scope: nil
+  def datastore scope: nil, retries: nil
     require "gcloud/datastore"
-    Gcloud.datastore @project, @keyfile, scope: scope
+    Gcloud.datastore @project, @keyfile, scope: scope,
+                                         retries: (retries || @retries)
   end
 
   ##
@@ -124,6 +130,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Storage::Project]
   #
@@ -142,9 +150,10 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/devstorage.read_only"
   #   readonly_storage = gcloud.storage scope: readonly_scope
   #
-  def storage scope: nil
+  def storage scope: nil, retries: nil
     require "gcloud/storage"
-    Gcloud.storage @project, @keyfile, scope: scope
+    Gcloud.storage @project, @keyfile, scope: scope,
+                                       retries: (retries || @retries)
   end
 
   ##
@@ -162,6 +171,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/pubsub`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Pubsub::Project]
   #
@@ -180,9 +191,10 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   pubsub = gcloud.pubsub scope: platform_scope
   #
-  def pubsub scope: nil
+  def pubsub scope: nil, retries: nil
     require "gcloud/pubsub"
-    Gcloud.pubsub @project, @keyfile, scope: scope
+    Gcloud.pubsub @project, @keyfile, scope: scope,
+                                      retries: (retries || @retries)
   end
 
   ##
@@ -200,6 +212,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/bigquery`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Bigquery::Project]
   #
@@ -221,9 +235,10 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   bigquery = gcloud.bigquery scope: platform_scope
   #
-  def bigquery scope: nil
+  def bigquery scope: nil, retries: nil
     require "gcloud/bigquery"
-    Gcloud.bigquery @project, @keyfile, scope: scope
+    Gcloud.bigquery @project, @keyfile, scope: scope,
+                                        retries: (retries || @retries)
   end
 
   ##
@@ -241,6 +256,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Dns::Project]
   #
@@ -261,9 +278,10 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/ndev.clouddns.readonly"
   #   dns = gcloud.dns scope: readonly_scope
   #
-  def dns scope: nil
+  def dns scope: nil, retries: nil
     require "gcloud/dns"
-    Gcloud.dns @project, @keyfile, scope: scope
+    Gcloud.dns @project, @keyfile, scope: scope,
+                                   retries: (retries || @retries)
   end
 
   # rubocop:disable Metrics/LineLength
@@ -285,6 +303,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::ResourceManager::Manager]
   #
@@ -304,9 +324,10 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/cloudresourcemanager.readonly"
   #   resource_manager = gcloud.resource_manager scope: readonly_scope
   #
-  def resource_manager scope: nil
+  def resource_manager scope: nil, retries: nil
     require "gcloud/resource_manager"
-    Gcloud.resource_manager @keyfile, scope: scope
+    Gcloud.resource_manager @keyfile, scope: scope,
+                                      retries: (retries || @retries)
   end
 
   # rubocop:enable Metrics/LineLength
@@ -326,6 +347,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/logging.admin`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Logging::Project]
   #
@@ -343,9 +366,10 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   logging = gcloud.logging scope: platform_scope
   #
-  def logging scope: nil
+  def logging scope: nil, retries: nil
     require "gcloud/logging"
-    Gcloud.logging @project, @keyfile, scope: scope
+    Gcloud.logging @project, @keyfile, scope: scope,
+                                       retries: (retries || @retries)
   end
 
   ##
@@ -361,6 +385,8 @@ module Gcloud
   # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
   #
   # @param [String] key a public API access key (not an OAuth 2.0 token)
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Translate::Api]
   #
@@ -384,9 +410,9 @@ module Gcloud
   #   translation = translate.translate "Hello world!", to: "la"
   #   translation.text #=> "Salve mundi!"
   #
-  def translate key = nil
+  def translate key = nil, retries: nil
     require "gcloud/translate"
-    Gcloud.translate key
+    Gcloud.translate key, retries: (retries || @retries)
   end
 
   ##
@@ -401,6 +427,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Vision::Project]
   #
@@ -422,8 +450,9 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   vision = gcloud.vision scope: platform_scope
   #
-  def vision scope: nil
+  def vision scope: nil, retries: nil
     require "gcloud/vision"
-    Gcloud.vision @project, @keyfile, scope: scope
+    Gcloud.vision @project, @keyfile, scope: scope,
+                                      retries: (retries || @retries)
   end
 end

--- a/lib/gcloud/backoff.rb
+++ b/lib/gcloud/backoff.rb
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
-require "google/apis/options"
-
 module Gcloud
   ##
+  # @private
   # Backoff allows users to control how Google API calls are retried.
   # If an API call fails the response will be checked to see if the
   # call can be retried. If the response matches the criteria, then it
@@ -38,8 +37,6 @@ module Gcloud
       # The default value is `3`.
       attr_reader :retries
       def retries= new_retries
-        # Set Google API Client
-        Google::Apis::RequestOptions.default.retries = new_retries
         @retries = new_retries
       end
 

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -36,6 +36,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/bigquery`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional., retries: nil
   #
   # @return [Gcloud::Bigquery::Project]
   #
@@ -46,14 +48,19 @@ module Gcloud
   #   dataset = bigquery.dataset "my_dataset"
   #   table = dataset.table "my_table"
   #
-  def self.bigquery project = nil, keyfile = nil, scope: nil
+  def self.bigquery project = nil, keyfile = nil, scope: nil, retries: nil
     project ||= Gcloud::Bigquery::Project.default_project
+    project = project.to_s # Always cast to a string
+    fail ArgumentError, "project is missing" if project.empty?
+
     if keyfile.nil?
       credentials = Gcloud::Bigquery::Credentials.default scope: scope
     else
       credentials = Gcloud::Bigquery::Credentials.new keyfile, scope: scope
     end
-    Gcloud::Bigquery::Project.new project, credentials
+
+    Gcloud::Bigquery::Project.new(
+      Gcloud::Bigquery::Service.new(project, credentials, retries: retries))
   end
 
   ##

--- a/lib/gcloud/bigquery/project.rb
+++ b/lib/gcloud/bigquery/project.rb
@@ -53,10 +53,8 @@ module Gcloud
       # Creates a new Service instance.
       #
       # See {Gcloud.bigquery}
-      def initialize project, credentials
-        project = project.to_s # Always cast to a string
-        fail ArgumentError, "project is missing" if project.empty?
-        @service = Service.new project, credentials
+      def initialize service
+        @service = service
       end
 
       ##

--- a/lib/gcloud/bigquery/service.rb
+++ b/lib/gcloud/bigquery/service.rb
@@ -37,13 +37,14 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials
+      def initialize project, credentials, retries: nil
         @project = project
         @credentials = credentials
         @credentials = credentials
         @service = API::BigqueryService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
+        @service.request_options.retries = retries || 3
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/datastore/dataset.rb
+++ b/lib/gcloud/datastore/dataset.rb
@@ -60,10 +60,8 @@ module Gcloud
       # @private Creates a new Dataset instance.
       #
       # See {Gcloud#datastore}
-      def initialize project, credentials
-        project = project.to_s # Always cast to a string
-        fail ArgumentError, "project is missing" if project.empty?
-        @service = Service.new project, credentials
+      def initialize service
+        @service = service
       end
 
       ##

--- a/lib/gcloud/datastore/service.rb
+++ b/lib/gcloud/datastore/service.rb
@@ -23,14 +23,15 @@ module Gcloud
     # @private Represents the gRPC Datastore service, including all the API
     # methods.
     class Service
-      attr_accessor :project, :credentials, :host
+      attr_accessor :project, :credentials, :host, :retries
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials
+      def initialize project, credentials, host: nil, retries: nil
         @project = project
         @credentials = credentials
-        @host = "datastore.googleapis.com"
+        @host = host || "datastore.googleapis.com"
+        @retries = retries
       end
 
       def creds
@@ -138,7 +139,7 @@ module Gcloud
       ##
       # Performs backoff and error handling
       def execute
-        Gcloud::Backoff.new.execute_grpc do
+        Gcloud::Backoff.new(retries: retries).execute_grpc do
           yield
         end
       rescue GRPC::BadStatus => e

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -36,6 +36,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Dns::Project]
   #
@@ -47,14 +49,19 @@ module Gcloud
   #
   #   zone = dns.zone "example-com"
   #
-  def self.dns project = nil, keyfile = nil, scope: nil
+  def self.dns project = nil, keyfile = nil, scope: nil, retries: nil
     project ||= Gcloud::Dns::Project.default_project
+    project = project.to_s # Always cast to a string
+    fail ArgumentError, "project is missing" if project.empty?
+
     if keyfile.nil?
       credentials = Gcloud::Dns::Credentials.default scope: scope
     else
       credentials = Gcloud::Dns::Credentials.new keyfile, scope: scope
     end
-    Gcloud::Dns::Project.new project, credentials
+
+    Gcloud::Dns::Project.new(
+      Gcloud::Dns::Service.new(project, credentials, retries: retries))
   end
 
   ##

--- a/lib/gcloud/dns/project.rb
+++ b/lib/gcloud/dns/project.rb
@@ -52,10 +52,8 @@ module Gcloud
       # @private Creates a new Service instance.
       #
       # See {Gcloud.dns}
-      def initialize project, credentials
-        project = project.to_s # Always cast to a string
-        fail ArgumentError, "project is missing" if project.empty?
-        @service = Service.new project, credentials
+      def initialize service
+        @service = service
         @gapi = nil
       end
 

--- a/lib/gcloud/dns/service.rb
+++ b/lib/gcloud/dns/service.rb
@@ -32,12 +32,13 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials
+      def initialize project, credentials, retries: nil
         @project = project
         @credentials = credentials
         @service = API::DnsService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
+        @service.request_options.retries = retries || 3
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -36,6 +36,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/logging.admin`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Logging::Project]
   #
@@ -46,14 +48,19 @@ module Gcloud
   #   logging = gcloud.logging
   #   # ...
   #
-  def self.logging project = nil, keyfile = nil, scope: nil
+  def self.logging project = nil, keyfile = nil, scope: nil, retries: nil
     project ||= Gcloud::Logging::Project.default_project
+    project = project.to_s # Always cast to a string
+    fail ArgumentError, "project is missing" if project.empty?
+
     if keyfile.nil?
       credentials = Gcloud::Logging::Credentials.default scope: scope
     else
       credentials = Gcloud::Logging::Credentials.new keyfile, scope: scope
     end
-    Gcloud::Logging::Project.new project, credentials
+
+    Gcloud::Logging::Project.new(
+      Gcloud::Logging::Service.new(project, credentials, retries: retries))
   end
 
   ##

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -49,10 +49,8 @@ module Gcloud
 
       ##
       # @private Creates a new Connection instance.
-      def initialize project, credentials
-        project = project.to_s # Always cast to a string
-        fail ArgumentError, "project is missing" if project.empty?
-        @service = Service.new project, credentials
+      def initialize service
+        @service = service
       end
 
       ##

--- a/lib/gcloud/logging/service.rb
+++ b/lib/gcloud/logging/service.rb
@@ -26,14 +26,15 @@ module Gcloud
     # @private Represents the gRPC Logging service, including all the API
     # methods.
     class Service
-      attr_accessor :project, :credentials, :host
+      attr_accessor :project, :credentials, :host, :retries
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials
+      def initialize project, credentials, host: nil, retries: nil
         @project = project
         @credentials = credentials
-        @host = "logging.googleapis.com"
+        @host = host || "logging.googleapis.com"
+        @retries = retries
       end
 
       def creds
@@ -251,7 +252,7 @@ module Gcloud
       end
 
       def execute
-        Gcloud::Backoff.new.execute_grpc do
+        Gcloud::Backoff.new(retries: retries).execute_grpc do
           yield
         end
       rescue GRPC::BadStatus => e

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -36,6 +36,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/pubsub`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Pubsub::Project]
   #
@@ -47,7 +49,7 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  def self.pubsub project = nil, keyfile = nil, scope: nil
+  def self.pubsub project = nil, keyfile = nil, scope: nil, retries: nil
     project ||= Gcloud::Pubsub::Project.default_project
     if ENV["PUBSUB_EMULATOR_HOST"]
       ps = Gcloud::Pubsub::Project.new project, :this_channel_is_insecure
@@ -59,7 +61,8 @@ module Gcloud
     else
       credentials = Gcloud::Pubsub::Credentials.new keyfile, scope: scope
     end
-    Gcloud::Pubsub::Project.new project, credentials
+    Gcloud::Pubsub::Project.new(
+      Gcloud::Pubsub::Service.new(project, credentials, retries: retries))
   end
 
   ##

--- a/lib/gcloud/pubsub/project.rb
+++ b/lib/gcloud/pubsub/project.rb
@@ -48,11 +48,9 @@ module Gcloud
       attr_accessor :service
 
       ##
-      # @private Creates a new Connection instance.
-      def initialize project, credentials
-        project = project.to_s # Always cast to a string
-        fail ArgumentError, "project is missing" if project.empty?
-        @service = Service.new project, credentials
+      # @private Creates a new Pub/Sub Project instance.
+      def initialize service
+        @service = service
       end
 
       # The Pub/Sub project connected to.

--- a/lib/gcloud/pubsub/service.rb
+++ b/lib/gcloud/pubsub/service.rb
@@ -26,14 +26,15 @@ module Gcloud
     # @private Represents the gRPC Pub/Sub service, including all the API
     # methods.
     class Service
-      attr_accessor :project, :credentials, :host
+      attr_accessor :project, :credentials, :host, :retries
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials
+      def initialize project, credentials, host: nil, retries: nil
         @project = project
         @credentials = credentials
-        @host = "pubsub.googleapis.com"
+        @host = host || "pubsub.googleapis.com"
+        @retries = retries
       end
 
       def creds
@@ -318,7 +319,7 @@ module Gcloud
       protected
 
       def execute
-        Gcloud::Backoff.new.execute_grpc do
+        Gcloud::Backoff.new(retries: retries).execute_grpc do
           yield
         end
       rescue GRPC::BadStatus => e

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -34,6 +34,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::ResourceManager::Manager]
   #
@@ -45,14 +47,15 @@ module Gcloud
   #     puts projects.project_id
   #   end
   #
-  def self.resource_manager keyfile = nil, scope: nil
+  def self.resource_manager keyfile = nil, scope: nil, retries: nil
     if keyfile.nil?
       credentials = Gcloud::ResourceManager::Credentials.default scope: scope
     else
       credentials = Gcloud::ResourceManager::Credentials.new keyfile,
                                                              scope: scope
     end
-    Gcloud::ResourceManager::Manager.new credentials
+    Gcloud::ResourceManager::Manager.new(
+      Gcloud::ResourceManager::Service.new(credentials, retries: retries))
   end
 
   ##

--- a/lib/gcloud/resource_manager/manager.rb
+++ b/lib/gcloud/resource_manager/manager.rb
@@ -44,8 +44,8 @@ module Gcloud
       # @private Creates a new Service instance.
       #
       # See {Gcloud.resource_manager}
-      def initialize credentials
-        @service = Service.new credentials
+      def initialize service
+        @service = service
       end
 
       ##

--- a/lib/gcloud/resource_manager/service.rb
+++ b/lib/gcloud/resource_manager/service.rb
@@ -32,11 +32,12 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize credentials
+      def initialize credentials, retries: nil
         @credentials = credentials
         @service = API::CloudResourceManagerService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
+        @service.request_options.retries = retries || 3
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -36,6 +36,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Storage::Project]
   #
@@ -48,14 +50,19 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  def self.storage project = nil, keyfile = nil, scope: nil
+  def self.storage project = nil, keyfile = nil, scope: nil, retries: nil
     project ||= Gcloud::Storage::Project.default_project
+    project = project.to_s # Always cast to a string
+    fail ArgumentError, "project is missing" if project.empty?
+
     if keyfile.nil?
       credentials = Gcloud::Storage::Credentials.default scope: scope
     else
       credentials = Gcloud::Storage::Credentials.new keyfile, scope: scope
     end
-    Gcloud::Storage::Project.new project, credentials
+
+    Gcloud::Storage::Project.new(
+      Gcloud::Storage::Service.new(project, credentials, retries: retries))
   end
 
   ##

--- a/lib/gcloud/storage/project.rb
+++ b/lib/gcloud/storage/project.rb
@@ -55,10 +55,8 @@ module Gcloud
       # @private Creates a new Project instance.
       #
       # See {Gcloud#storage}
-      def initialize project, credentials
-        project = project.to_s # Always cast to a string
-        fail ArgumentError, "project is missing" if project.empty?
-        @service = Service.new project, credentials
+      def initialize service
+        @service = service
       end
 
       ##

--- a/lib/gcloud/storage/service.rb
+++ b/lib/gcloud/storage/service.rb
@@ -38,13 +38,14 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials
+      def initialize project, credentials, retries: nil
         @project = project
         @credentials = credentials
         @credentials = credentials
         @service = API::StorageService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
+        @service.request_options.retries = retries || 3
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/translate.rb
+++ b/lib/gcloud/translate.rb
@@ -30,6 +30,8 @@ module Gcloud
   # keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).
   #
   # @param [String] key a public API access key (not an OAuth 2.0 token)
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Translate::Api]
   #
@@ -51,8 +53,15 @@ module Gcloud
   #   translation = translate.translate "Hello world!", to: "la"
   #   translation.text #=> "Salve mundi!"
   #
-  def self.translate key = nil
-    Gcloud::Translate::Api.new key
+  def self.translate key = nil, retries: nil
+    key ||= ENV["TRANSLATE_KEY"]
+    if key.nil?
+      key_missing_msg = "An API key is required to use the Translate API."
+      fail ArgumentError, key_missing_msg
+    end
+
+    Gcloud::Translate::Api.new(
+      Gcloud::Translate::Service.new(key, retries: retries))
   end
 
   ##

--- a/lib/gcloud/translate/api.rb
+++ b/lib/gcloud/translate/api.rb
@@ -58,13 +58,8 @@ module Gcloud
       # @private Creates a new Translate Api instance.
       #
       # See {Gcloud.translate}
-      def initialize key
-        key ||= ENV["TRANSLATE_KEY"]
-        if key.nil?
-          key_missing_msg = "An API key is required to use the Translate API."
-          fail ArgumentError, key_missing_msg
-        end
-        @service = Service.new key
+      def initialize service
+        @service = service
       end
 
       ##

--- a/lib/gcloud/translate/service.rb
+++ b/lib/gcloud/translate/service.rb
@@ -31,10 +31,11 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize key
+      def initialize key, retries: nil
         @service = API::TranslateService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
+        @service.request_options.retries = retries || 3
         @service.authorization = nil
         @service.key = key
       end

--- a/lib/gcloud/vision.rb
+++ b/lib/gcloud/vision.rb
@@ -33,6 +33,8 @@ module Gcloud
   #   The default scope is:
   #
   #   * `https://www.googleapis.com/auth/cloud-platform`
+  # @param [Integer] retries Number of times to retry requests on server error.
+  #   The default value is `3`. Optional.
   #
   # @return [Gcloud::Vision::Project]
   #
@@ -47,14 +49,19 @@ module Gcloud
   #   landmark = image.landmark
   #   landmark.description #=> "Mount Rushmore"
   #
-  def self.vision project = nil, keyfile = nil, scope: nil
+  def self.vision project = nil, keyfile = nil, scope: nil, retries: nil
     project ||= Gcloud::Vision::Project.default_project
+    project = project.to_s # Always cast to a string
+    fail ArgumentError, "project is missing" if project.empty?
+
     if keyfile.nil?
       credentials = Gcloud::Vision::Credentials.default scope: scope
     else
       credentials = Gcloud::Vision::Credentials.new keyfile, scope: scope
     end
-    Gcloud::Vision::Project.new project, credentials
+
+    Gcloud::Vision::Project.new(
+      Gcloud::Vision::Service.new(project, credentials, retries: retries))
   end
 
   ##

--- a/lib/gcloud/vision/project.rb
+++ b/lib/gcloud/vision/project.rb
@@ -53,10 +53,8 @@ module Gcloud
 
       ##
       # @private Creates a new Project instance.
-      def initialize project, credentials
-        project = project.to_s # Always cast to a string
-        fail ArgumentError, "project is missing" if project.empty?
-        @service = Service.new project, credentials
+      def initialize service
+        @service = service
       end
 
       # The Vision project connected to.

--- a/lib/gcloud/vision/service.rb
+++ b/lib/gcloud/vision/service.rb
@@ -32,12 +32,13 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials
+      def initialize project, credentials, retries: nil
         @project = project
         @credentials = credentials
         @service = API::VisionService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
+        @service.request_options.retries = retries || 3
         @service.authorization = @credentials.client
       end
 

--- a/test/gcloud/bigquery/table_extract_test.rb
+++ b/test/gcloud/bigquery/table_extract_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Gcloud::Bigquery::Table, :extract, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
-  let(:storage) { Gcloud::Storage::Project.new project, credentials }
+  let(:storage) { Gcloud::Storage::Project.new(Gcloud::Storage::Service.new(project, credentials)) }
   let(:extract_bucket_gapi) {  Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
   let(:extract_bucket) { Gcloud::Storage::Bucket.from_gapi extract_bucket_gapi,
                                                            storage.service }

--- a/test/gcloud/bigquery/table_load_storage_test.rb
+++ b/test/gcloud/bigquery/table_load_storage_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Gcloud::Bigquery::Table, :load, :storage, :mock_bigquery do
   let(:credentials) { OpenStruct.new }
-  let(:storage) { Gcloud::Storage::Project.new project, credentials }
+  let(:storage) { Gcloud::Storage::Project.new(Gcloud::Storage::Service.new(project, credentials)) }
   let(:load_bucket_gapi) { Google::Apis::StorageV1::Bucket.from_json random_bucket_hash.to_json }
   let(:load_bucket) { Gcloud::Storage::Bucket.from_gapi load_bucket_gapi, storage.service }
   let(:load_file) { storage_file }

--- a/test/gcloud/datastore/dataset_test.rb
+++ b/test/gcloud/datastore/dataset_test.rb
@@ -18,7 +18,7 @@ require "gcloud/datastore"
 describe Gcloud::Datastore::Dataset do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Gcloud::Datastore::Dataset.new project, credentials }
+  let(:dataset)     { Gcloud::Datastore::Dataset.new(Gcloud::Datastore::Service.new(project, credentials)) }
   let(:run_query_res) do
     run_query_res_entities = 2.times.map do |i|
       Google::Datastore::V1beta3::EntityResult.new(

--- a/test/gcloud/datastore/lookup_results/find_all_test.rb
+++ b/test/gcloud/datastore/lookup_results/find_all_test.rb
@@ -18,7 +18,7 @@ require "gcloud/datastore"
 describe Gcloud::Datastore::Dataset, :find_all do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Gcloud::Datastore::Dataset.new project, credentials }
+  let(:dataset)     { Gcloud::Datastore::Dataset.new(Gcloud::Datastore::Service.new(project, credentials)) }
   # let(:query_cursor) { Gcloud::Datastore::Cursor.new "c3VwZXJhd2Vzb21lIQ==" }
 
   let(:key1) { Gcloud::Datastore::Key.new "ds-test", "thingie1" }

--- a/test/gcloud/datastore/query_results/all_test.rb
+++ b/test/gcloud/datastore/query_results/all_test.rb
@@ -18,7 +18,7 @@ require "gcloud/datastore"
 describe Gcloud::Datastore::Dataset, :all do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Gcloud::Datastore::Dataset.new project, credentials }
+  let(:dataset)     { Gcloud::Datastore::Dataset.new(Gcloud::Datastore::Service.new(project, credentials)) }
   let(:first_run_query_req) do
     Google::Datastore::V1beta3::RunQueryRequest.new(
       project_id: project,

--- a/test/gcloud/datastore/query_results/all_with_more_test.rb
+++ b/test/gcloud/datastore/query_results/all_with_more_test.rb
@@ -18,7 +18,7 @@ require "gcloud/datastore"
 describe Gcloud::Datastore::Dataset, :all_with_more do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Gcloud::Datastore::Dataset.new project, credentials }
+  let(:dataset)     { Gcloud::Datastore::Dataset.new(Gcloud::Datastore::Service.new(project, credentials)) }
   let(:first_run_query_req) do
     Google::Datastore::V1beta3::RunQueryRequest.new(
       project_id: project,

--- a/test/gcloud/datastore/query_results_test.rb
+++ b/test/gcloud/datastore/query_results_test.rb
@@ -18,7 +18,7 @@ require "gcloud/datastore"
 describe Gcloud::Datastore::Dataset::QueryResults do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Gcloud::Datastore::Dataset.new project, credentials }
+  let(:dataset)     { Gcloud::Datastore::Dataset.new(Gcloud::Datastore::Service.new(project, credentials)) }
   let(:run_query_res) do
     run_query_res_entities = 2.times.map do |i|
       Google::Datastore::V1beta3::EntityResult.new(

--- a/test/gcloud/datastore/transaction_test.rb
+++ b/test/gcloud/datastore/transaction_test.rb
@@ -18,7 +18,7 @@ require "gcloud/datastore"
 describe Gcloud::Datastore::Transaction do
   let(:project)     { "my-todo-project" }
   let(:credentials) { OpenStruct.new }
-  let(:dataset)     { Gcloud::Datastore::Dataset.new project, credentials }
+  let(:dataset)     { Gcloud::Datastore::Dataset.new(Gcloud::Datastore::Service.new(project, credentials)) }
   let(:service) do
     s = dataset.service
     s.mocked_datastore = Minitest::Mock.new

--- a/test/gcloud/gcloud_test.rb
+++ b/test/gcloud/gcloud_test.rb
@@ -20,10 +20,11 @@ require "gcloud/pubsub"
 describe Gcloud do
   it "calls out to Gcloud.datastore" do
     gcloud = Gcloud.new
-    stubbed_datastore = ->(project, keyfile, scope: nil) {
+    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
+      retries.must_be :nil?
       "datastore-project-object-empty"
     }
     Gcloud.stub :datastore, stubbed_datastore do
@@ -34,10 +35,11 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.datastore" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_datastore = ->(project, keyfile, scope: nil) {
+    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
+      retries.must_be :nil?
       "datastore-project-object"
     }
     Gcloud.stub :datastore, stubbed_datastore do
@@ -48,24 +50,26 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.datastore" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_datastore = ->(project, keyfile, scope: nil) {
+    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
+      retries.must_equal 5
       "datastore-project-object-scoped"
     }
     Gcloud.stub :datastore, stubbed_datastore do
-      dataset = gcloud.datastore scope: "http://example.com/scope"
+      dataset = gcloud.datastore scope: "http://example.com/scope", retries: 5
       dataset.must_equal "datastore-project-object-scoped"
     end
   end
 
   it "calls out to Gcloud.storage" do
     gcloud = Gcloud.new
-    stubbed_storage = ->(project, keyfile, scope: nil) {
+    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
+      retries.must_be :nil?
       "storage-project-object-empty"
     }
     Gcloud.stub :storage, stubbed_storage do
@@ -76,10 +80,11 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.storage" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_storage = ->(project, keyfile, scope: nil) {
+    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
+      retries.must_be :nil?
       "storage-project-object"
     }
     Gcloud.stub :storage, stubbed_storage do
@@ -90,24 +95,26 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.storage" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_storage = ->(project, keyfile, scope: nil) {
+    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
+      retries.must_equal 5
       "storage-project-object-scoped"
     }
     Gcloud.stub :storage, stubbed_storage do
-      dataset = gcloud.storage scope: "http://example.com/scope"
+      dataset = gcloud.storage scope: "http://example.com/scope", retries: 5
       dataset.must_equal "storage-project-object-scoped"
     end
   end
 
   it "calls out to Gcloud.pubsub" do
     gcloud = Gcloud.new
-    stubbed_pubsub = ->(project, keyfile, scope: nil) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
+      retries.must_be :nil?
       "pubsub-project-object-empty"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
@@ -118,10 +125,11 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.pubsub" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_pubsub = ->(project, keyfile, scope: nil) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
+      retries.must_be :nil?
       "pubsub-project-object"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
@@ -132,24 +140,26 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.pubsub" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_pubsub = ->(project, keyfile, scope: nil) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
+      retries.must_equal 5
       "pubsub-project-object-scoped"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
-      dataset = gcloud.pubsub scope: "http://example.com/scope"
+      dataset = gcloud.pubsub scope: "http://example.com/scope", retries: 5
       dataset.must_equal "pubsub-project-object-scoped"
     end
   end
 
   it "calls out to Gcloud.bigquery" do
     gcloud = Gcloud.new
-    stubbed_bigquery = ->(project, keyfile, scope: nil) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
+      retries.must_be :nil?
       "bigquery-project-object-empty"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
@@ -160,10 +170,11 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.bigquery" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_bigquery = ->(project, keyfile, scope: nil) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
+      retries.must_be :nil?
       "bigquery-project-object"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
@@ -174,24 +185,26 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.bigquery" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_bigquery = ->(project, keyfile, scope: nil) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
+      retries.must_equal 5
       "bigquery-project-object-scoped"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
-      dataset = gcloud.bigquery scope: "http://example.com/scope"
+      dataset = gcloud.bigquery scope: "http://example.com/scope", retries: 5
       dataset.must_equal "bigquery-project-object-scoped"
     end
   end
 
   it "calls out to Gcloud.dns" do
     gcloud = Gcloud.new
-    stubbed_dns = ->(project, keyfile, scope: nil) {
+    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
+      retries.must_be :nil?
       "dns-project-object-empty"
     }
     Gcloud.stub :dns, stubbed_dns do
@@ -202,10 +215,11 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.dns" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_dns = ->(project, keyfile, scope: nil) {
+    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
+      retries.must_be :nil?
       "dns-project-object"
     }
     Gcloud.stub :dns, stubbed_dns do
@@ -216,14 +230,15 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.dns" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_dns = ->(project, keyfile, scope: nil) {
+    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
+      retries.must_equal 5
       "dns-project-object-scoped"
     }
     Gcloud.stub :dns, stubbed_dns do
-      dataset = gcloud.dns scope: "http://example.com/scope"
+      dataset = gcloud.dns scope: "http://example.com/scope", retries: 5
       dataset.must_equal "dns-project-object-scoped"
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -45,7 +45,7 @@ end
 class MockStorage < Minitest::Spec
   let(:project) { "test" }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
-  let(:storage) { Gcloud::Storage::Project.new(project, credentials) }
+  let(:storage) { Gcloud::Storage::Project.new(Gcloud::Storage::Service.new(project, credentials)) }
 
   # Register this spec type for when :mock_storage is used.
   register_spec_type(self) do |desc, *addl|
@@ -125,7 +125,7 @@ end
 class MockPubsub < Minitest::Spec
   let(:project) { "test" }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
-  let(:pubsub) { Gcloud::Pubsub::Project.new(project, credentials) }
+  let(:pubsub) { Gcloud::Pubsub::Project.new(Gcloud::Pubsub::Service.new(project, credentials)) }
 
   def topics_json num_topics, token = nil
     topics = num_topics.times.map do
@@ -208,7 +208,7 @@ end
 class MockBigquery < Minitest::Spec
   let(:project) { bigquery.service.project }
   let(:credentials) { bigquery.service.credentials }
-  let(:bigquery) { Gcloud::Bigquery::Project.new("test-project", OpenStruct.new) }
+  let(:bigquery) { Gcloud::Bigquery::Project.new(Gcloud::Bigquery::Service.new("test-project", OpenStruct.new)) }
 
   # Register this spec type for when :mock_bigquery is used.
   register_spec_type(self) do |desc, *addl|
@@ -590,7 +590,7 @@ end
 class MockDns < Minitest::Spec
   let(:project) { dns.service.project }
   let(:credentials) { dns.service.credentials }
-  let(:dns) { Gcloud::Dns::Project.new("test", OpenStruct.new) }
+  let(:dns) { Gcloud::Dns::Project.new(Gcloud::Dns::Service.new("test", OpenStruct.new)) }
 
   def random_project_gapi
     Google::Apis::DnsV1::Project.new(
@@ -677,7 +677,7 @@ end
 
 class MockResourceManager < Minitest::Spec
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
-  let(:resource_manager) { Gcloud::ResourceManager::Manager.new(credentials) }
+  let(:resource_manager) { Gcloud::ResourceManager::Manager.new(Gcloud::ResourceManager::Service.new(credentials)) }
 
   # Register this spec type for when :mock_res_man is used.
   register_spec_type(self) do |desc, *addl|
@@ -701,7 +701,7 @@ end
 class MockLogging < Minitest::Spec
   let(:project) { "test" }
   let(:credentials) { OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {})) }
-  let(:logging) { Gcloud::Logging::Project.new(project, credentials) }
+  let(:logging) { Gcloud::Logging::Project.new(Gcloud::Logging::Service.new(project, credentials)) }
 
   # Register this spec type for when :mock_logging is used.
   register_spec_type(self) do |desc, *addl|
@@ -816,7 +816,7 @@ end
 
 class MockTranslate < Minitest::Spec
   let(:key) { "test-api-key" }
-  let(:translate) { Gcloud::Translate::Api.new(key) }
+  let(:translate) { Gcloud::Translate::Api.new(Gcloud::Translate::Service.new(key)) }
 
   # Register this spec type for when :mock_translate is used.
   register_spec_type(self) do |desc, *addl|
@@ -828,7 +828,7 @@ class MockVision < Minitest::Spec
   API = Google::Apis::VisionV1
   let(:project) { vision.service.project }
   let(:credentials) { vision.service.credentials }
-  let(:vision) { Gcloud::Vision::Project.new("test", OpenStruct.new) }
+  let(:vision) { Gcloud::Vision::Project.new(Gcloud::Vision::Service.new("test", OpenStruct.new)) }
 
   # Register this spec type for when :mock_vision is used.
   register_spec_type(self) do |desc, *addl|


### PR DESCRIPTION
Remove Gcloud::Backoff and add retries as optional argument when creating
new service objects.

[closes #463]