### PR TITLE
Update Storage ACL implementation and tests

### DIFF
--- a/acceptance/storage/storage_test.rb
+++ b/acceptance/storage/storage_test.rb
@@ -38,6 +38,93 @@ describe "Storage", :storage do
     bucket.files.map &:delete
   end
 
+  describe "bucket acl" do
+    it "adds a reader" do
+      bucket.acl.private!
+      user_val = "user-blowmage@gmail.com"
+      bucket.acl.readers.wont_include user_val
+      bucket.acl.add_reader user_val
+      bucket.acl.readers.must_include user_val
+      bucket.acl.refresh!
+      bucket.acl.readers.must_include user_val
+      bucket.refresh!
+      bucket.acl.readers.must_include user_val
+    end
+
+    it "adds a writer" do
+      bucket.acl.private!
+      user_val = "user-blowmage@gmail.com"
+      bucket.acl.writers.wont_include user_val
+      bucket.acl.add_writer user_val
+      bucket.acl.writers.must_include user_val
+      bucket.acl.refresh!
+      bucket.acl.writers.must_include user_val
+      bucket.refresh!
+      bucket.acl.writers.must_include user_val
+    end
+
+    it "adds an owner" do
+      bucket.acl.private!
+      user_val = "user-blowmage@gmail.com"
+      bucket.acl.owners.wont_include user_val
+      bucket.acl.add_owner user_val
+      bucket.acl.owners.must_include user_val
+      bucket.acl.refresh!
+      bucket.acl.owners.must_include user_val
+      bucket.refresh!
+      bucket.acl.owners.must_include user_val
+    end
+
+    it "updates predefined rules" do
+      bucket.acl.private!
+      bucket.acl.readers.wont_include "allAuthenticatedUsers"
+      bucket.acl.auth!
+      bucket.acl.readers.must_include "allAuthenticatedUsers"
+      bucket.acl.refresh!
+      bucket.acl.readers.must_include "allAuthenticatedUsers"
+      bucket.refresh!
+      bucket.acl.readers.must_include "allAuthenticatedUsers"
+    end
+  end
+
+
+  describe "bucket default acl" do
+    it "adds a reader" do
+      bucket.default_acl.private!
+      user_val = "user-blowmage@gmail.com"
+      bucket.default_acl.readers.wont_include user_val
+      bucket.default_acl.add_reader user_val
+      bucket.default_acl.readers.must_include user_val
+      bucket.default_acl.refresh!
+      bucket.default_acl.readers.must_include user_val
+      bucket.refresh!
+      bucket.default_acl.readers.must_include user_val
+    end
+
+    it "adds an owner" do
+      bucket.default_acl.private!
+      user_val = "user-blowmage@gmail.com"
+      bucket.default_acl.owners.wont_include user_val
+      bucket.default_acl.add_owner user_val
+      bucket.default_acl.owners.must_include user_val
+      bucket.default_acl.refresh!
+      bucket.default_acl.owners.must_include user_val
+      bucket.refresh!
+      bucket.default_acl.owners.must_include user_val
+    end
+
+    it "updates predefined rules" do
+      bucket.default_acl.private!
+      bucket.default_acl.readers.wont_include "allAuthenticatedUsers"
+      bucket.default_acl.auth!
+      bucket.default_acl.readers.must_include "allAuthenticatedUsers"
+      bucket.default_acl.refresh!
+      bucket.default_acl.readers.must_include "allAuthenticatedUsers"
+      bucket.refresh!
+      bucket.default_acl.readers.must_include "allAuthenticatedUsers"
+    end
+  end
+
   describe "getting buckets" do
     let(:new_buckets) do
       new_bucket_names.map do |b|
@@ -189,6 +276,48 @@ describe "Storage", :storage do
       resp = http.delete uri.request_uri
 
       resp.code.must_equal "204"
+    end
+  end
+
+  describe "file acl" do
+    let(:local_file) { File.new files[:logo][:path] }
+
+    it "adds a reader" do
+      bucket.default_acl.auth!
+      file = bucket.create_file local_file, "ReaderTest.jpg"
+      user_val = "user-blowmage@gmail.com"
+      file.acl.readers.wont_include user_val
+      file.acl.add_reader user_val
+      file.acl.readers.must_include user_val
+      file.acl.refresh!
+      file.acl.readers.must_include user_val
+      file.refresh!
+      file.acl.readers.must_include user_val
+    end
+
+    it "adds an owner" do
+      bucket.default_acl.auth!
+      file = bucket.create_file local_file, "OwnerTest.jpg"
+      user_val = "user-blowmage@gmail.com"
+      file.acl.owners.wont_include user_val
+      file.acl.add_owner user_val
+      file.acl.owners.must_include user_val
+      file.acl.refresh!
+      file.acl.owners.must_include user_val
+      file.refresh!
+      file.acl.owners.must_include user_val
+    end
+
+    it "updates predefined rules" do
+      bucket.default_acl.auth!
+      file = bucket.create_file local_file, "AclTest.jpg"
+      file.acl.readers.must_include "allAuthenticatedUsers"
+      file.acl.private!
+      file.acl.readers.must_be :empty?
+      file.acl.refresh!
+      file.acl.readers.must_be :empty?
+      file.refresh!
+      file.acl.readers.must_be :empty?
     end
   end
 end

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -490,7 +490,11 @@ module Gcloud
         #
         def reload!
           gapi = @service.list_default_acls @bucket
-          acls = gapi.items
+          acls = Array(gapi.items).map do |acl|
+            return acl if acl.is_a? Google::Apis::StorageV1::ObjectAccessControl
+            fail "Unknown ACL format: #{acl.class}" unless acl.is_a? Hash
+            Google::Apis::StorageV1::ObjectAccessControl.from_json acl.to_json
+          end
           @owners  = entities_from_acls acls, "OWNER"
           @readers = entities_from_acls acls, "READER"
         end

--- a/lib/gcloud/storage/bucket/acl.rb
+++ b/lib/gcloud/storage/bucket/acl.rb
@@ -74,7 +74,7 @@ module Gcloud
         #
         def reload!
           gapi = @service.list_bucket_acls @bucket
-          acls = gapi.items
+          acls = Array(gapi.items)
           @owners  = entities_from_acls acls, "OWNER"
           @writers = entities_from_acls acls, "WRITER"
           @readers = entities_from_acls acls, "READER"
@@ -472,7 +472,6 @@ module Gcloud
           @bucket = bucket.name
           @service = bucket.service
           @owners  = nil
-          @writers = nil
           @readers = nil
         end
 
@@ -493,7 +492,6 @@ module Gcloud
           gapi = @service.list_default_acls @bucket
           acls = gapi.items
           @owners  = entities_from_acls acls, "OWNER"
-          @writers = entities_from_acls acls, "WRITER"
           @readers = entities_from_acls acls, "READER"
         end
         alias_method :refresh!, :reload!
@@ -516,26 +514,6 @@ module Gcloud
         def owners
           reload! if @owners.nil?
           @owners
-        end
-
-        ##
-        # Lists the default writers for files in the bucket.
-        #
-        # @return [Array<String>]
-        #
-        # @example
-        #   require "gcloud"
-        #
-        #   gcloud = Gcloud.new
-        #   storage = gcloud.storage
-        #
-        #   bucket = storage.bucket "my-bucket"
-        #
-        #   bucket.default_acl.writers.each { |writer| puts writer }
-        #
-        def writers
-          reload! if @writers.nil?
-          @writers
         end
 
         ##
@@ -599,50 +577,6 @@ module Gcloud
           gapi = @service.insert_default_acl @bucket, entity, "OWNER"
           entity = gapi.entity
           @owners.push entity unless @owners.nil?
-          entity
-        end
-
-        ##
-        # Grants default writer permission to files in the bucket.
-        #
-        # @param [String] entity The entity holding the permission, in one of
-        #   the following forms:
-        #
-        #   * user-userId
-        #   * user-email
-        #   * group-groupId
-        #   * group-email
-        #   * domain-domain
-        #   * project-team-projectId
-        #   * allUsers
-        #   * allAuthenticatedUsers
-        #
-        # @example Grant access to a user by pre-pending `"user-"` to an email:
-        #   require "gcloud"
-        #
-        #   gcloud = Gcloud.new
-        #   storage = gcloud.storage
-        #
-        #   bucket = storage.bucket "my-bucket"
-        #
-        #   email = "heidi@example.net"
-        #   bucket.default_acl.add_writer "user-#{email}"
-        #
-        # @example Grant access to a group by pre-pending `"group-"` to an email
-        #   require "gcloud"
-        #
-        #   gcloud = Gcloud.new
-        #   storage = gcloud.storage
-        #
-        #   bucket = storage.bucket "my-bucket"
-        #
-        #   email = "authors@example.net"
-        #   bucket.default_acl.add_writer "group-#{email}"
-        #
-        def add_writer entity
-          gapi = @service.insert_default_acl @bucket, entity, "WRITER"
-          entity = gapi.entity
-          @writers.push entity unless @writers.nil?
           entity
         end
 
@@ -720,7 +654,6 @@ module Gcloud
         def delete entity
           @service.delete_default_acl @bucket, entity
           @owners.delete entity  unless @owners.nil?
-          @writers.delete entity unless @writers.nil?
           @readers.delete entity unless @readers.nil?
           true
         end
@@ -853,14 +786,12 @@ module Gcloud
 
         def clear!
           @owners  = nil
-          @writers = nil
           @readers = nil
           self
         end
 
         def update_predefined_default_acl! acl_role
-          @service.patch_bucket @bucket, predefined_default_acl: acl_role,
-                                         default_acl: []
+          @service.patch_bucket @bucket, predefined_default_acl: acl_role
           clear!
         end
 

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -58,7 +58,6 @@ module Gcloud
           @file = file.name
           @service = file.service
           @owners  = nil
-          @writers = nil
           @readers = nil
         end
 
@@ -80,7 +79,6 @@ module Gcloud
           gapi = @service.list_file_acls @bucket, @file
           acls = gapi.items
           @owners  = entities_from_acls acls, "OWNER"
-          @writers = entities_from_acls acls, "WRITER"
           @readers = entities_from_acls acls, "READER"
         end
         alias_method :refresh!, :reload!
@@ -104,27 +102,6 @@ module Gcloud
         def owners
           reload! if @owners.nil?
           @owners
-        end
-
-        ##
-        # Lists the owners of the file.
-        #
-        # @return [Array<String>]
-        #
-        # @example
-        #   require "gcloud"
-        #
-        #   gcloud = Gcloud.new
-        #   storage = gcloud.storage
-        #
-        #   bucket = storage.bucket "my-bucket"
-        #
-        #   file = bucket.file "path/to/my-file.ext"
-        #   file.acl.writers.each { |writer| puts writer }
-        #
-        def writers
-          reload! if @writers.nil?
-          @writers
         end
 
         ##
@@ -196,57 +173,6 @@ module Gcloud
                                           options
           entity = gapi.entity
           @owners.push entity unless @owners.nil?
-          entity
-        end
-
-        ##
-        # Grants writer permission to the file.
-        #
-        # @param [String] entity The entity holding the permission, in one of
-        #   the following forms:
-        #
-        #   * user-userId
-        #   * user-email
-        #   * group-groupId
-        #   * group-email
-        #   * domain-domain
-        #   * project-team-projectId
-        #   * allUsers
-        #   * allAuthenticatedUsers
-        #
-        # @param [Integer] generation When present, selects a specific revision
-        #   of this object. Default is the latest version.
-        #
-        # @example Grant access to a user by pre-pending `"user-"` to an email:
-        #   require "gcloud"
-        #
-        #   gcloud = Gcloud.new
-        #   storage = gcloud.storage
-        #
-        #   bucket = storage.bucket "my-bucket"
-        #
-        #   file = bucket.file "path/to/my-file.ext"
-        #   email = "heidi@example.net"
-        #   file.acl.add_writer "user-#{email}"
-        #
-        # @example Grant access to a group by pre-pending `"group-"` to an email
-        #   require "gcloud"
-        #
-        #   gcloud = Gcloud.new
-        #   storage = gcloud.storage
-        #
-        #   bucket = storage.bucket "my-bucket"
-        #
-        #   file = bucket.file "path/to/my-file.ext"
-        #   email = "authors@example.net"
-        #   file.acl.add_writer "group-#{email}"
-        #
-        def add_writer entity, generation: nil
-          options = { generation: generation }
-          gapi = @service.insert_file_acl @bucket, @file, entity, "WRITER",
-                                          options
-          entity = gapi.entity
-          @writers.push entity unless @writers.nil?
           entity
         end
 
@@ -335,7 +261,6 @@ module Gcloud
           options = { generation: generation }
           @service.delete_file_acl @bucket, @file, entity, options
           @owners.delete entity  unless @owners.nil?
-          @writers.delete entity unless @writers.nil?
           @readers.delete entity unless @readers.nil?
           true
         end
@@ -474,7 +399,6 @@ module Gcloud
 
         def clear!
           @owners  = nil
-          @writers = nil
           @readers = nil
           self
         end

--- a/lib/gcloud/storage/file/acl.rb
+++ b/lib/gcloud/storage/file/acl.rb
@@ -77,7 +77,11 @@ module Gcloud
         #
         def reload!
           gapi = @service.list_file_acls @bucket, @file
-          acls = gapi.items
+          acls = Array(gapi.items).map do |acl|
+            return acl if acl.is_a? Google::Apis::StorageV1::ObjectAccessControl
+            fail "Unknown ACL format: #{acl.class}" unless acl.is_a? Hash
+            Google::Apis::StorageV1::ObjectAccessControl.from_json acl.to_json
+          end
           @owners  = entities_from_acls acls, "OWNER"
           @readers = entities_from_acls acls, "READER"
         end

--- a/lib/gcloud/storage/service.rb
+++ b/lib/gcloud/storage/service.rb
@@ -91,6 +91,8 @@ module Gcloud
         predefined_default_acl = options.delete :predefined_default_acl
         patched_bucket = Google::Apis::StorageV1::Bucket.new options
 
+        patched_bucket.default_object_acl = nil if predefined_default_acl
+
         service.patch_bucket \
           bucket_name, patched_bucket,
           predefined_acl: predefined_acl,

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -168,6 +168,39 @@ namespace :test do
 
   namespace :acceptance do
 
+    desc "Runs acceptance tests with coverage."
+    task :coverage, :project, :keyfile do |t, args|
+      project = args[:project]
+      project ||= ENV["GCLOUD_TEST_PROJECT"] || ENV["DATASTORE_TEST_PROJECT"]
+      keyfile = args[:keyfile]
+      keyfile ||= ENV["GCLOUD_TEST_KEYFILE"] || ENV["DATASTORE_TEST_KEYFILE"]
+      if project.nil? || keyfile.nil?
+        fail "You must provide a project and keyfile. e.g. rake test:coverage[test123, /path/to/keyfile.json] or GCLOUD_TEST_PROJECT=test123 GCLOUD_TEST_KEYFILE=/path/to/keyfile.json rake test:coverage"
+      end
+      # always overwrite when running tests
+      ENV["DATASTORE_PROJECT"] = project
+      ENV["DATASTORE_KEYFILE"] = keyfile
+      ENV["STORAGE_PROJECT"] = project
+      ENV["STORAGE_KEYFILE"] = keyfile
+      ENV["PUBSUB_PROJECT"] = project
+      ENV["PUBSUB_KEYFILE"] = keyfile
+      ENV["BIGQUERY_PROJECT"] = project
+      ENV["BIGQUERY_KEYFILE"] = keyfile
+      ENV["DNS_PROJECT"] = project
+      ENV["DNS_KEYFILE"] = keyfile
+      ENV["LOGGING_PROJECT"] = project
+      ENV["LOGGING_KEYFILE"] = keyfile
+      ENV["VISION_PROJECT"] = project
+      ENV["VISION_KEYFILE"] = keyfile
+
+      require "simplecov"
+      SimpleCov.start("test_frameworks") { command_name "Minitest" }
+
+      # Rake::Task["test"].execute
+      $LOAD_PATH.unshift "lib", "test", "acceptance"
+      Dir.glob("acceptance/**/*_test.rb").each { |file| require_relative "../#{file}"}
+    end
+
     desc "Runs the datastore acceptance tests."
     task :datastore, :project, :keyfile do |t, args|
       project = args[:project]


### PR DESCRIPTION
The original implementation included WRITER roles for Bucket#default_acl and File#acl.
But the service does not allow WRITER roles for file or default file acl.
Remove WRITER role from file acl and add acceptance tests to cover acl functionality.