### PR TITLE
Allow for more difference in time values

### DIFF
--- a/test/gcloud/bigquery/dataset_attributes_test.rb
+++ b/test/gcloud/bigquery/dataset_attributes_test.rb
@@ -33,10 +33,10 @@ describe Gcloud::Bigquery::Dataset, :attributes, :mock_bigquery do
     bigquery.service.mocked_service = mock
     mock.expect :get_dataset, dataset_full_gapi, [project, dataset_id]
 
-    dataset.created_at.must_be_close_to Time.now, 10
+    dataset.created_at.must_be_close_to Time.now, 1
 
     # A second call to attribute does not make a second HTTP API call
-    dataset.created_at.must_be_close_to Time.now, 10
+    dataset.created_at.must_be_close_to Time.now, 1
     mock.verify
   end
 
@@ -45,10 +45,10 @@ describe Gcloud::Bigquery::Dataset, :attributes, :mock_bigquery do
     bigquery.service.mocked_service = mock
     mock.expect :get_dataset, dataset_full_gapi, [project, dataset_id]
 
-    dataset.modified_at.must_be_close_to Time.now, 10
+    dataset.modified_at.must_be_close_to Time.now, 1
 
     # A second call to attribute does not make a second HTTP API call
-    dataset.modified_at.must_be_close_to Time.now, 10
+    dataset.modified_at.must_be_close_to Time.now, 1
     mock.verify
   end
 

--- a/test/gcloud/bigquery/dataset_test.rb
+++ b/test/gcloud/bigquery/dataset_test.rb
@@ -66,10 +66,10 @@ describe Gcloud::Bigquery::Dataset, :mock_bigquery do
     now = Time.now
 
     dataset.gapi.creation_time = time_millis
-    dataset.created_at.must_be_close_to now
+    dataset.created_at.must_be_close_to now, 0.1
 
     dataset.gapi.last_modified_time = time_millis
-    dataset.modified_at.must_be_close_to now
+    dataset.modified_at.must_be_close_to now, 0.1
   end
 
   it "can delete itself" do

--- a/test/gcloud/bigquery/job_test.rb
+++ b/test/gcloud/bigquery/job_test.rb
@@ -116,9 +116,9 @@ describe Gcloud::Bigquery::Job, :mock_bigquery do
     job.gapi.statistics.start_time = timestamp
     job.gapi.statistics.end_time = timestamp
 
-    job.created_at.must_be_close_to nowish
-    job.started_at.must_be_close_to nowish
-    job.ended_at.must_be_close_to nowish
+    job.created_at.must_be_close_to nowish, 1
+    job.started_at.must_be_close_to nowish, 1
+    job.ended_at.must_be_close_to nowish, 1
   end
 
   it "knows its configuration" do

--- a/test/gcloud/bigquery/table_attributes_test.rb
+++ b/test/gcloud/bigquery/table_attributes_test.rb
@@ -33,7 +33,7 @@ describe Gcloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.created_at.must_be_close_to Time.now, 10
+    table.created_at.must_be_close_to Time.now, 1
 
     mock.verify
 
@@ -47,7 +47,7 @@ describe Gcloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.expires_at.must_be_close_to Time.now, 10
+    table.expires_at.must_be_close_to Time.now, 1
 
     mock.verify
 
@@ -77,7 +77,7 @@ describe Gcloud::Bigquery::Table, :attributes, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id]
     table.service.mocked_service = mock
 
-    table.modified_at.must_be_close_to Time.now, 10
+    table.modified_at.must_be_close_to Time.now, 1
 
     mock.verify
 

--- a/test/gcloud/bigquery/table_test.rb
+++ b/test/gcloud/bigquery/table_test.rb
@@ -55,9 +55,9 @@ describe Gcloud::Bigquery::Table, :mock_bigquery do
     table_hash["expirationTime"] = time_millis
 
 
-    table.created_at.must_be_close_to now
-    table.modified_at.must_be_close_to now
-    table.expires_at.must_be_close_to now
+    table.created_at.must_be_close_to now, 1
+    table.modified_at.must_be_close_to now, 1
+    table.expires_at.must_be_close_to now, 1
   end
 
   it "can have an empty expiration times" do

--- a/test/gcloud/bigquery/view_attributes_test.rb
+++ b/test/gcloud/bigquery/view_attributes_test.rb
@@ -33,7 +33,7 @@ describe Gcloud::Bigquery::View, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.created_at.must_be_close_to Time.now, 10
+    view.created_at.must_be_close_to Time.now, 1
 
     mock.verify
 
@@ -47,7 +47,7 @@ describe Gcloud::Bigquery::View, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.expires_at.must_be_close_to Time.now, 10
+    view.expires_at.must_be_close_to Time.now, 1
 
     mock.verify
 
@@ -61,7 +61,7 @@ describe Gcloud::Bigquery::View, :attributes, :mock_bigquery do
       [view.project_id, view.dataset_id, view.table_id]
     view.service.mocked_service = mock
 
-    view.modified_at.must_be_close_to Time.now, 10
+    view.modified_at.must_be_close_to Time.now, 1
 
     mock.verify
 

--- a/test/gcloud/bigquery/view_test.rb
+++ b/test/gcloud/bigquery/view_test.rb
@@ -47,9 +47,9 @@ describe Gcloud::Bigquery::View, :mock_bigquery do
     view_hash["expirationTime"] = time_millis
 
 
-    view.created_at.must_be_close_to now
-    view.modified_at.must_be_close_to now
-    view.expires_at.must_be_close_to now
+    view.created_at.must_be_close_to now, 1
+    view.modified_at.must_be_close_to now, 1
+    view.expires_at.must_be_close_to now, 1
   end
 
   it "knows schema, fields, and headers" do


### PR DESCRIPTION
The default delta of 0.001 is too small for Travis-CI.
Getting some failures on this test for some reason.
Bump up the delta to make it pass more reliably on CI.