### PR TITLE
Relax mime-types dependency

### DIFF
--- a/gcloud.gemspec
+++ b/gcloud.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency                  "grpc", "~> 0.13.1"
   gem.add_dependency                  "google-protobuf", "= 3.0.0.alpha.5.0.5.1"
   gem.add_dependency                  "google-api-client", "~> 0.9.9"
-  gem.add_dependency                  "mime-types", "~> 2.4"
+  gem.add_dependency                  "mime-types", [">= 2.4", "< 4.0"]
   gem.add_dependency                  "digest-crc", "~> 0.4"
   gem.add_dependency                  "zonefile", "~> 1.04"
 


### PR DESCRIPTION
Allow mime-types 3 to be used, which addresses many performance issues.
Originally the dependency was pinned to 2.x, since we didn't know what changes
would be made in 3.x, but so far there haven't been any affecting gcloud.

[closes #765]