### PR TITLE
Add timeout optional argument

### DIFF
--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -44,6 +44,7 @@ module Gcloud
   #   path the file must be readable.
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud]
   #
@@ -55,11 +56,12 @@ module Gcloud
   #   pubsub  = gcloud.pubsub
   #   storage = gcloud.storage
   #
-  def self.new project = nil, keyfile = nil, retries: nil
+  def self.new project = nil, keyfile = nil, retries: nil, timeout: nil
     gcloud = Object.new
     gcloud.instance_variable_set "@project", project
     gcloud.instance_variable_set "@keyfile", keyfile
     gcloud.instance_variable_set "@retries", retries
+    gcloud.instance_variable_set "@timeout", timeout
     gcloud.extend Gcloud
     gcloud
   end
@@ -81,6 +83,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/datastore`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Datastore::Dataset]
   #
@@ -106,10 +109,11 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   datastore = gcloud.datastore scope: platform_scope
   #
-  def datastore scope: nil, retries: nil
+  def datastore scope: nil, retries: nil, timeout: nil
     require "gcloud/datastore"
     Gcloud.datastore @project, @keyfile, scope: scope,
-                                         retries: (retries || @retries)
+                                         retries: (retries || @retries),
+                                         timeout: (timeout || @timeout)
   end
 
   ##
@@ -132,6 +136,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Storage::Project]
   #
@@ -150,10 +155,11 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/devstorage.read_only"
   #   readonly_storage = gcloud.storage scope: readonly_scope
   #
-  def storage scope: nil, retries: nil
+  def storage scope: nil, retries: nil, timeout: nil
     require "gcloud/storage"
     Gcloud.storage @project, @keyfile, scope: scope,
-                                       retries: (retries || @retries)
+                                       retries: (retries || @retries),
+                                       timeout: (timeout || @timeout)
   end
 
   ##
@@ -173,6 +179,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/pubsub`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Pubsub::Project]
   #
@@ -191,10 +198,11 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   pubsub = gcloud.pubsub scope: platform_scope
   #
-  def pubsub scope: nil, retries: nil
+  def pubsub scope: nil, retries: nil, timeout: nil
     require "gcloud/pubsub"
     Gcloud.pubsub @project, @keyfile, scope: scope,
-                                      retries: (retries || @retries)
+                                      retries: (retries || @retries),
+                                      timeout: (timeout || @timeout)
   end
 
   ##
@@ -214,6 +222,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/bigquery`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Bigquery::Project]
   #
@@ -235,10 +244,11 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   bigquery = gcloud.bigquery scope: platform_scope
   #
-  def bigquery scope: nil, retries: nil
+  def bigquery scope: nil, retries: nil, timeout: nil
     require "gcloud/bigquery"
     Gcloud.bigquery @project, @keyfile, scope: scope,
-                                        retries: (retries || @retries)
+                                        retries: (retries || @retries),
+                                        timeout: (timeout || @timeout)
   end
 
   ##
@@ -258,6 +268,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Dns::Project]
   #
@@ -278,10 +289,11 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/ndev.clouddns.readonly"
   #   dns = gcloud.dns scope: readonly_scope
   #
-  def dns scope: nil, retries: nil
+  def dns scope: nil, retries: nil, timeout: nil
     require "gcloud/dns"
     Gcloud.dns @project, @keyfile, scope: scope,
-                                   retries: (retries || @retries)
+                                   retries: (retries || @retries),
+                                   timeout: (timeout || @timeout)
   end
 
   # rubocop:disable Metrics/LineLength
@@ -305,6 +317,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/cloud-platform`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::ResourceManager::Manager]
   #
@@ -324,10 +337,11 @@ module Gcloud
   #   readonly_scope = "https://www.googleapis.com/auth/cloudresourcemanager.readonly"
   #   resource_manager = gcloud.resource_manager scope: readonly_scope
   #
-  def resource_manager scope: nil, retries: nil
+  def resource_manager scope: nil, retries: nil, timeout: nil
     require "gcloud/resource_manager"
     Gcloud.resource_manager @keyfile, scope: scope,
-                                      retries: (retries || @retries)
+                                      retries: (retries || @retries),
+                                      timeout: (timeout || @timeout)
   end
 
   # rubocop:enable Metrics/LineLength
@@ -349,6 +363,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/logging.admin`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Logging::Project]
   #
@@ -366,10 +381,11 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   logging = gcloud.logging scope: platform_scope
   #
-  def logging scope: nil, retries: nil
+  def logging scope: nil, retries: nil, timeout: nil
     require "gcloud/logging"
     Gcloud.logging @project, @keyfile, scope: scope,
-                                       retries: (retries || @retries)
+                                       retries: (retries || @retries),
+                                       timeout: (timeout || @timeout)
   end
 
   ##
@@ -387,6 +403,7 @@ module Gcloud
   # @param [String] key a public API access key (not an OAuth 2.0 token)
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Translate::Api]
   #
@@ -410,9 +427,10 @@ module Gcloud
   #   translation = translate.translate "Hello world!", to: "la"
   #   translation.text #=> "Salve mundi!"
   #
-  def translate key = nil, retries: nil
+  def translate key = nil, retries: nil, timeout: nil
     require "gcloud/translate"
-    Gcloud.translate key, retries: (retries || @retries)
+    Gcloud.translate key, retries: (retries || @retries),
+                          timeout: (timeout || @timeout)
   end
 
   ##
@@ -429,6 +447,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/cloud-platform`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Vision::Project]
   #
@@ -450,9 +469,10 @@ module Gcloud
   #   platform_scope = "https://www.googleapis.com/auth/cloud-platform"
   #   vision = gcloud.vision scope: platform_scope
   #
-  def vision scope: nil, retries: nil
+  def vision scope: nil, retries: nil, timeout: nil
     require "gcloud/vision"
     Gcloud.vision @project, @keyfile, scope: scope,
-                                      retries: (retries || @retries)
+                                      retries: (retries || @retries),
+                                      timeout: (timeout || @timeout)
   end
 end

--- a/lib/gcloud/bigquery.rb
+++ b/lib/gcloud/bigquery.rb
@@ -37,7 +37,8 @@ module Gcloud
   #
   #   * `https://www.googleapis.com/auth/bigquery`
   # @param [Integer] retries Number of times to retry requests on server error.
-  #   The default value is `3`. Optional., retries: nil
+  #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Bigquery::Project]
   #
@@ -48,7 +49,8 @@ module Gcloud
   #   dataset = bigquery.dataset "my_dataset"
   #   table = dataset.table "my_table"
   #
-  def self.bigquery project = nil, keyfile = nil, scope: nil, retries: nil
+  def self.bigquery project = nil, keyfile = nil, scope: nil, retries: nil,
+                    timeout: nil
     project ||= Gcloud::Bigquery::Project.default_project
     project = project.to_s # Always cast to a string
     fail ArgumentError, "project is missing" if project.empty?
@@ -60,7 +62,8 @@ module Gcloud
     end
 
     Gcloud::Bigquery::Project.new(
-      Gcloud::Bigquery::Service.new(project, credentials, retries: retries))
+      Gcloud::Bigquery::Service.new(
+        project, credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/bigquery/service.rb
+++ b/lib/gcloud/bigquery/service.rb
@@ -37,7 +37,7 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials, retries: nil
+      def initialize project, credentials, retries: nil, timeout: nil
         @project = project
         @credentials = credentials
         @credentials = credentials
@@ -45,6 +45,7 @@ module Gcloud
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
         @service.request_options.retries = retries || 3
+        @service.request_options.timeout_sec = timeout if timeout
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/datastore.rb
+++ b/lib/gcloud/datastore.rb
@@ -41,6 +41,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/datastore`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Datastore::Dataset]
   #
@@ -59,7 +60,8 @@ module Gcloud
   #
   #   datastore.save task
   #
-  def self.datastore project = nil, keyfile = nil, scope: nil, retries: nil
+  def self.datastore project = nil, keyfile = nil, scope: nil, retries: nil,
+                     timeout: nil
     project ||= Gcloud::Datastore::Dataset.default_project
     project = project.to_s # Always cast to a string
     fail ArgumentError, "project is missing" if project.empty?
@@ -78,7 +80,8 @@ module Gcloud
     end
 
     Gcloud::Datastore::Dataset.new(
-      Gcloud::Datastore::Service.new(project, credentials, retries: retries))
+      Gcloud::Datastore::Service.new(
+        project, credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/datastore/service.rb
+++ b/lib/gcloud/datastore/service.rb
@@ -23,15 +23,16 @@ module Gcloud
     # @private Represents the gRPC Datastore service, including all the API
     # methods.
     class Service
-      attr_accessor :project, :credentials, :host, :retries
+      attr_accessor :project, :credentials, :host, :retries, :timeout
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials, host: nil, retries: nil
+      def initialize project, credentials, host: nil, retries: nil, timeout: nil
         @project = project
         @credentials = credentials
         @host = host || "datastore.googleapis.com"
         @retries = retries
+        @timeout = timeout
       end
 
       def creds
@@ -43,7 +44,7 @@ module Gcloud
       def datastore
         return mocked_datastore if mocked_datastore
         @datastore ||= Google::Datastore::V1beta3::Datastore::Stub.new(
-          host, creds)
+          host, creds, timeout: timeout)
       end
       attr_accessor :mocked_datastore
 

--- a/lib/gcloud/dns.rb
+++ b/lib/gcloud/dns.rb
@@ -38,6 +38,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/ndev.clouddns.readwrite`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Dns::Project]
   #
@@ -49,7 +50,8 @@ module Gcloud
   #
   #   zone = dns.zone "example-com"
   #
-  def self.dns project = nil, keyfile = nil, scope: nil, retries: nil
+  def self.dns project = nil, keyfile = nil, scope: nil, retries: nil,
+               timeout: nil
     project ||= Gcloud::Dns::Project.default_project
     project = project.to_s # Always cast to a string
     fail ArgumentError, "project is missing" if project.empty?
@@ -61,7 +63,8 @@ module Gcloud
     end
 
     Gcloud::Dns::Project.new(
-      Gcloud::Dns::Service.new(project, credentials, retries: retries))
+      Gcloud::Dns::Service.new(
+        project, credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/dns/service.rb
+++ b/lib/gcloud/dns/service.rb
@@ -32,13 +32,14 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials, retries: nil
+      def initialize project, credentials, retries: nil, timeout: nil
         @project = project
         @credentials = credentials
         @service = API::DnsService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
         @service.request_options.retries = retries || 3
+        @service.request_options.timeout_sec = timeout if timeout
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -38,6 +38,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/logging.admin`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Logging::Project]
   #
@@ -48,7 +49,8 @@ module Gcloud
   #   logging = gcloud.logging
   #   # ...
   #
-  def self.logging project = nil, keyfile = nil, scope: nil, retries: nil
+  def self.logging project = nil, keyfile = nil, scope: nil, retries: nil,
+                   timeout: nil
     project ||= Gcloud::Logging::Project.default_project
     project = project.to_s # Always cast to a string
     fail ArgumentError, "project is missing" if project.empty?
@@ -60,7 +62,8 @@ module Gcloud
     end
 
     Gcloud::Logging::Project.new(
-      Gcloud::Logging::Service.new(project, credentials, retries: retries))
+      Gcloud::Logging::Service.new(
+        project, credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/logging/service.rb
+++ b/lib/gcloud/logging/service.rb
@@ -26,15 +26,16 @@ module Gcloud
     # @private Represents the gRPC Logging service, including all the API
     # methods.
     class Service
-      attr_accessor :project, :credentials, :host, :retries
+      attr_accessor :project, :credentials, :host, :retries, :timeout
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials, host: nil, retries: nil
+      def initialize project, credentials, host: nil, retries: nil, timeout: nil
         @project = project
         @credentials = credentials
         @host = host || "logging.googleapis.com"
         @retries = retries
+        @timeout = timeout
       end
 
       def creds
@@ -44,19 +45,22 @@ module Gcloud
 
       def logging
         return mocked_logging if mocked_logging
-        @logging ||= Google::Logging::V2::LoggingServiceV2::Stub.new host, creds
+        @logging ||= Google::Logging::V2::LoggingServiceV2::Stub.new(
+          host, creds, timeout: timeout)
       end
       attr_accessor :mocked_logging
 
       def sinks
         return mocked_sinks if mocked_sinks
-        @sinks ||= Google::Logging::V2::ConfigServiceV2::Stub.new host, creds
+        @sinks ||= Google::Logging::V2::ConfigServiceV2::Stub.new(
+          host, creds, timeout: timeout)
       end
       attr_accessor :mocked_sinks
 
       def metrics
         return mocked_metrics if mocked_metrics
-        @metrics ||= Google::Logging::V2::MetricsServiceV2::Stub.new host, creds
+        @metrics ||= Google::Logging::V2::MetricsServiceV2::Stub.new(
+          host, creds, timeout: timeout)
       end
       attr_accessor :mocked_metrics
 

--- a/lib/gcloud/pubsub.rb
+++ b/lib/gcloud/pubsub.rb
@@ -38,6 +38,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/pubsub`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Pubsub::Project]
   #
@@ -49,7 +50,8 @@ module Gcloud
   #   topic = pubsub.topic "my-topic"
   #   topic.publish "task completed"
   #
-  def self.pubsub project = nil, keyfile = nil, scope: nil, retries: nil
+  def self.pubsub project = nil, keyfile = nil, scope: nil, retries: nil,
+                  timeout: nil
     project ||= Gcloud::Pubsub::Project.default_project
     if ENV["PUBSUB_EMULATOR_HOST"]
       ps = Gcloud::Pubsub::Project.new project, :this_channel_is_insecure
@@ -62,7 +64,8 @@ module Gcloud
       credentials = Gcloud::Pubsub::Credentials.new keyfile, scope: scope
     end
     Gcloud::Pubsub::Project.new(
-      Gcloud::Pubsub::Service.new(project, credentials, retries: retries))
+      Gcloud::Pubsub::Service.new(
+        project, credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/pubsub/service.rb
+++ b/lib/gcloud/pubsub/service.rb
@@ -26,15 +26,16 @@ module Gcloud
     # @private Represents the gRPC Pub/Sub service, including all the API
     # methods.
     class Service
-      attr_accessor :project, :credentials, :host, :retries
+      attr_accessor :project, :credentials, :host, :retries, :timeout
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials, host: nil, retries: nil
+      def initialize project, credentials, host: nil, retries: nil, timeout: nil
         @project = project
         @credentials = credentials
         @host = host || "pubsub.googleapis.com"
         @retries = retries
+        @timeout = timeout
       end
 
       def creds
@@ -45,19 +46,22 @@ module Gcloud
 
       def subscriber
         return mocked_subscriber if mocked_subscriber
-        @subscriber ||= Google::Pubsub::V1::Subscriber::Stub.new host, creds
+        @subscriber ||= Google::Pubsub::V1::Subscriber::Stub.new(
+          host, creds, timeout: timeout)
       end
       attr_accessor :mocked_subscriber
 
       def publisher
         return mocked_publisher if mocked_publisher
-        @publisher ||= Google::Pubsub::V1::Publisher::Stub.new host, creds
+        @publisher ||= Google::Pubsub::V1::Publisher::Stub.new(
+          host, creds, timeout: timeout)
       end
       attr_accessor :mocked_publisher
 
       def iam
         return mocked_iam if mocked_iam
-        @iam ||= Google::Iam::V1::IAMPolicy::Stub.new host, creds
+        @iam ||= Google::Iam::V1::IAMPolicy::Stub.new(
+          host, creds, timeout: timeout)
       end
       attr_accessor :mocked_iam
 

--- a/lib/gcloud/resource_manager.rb
+++ b/lib/gcloud/resource_manager.rb
@@ -36,6 +36,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/cloud-platform`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::ResourceManager::Manager]
   #
@@ -47,7 +48,8 @@ module Gcloud
   #     puts projects.project_id
   #   end
   #
-  def self.resource_manager keyfile = nil, scope: nil, retries: nil
+  def self.resource_manager keyfile = nil, scope: nil, retries: nil,
+                            timeout: nil
     if keyfile.nil?
       credentials = Gcloud::ResourceManager::Credentials.default scope: scope
     else
@@ -55,7 +57,8 @@ module Gcloud
                                                              scope: scope
     end
     Gcloud::ResourceManager::Manager.new(
-      Gcloud::ResourceManager::Service.new(credentials, retries: retries))
+      Gcloud::ResourceManager::Service.new(
+        credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/resource_manager/service.rb
+++ b/lib/gcloud/resource_manager/service.rb
@@ -32,12 +32,13 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize credentials, retries: nil
+      def initialize credentials, retries: nil, timeout: nil
         @credentials = credentials
         @service = API::CloudResourceManagerService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
         @service.request_options.retries = retries || 3
+        @service.request_options.timeout_sec = timeout if timeout
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/storage.rb
+++ b/lib/gcloud/storage.rb
@@ -38,6 +38,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/devstorage.full_control`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Storage::Project]
   #
@@ -50,7 +51,8 @@ module Gcloud
   #   bucket = storage.bucket "my-bucket"
   #   file = bucket.file "path/to/my-file.ext"
   #
-  def self.storage project = nil, keyfile = nil, scope: nil, retries: nil
+  def self.storage project = nil, keyfile = nil, scope: nil, retries: nil,
+                   timeout: nil
     project ||= Gcloud::Storage::Project.default_project
     project = project.to_s # Always cast to a string
     fail ArgumentError, "project is missing" if project.empty?
@@ -62,7 +64,8 @@ module Gcloud
     end
 
     Gcloud::Storage::Project.new(
-      Gcloud::Storage::Service.new(project, credentials, retries: retries))
+      Gcloud::Storage::Service.new(
+        project, credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/storage/service.rb
+++ b/lib/gcloud/storage/service.rb
@@ -38,7 +38,7 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials, retries: nil
+      def initialize project, credentials, retries: nil, timeout: nil
         @project = project
         @credentials = credentials
         @credentials = credentials
@@ -46,6 +46,7 @@ module Gcloud
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
         @service.request_options.retries = retries || 3
+        @service.request_options.timeout_sec = timeout if timeout
         @service.authorization = @credentials.client
       end
 

--- a/lib/gcloud/translate.rb
+++ b/lib/gcloud/translate.rb
@@ -32,6 +32,7 @@ module Gcloud
   # @param [String] key a public API access key (not an OAuth 2.0 token)
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Translate::Api]
   #
@@ -53,7 +54,7 @@ module Gcloud
   #   translation = translate.translate "Hello world!", to: "la"
   #   translation.text #=> "Salve mundi!"
   #
-  def self.translate key = nil, retries: nil
+  def self.translate key = nil, retries: nil, timeout: nil
     key ||= ENV["TRANSLATE_KEY"]
     if key.nil?
       key_missing_msg = "An API key is required to use the Translate API."
@@ -61,7 +62,8 @@ module Gcloud
     end
 
     Gcloud::Translate::Api.new(
-      Gcloud::Translate::Service.new(key, retries: retries))
+      Gcloud::Translate::Service.new(
+        key, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/translate/service.rb
+++ b/lib/gcloud/translate/service.rb
@@ -31,11 +31,12 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize key, retries: nil
+      def initialize key, retries: nil, timeout: nil
         @service = API::TranslateService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
         @service.request_options.retries = retries || 3
+        @service.request_options.timeout_sec = timeout if timeout
         @service.authorization = nil
         @service.key = key
       end

--- a/lib/gcloud/vision.rb
+++ b/lib/gcloud/vision.rb
@@ -35,6 +35,7 @@ module Gcloud
   #   * `https://www.googleapis.com/auth/cloud-platform`
   # @param [Integer] retries Number of times to retry requests on server error.
   #   The default value is `3`. Optional.
+  # @param [Integer] timeout Default timeout to use in requests. Optional.
   #
   # @return [Gcloud::Vision::Project]
   #
@@ -49,7 +50,8 @@ module Gcloud
   #   landmark = image.landmark
   #   landmark.description #=> "Mount Rushmore"
   #
-  def self.vision project = nil, keyfile = nil, scope: nil, retries: nil
+  def self.vision project = nil, keyfile = nil, scope: nil, retries: nil,
+                  timeout: nil
     project ||= Gcloud::Vision::Project.default_project
     project = project.to_s # Always cast to a string
     fail ArgumentError, "project is missing" if project.empty?
@@ -61,7 +63,8 @@ module Gcloud
     end
 
     Gcloud::Vision::Project.new(
-      Gcloud::Vision::Service.new(project, credentials, retries: retries))
+      Gcloud::Vision::Service.new(
+        project, credentials, retries: retries, timeout: timeout))
   end
 
   ##

--- a/lib/gcloud/vision/service.rb
+++ b/lib/gcloud/vision/service.rb
@@ -32,13 +32,14 @@ module Gcloud
 
       ##
       # Creates a new Service instance.
-      def initialize project, credentials, retries: nil
+      def initialize project, credentials, retries: nil, timeout: nil
         @project = project
         @credentials = credentials
         @service = API::VisionService.new
         @service.client_options.application_name    = "gcloud-ruby"
         @service.client_options.application_version = Gcloud::VERSION
         @service.request_options.retries = retries || 3
+        @service.request_options.timeout_sec = timeout if timeout
         @service.authorization = @credentials.client
       end
 

--- a/test/gcloud/bigquery_test.rb
+++ b/test/gcloud/bigquery_test.rb
@@ -18,11 +18,12 @@ require "gcloud/bigquery"
 describe Gcloud do
   it "calls out to Gcloud.bigquery" do
     gcloud = Gcloud.new
-    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "bigquery-project-object-empty"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
@@ -33,11 +34,12 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.bigquery" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "bigquery-project-object"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
@@ -48,15 +50,16 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.bigquery" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_bigquery = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "bigquery-project-object-scoped"
     }
     Gcloud.stub :bigquery, stubbed_bigquery do
-      project = gcloud.bigquery scope: "http://example.com/scope", retries: 5
+      project = gcloud.bigquery scope: "http://example.com/scope", retries: 5, timeout: 60
       project.must_equal "bigquery-project-object-scoped"
     end
   end

--- a/test/gcloud/datastore_test.rb
+++ b/test/gcloud/datastore_test.rb
@@ -18,11 +18,12 @@ require "gcloud/datastore"
 describe Gcloud do
   it "calls out to Gcloud.datastore" do
     gcloud = Gcloud.new
-    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "datastore-dataset-object-empty"
     }
     Gcloud.stub :datastore, stubbed_datastore do
@@ -33,11 +34,12 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.datastore" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "datastore-dataset-object"
     }
     Gcloud.stub :datastore, stubbed_datastore do
@@ -48,15 +50,16 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.datastore" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_datastore = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "datastore-dataset-object-scoped"
     }
     Gcloud.stub :datastore, stubbed_datastore do
-      dataset = gcloud.datastore scope: "http://example.com/scope", retries: 5
+      dataset = gcloud.datastore scope: "http://example.com/scope", retries: 5, timeout: 60
       dataset.must_equal "datastore-dataset-object-scoped"
     end
   end

--- a/test/gcloud/dns_test.rb
+++ b/test/gcloud/dns_test.rb
@@ -18,11 +18,12 @@ require "gcloud/dns"
 describe Gcloud do
   it "calls out to Gcloud.dns" do
     gcloud = Gcloud.new
-    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "dns-project-object-empty"
     }
     Gcloud.stub :dns, stubbed_dns do
@@ -33,11 +34,12 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.dns" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "dns-project-object"
     }
     Gcloud.stub :dns, stubbed_dns do
@@ -48,15 +50,16 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.dns" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_dns = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "dns-project-object-scoped"
     }
     Gcloud.stub :dns, stubbed_dns do
-      project = gcloud.dns scope: "http://example.com/scope", retries: 5
+      project = gcloud.dns scope: "http://example.com/scope", retries: 5, timeout: 60
       project.must_equal "dns-project-object-scoped"
     end
   end

--- a/test/gcloud/logging_test.rb
+++ b/test/gcloud/logging_test.rb
@@ -18,11 +18,12 @@ require "gcloud/logging"
 describe Gcloud do
   it "calls out to Gcloud.logging" do
     gcloud = Gcloud.new
-    stubbed_logging = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_logging = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "logging-project-object-empty"
     }
     Gcloud.stub :logging, stubbed_logging do
@@ -33,11 +34,12 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.logging" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_logging = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_logging = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "logging-project-object"
     }
     Gcloud.stub :logging, stubbed_logging do
@@ -48,15 +50,16 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.logging" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_logging = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_logging = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "logging-project-object-scoped"
     }
     Gcloud.stub :logging, stubbed_logging do
-      project = gcloud.logging scope: "http://example.com/scope", retries: 5
+      project = gcloud.logging scope: "http://example.com/scope", retries: 5, timeout: 60
       project.must_equal "logging-project-object-scoped"
     end
   end

--- a/test/gcloud/pubsub_test.rb
+++ b/test/gcloud/pubsub_test.rb
@@ -18,11 +18,12 @@ require "gcloud/pubsub"
 describe Gcloud do
   it "calls out to Gcloud.pubsub" do
     gcloud = Gcloud.new
-    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "pubsub-project-object-empty"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
@@ -33,11 +34,12 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.pubsub" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "pubsub-project-object"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
@@ -48,15 +50,16 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.pubsub" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_pubsub = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "pubsub-project-object-scoped"
     }
     Gcloud.stub :pubsub, stubbed_pubsub do
-      project = gcloud.pubsub scope: "http://example.com/scope", retries: 5
+      project = gcloud.pubsub scope: "http://example.com/scope", retries: 5, timeout: 60
       project.must_equal "pubsub-project-object-scoped"
     end
   end

--- a/test/gcloud/resource_manager_test.rb
+++ b/test/gcloud/resource_manager_test.rb
@@ -18,10 +18,11 @@ require "gcloud/resource_manager"
 describe Gcloud do
   it "calls out to Gcloud.resource_manager" do
     gcloud = Gcloud.new
-    stubbed_resource_manager = ->(keyfile, scope: nil, retries: nil) {
+    stubbed_resource_manager = ->(keyfile, scope: nil, retries: nil, timeout: nil) {
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "resource_manager-manager-object-empty"
     }
     Gcloud.stub :resource_manager, stubbed_resource_manager do
@@ -32,10 +33,11 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.resource_manager" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_resource_manager = ->(keyfile, scope: nil, retries: nil) {
+    stubbed_resource_manager = ->(keyfile, scope: nil, retries: nil, timeout: nil) {
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "resource_manager-manager-object"
     }
     Gcloud.stub :resource_manager, stubbed_resource_manager do
@@ -46,14 +48,15 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.resource_manager" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_resource_manager = ->(keyfile, scope: nil, retries: nil) {
+    stubbed_resource_manager = ->(keyfile, scope: nil, retries: nil, timeout: nil) {
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "resource_manager-manager-object-scoped"
     }
     Gcloud.stub :resource_manager, stubbed_resource_manager do
-      manager = gcloud.resource_manager scope: "http://example.com/scope", retries: 5
+      manager = gcloud.resource_manager scope: "http://example.com/scope", retries: 5, timeout: 60
       manager.must_equal "resource_manager-manager-object-scoped"
     end
   end

--- a/test/gcloud/storage_test.rb
+++ b/test/gcloud/storage_test.rb
@@ -18,11 +18,12 @@ require "gcloud/storage"
 describe Gcloud do
   it "calls out to Gcloud.storage" do
     gcloud = Gcloud.new
-    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "storage-project-object-empty"
     }
     Gcloud.stub :storage, stubbed_storage do
@@ -33,11 +34,12 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.storage" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "storage-project-object"
     }
     Gcloud.stub :storage, stubbed_storage do
@@ -48,15 +50,16 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.storage" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "storage-project-object-scoped"
     }
     Gcloud.stub :storage, stubbed_storage do
-      project = gcloud.storage scope: "http://example.com/scope", retries: 5
+      project = gcloud.storage scope: "http://example.com/scope", retries: 5, timeout: 60
       project.must_equal "storage-project-object-scoped"
     end
   end

--- a/test/gcloud/translate_test.rb
+++ b/test/gcloud/translate_test.rb
@@ -18,9 +18,10 @@ require "gcloud/translate"
 describe Gcloud do
   it "calls out to Gcloud.translate" do
     gcloud = Gcloud.new
-    stubbed_translate = ->(key, retries: nil) {
+    stubbed_translate = ->(key, retries: nil, timeout: nil) {
       key.must_equal "this-is-the-api-key"
       retries.must_be :nil?
+      timeout.must_be :nil?
       "translate-api-object-empty"
     }
     Gcloud.stub :translate, stubbed_translate do
@@ -31,9 +32,10 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.translate" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_translate = ->(key, retries: nil) {
+    stubbed_translate = ->(key, retries: nil, timeout: nil) {
       key.must_equal "this-is-the-api-key"
       retries.must_be :nil?
+      timeout.must_be :nil?
       "translate-api-object"
     }
     Gcloud.stub :translate, stubbed_translate do
@@ -44,13 +46,14 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.translate" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_translate = ->(key, retries: nil) {
+    stubbed_translate = ->(key, retries: nil, timeout: nil) {
       key.must_equal "this-is-the-api-key"
       retries.must_equal 5
+      timeout.must_equal 60
       "translate-api-object-scoped"
     }
     Gcloud.stub :translate, stubbed_translate do
-      api = gcloud.translate "this-is-the-api-key", retries: 5
+      api = gcloud.translate "this-is-the-api-key", retries: 5, timeout: 60
       api.must_equal "translate-api-object-scoped"
     end
   end

--- a/test/gcloud/vision_test.rb
+++ b/test/gcloud/vision_test.rb
@@ -18,11 +18,12 @@ require "gcloud/vision"
 describe Gcloud do
   it "calls out to Gcloud.vision" do
     gcloud = Gcloud.new
-    stubbed_vision = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_vision = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal nil
       keyfile.must_equal nil
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "vision-project-object-empty"
     }
     Gcloud.stub :vision, stubbed_vision do
@@ -33,11 +34,12 @@ describe Gcloud do
 
   it "passes project and keyfile to Gcloud.vision" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_vision = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_vision = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_be :nil?
       retries.must_be :nil?
+      timeout.must_be :nil?
       "vision-project-object"
     }
     Gcloud.stub :vision, stubbed_vision do
@@ -48,15 +50,16 @@ describe Gcloud do
 
   it "passes project and keyfile and options to Gcloud.vision" do
     gcloud = Gcloud.new "project-id", "keyfile-path"
-    stubbed_vision = ->(project, keyfile, scope: nil, retries: nil) {
+    stubbed_vision = ->(project, keyfile, scope: nil, retries: nil, timeout: nil) {
       project.must_equal "project-id"
       keyfile.must_equal "keyfile-path"
       scope.must_equal "http://example.com/scope"
       retries.must_equal 5
+      timeout.must_equal 60
       "vision-project-object-scoped"
     }
     Gcloud.stub :vision, stubbed_vision do
-      project = gcloud.vision scope: "http://example.com/scope", retries: 5
+      project = gcloud.vision scope: "http://example.com/scope", retries: 5, timeout: 60
       project.must_equal "vision-project-object-scoped"
     end
   end


### PR DESCRIPTION
This is an extension of the existing API. We don't currently allow users to specify a timeout. Part of the challenge is how we would support the feature as we move from Google API Client 0.8 to 0.9 and eventually to GRPC and GAX. I believe we should be able to support this API across all those implementations.