### PR TITLE
Exclude private modules

### DIFF
--- a/lib/gcloud/jsondoc/generator.rb
+++ b/lib/gcloud/jsondoc/generator.rb
@@ -39,7 +39,9 @@ module Gcloud
       end
 
       def build!
-        modules = @registry.all(:module)
+        modules = @registry.all(:module).select do |c|
+          c.visibility == :public && !c.has_tag?(:private)
+        end
         modules.each do |object|
           @docs += Doc.new(object).subtree
         end

--- a/test/fixtures/my_module/hidden_class.rb
+++ b/test/fixtures/my_module/hidden_class.rb
@@ -1,10 +1,18 @@
 module MyModule
   ##
-  # @private This method should not appear in the output.
+  # @private This class should not appear in the output.
   class HiddenClass
     ##
     # This method should not appear in the output.
     def my_hidden_method
+    end
+  end
+  ##
+  # @private This module should not appear in the output.
+  module HiddenModule
+    ##
+    # This method should not appear in the output.
+    def self.my_hidden_module_method
     end
   end
 end


### PR DESCRIPTION
Ensures that modules marked `@private`, such as `Gcloud::GRPCUtils`, are excluded from the output.