### PR TITLE
Upgrade Resource Manager to V1

### DIFF
--- a/lib/gcloud/resource_manager/policy.rb
+++ b/lib/gcloud/resource_manager/policy.rb
@@ -72,7 +72,7 @@ module Gcloud
     class Policy
       ##
       # Alias to the Google Client API module
-      API = Google::Apis::CloudresourcemanagerV1beta1
+      API = Google::Apis::CloudresourcemanagerV1
 
       attr_reader :etag, :roles
 
@@ -183,7 +183,7 @@ module Gcloud
 
       ##
       # @private Convert the Policy to a
-      # Google::Apis::CloudresourcemanagerV1beta1::Policy.
+      # Google::Apis::CloudresourcemanagerV1::Policy.
       def to_gapi
         API::Policy.new(
           etag: etag,
@@ -199,7 +199,7 @@ module Gcloud
 
       ##
       # @private New Policy from a
-      # Google::Apis::CloudresourcemanagerV1beta1::Policy object.
+      # Google::Apis::CloudresourcemanagerV1::Policy object.
       def self.from_gapi gapi
         roles = gapi.bindings.each_with_object({}) do |binding, memo|
           memo[binding.role] = binding.members.to_a

--- a/lib/gcloud/resource_manager/service.rb
+++ b/lib/gcloud/resource_manager/service.rb
@@ -15,7 +15,7 @@
 
 require "gcloud/version"
 require "gcloud/errors"
-require "google/apis/cloudresourcemanager_v1beta1"
+require "google/apis/cloudresourcemanager_v1"
 
 module Gcloud
   module ResourceManager
@@ -26,7 +26,7 @@ module Gcloud
     class Service
       ##
       # Alias to the Google Client API module
-      API = Google::Apis::CloudresourcemanagerV1beta1
+      API = Google::Apis::CloudresourcemanagerV1
 
       attr_accessor :credentials
 

--- a/test/gcloud/resource_manager/manager_test.rb
+++ b/test/gcloud/resource_manager/manager_test.rb
@@ -31,7 +31,7 @@ describe Gcloud::ResourceManager::Manager, :mock_res_man do
   it "creates a project" do
     mock = Minitest::Mock.new
     created_project = create_project_gapi("new-project-456")
-    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1beta1::Project.new(projectId: "new-project-456")]
+    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1::Project.new(projectId: "new-project-456")]
 
     resource_manager.service.mocked_service = mock
     project = resource_manager.create_project "new-project-456"
@@ -46,7 +46,7 @@ describe Gcloud::ResourceManager::Manager, :mock_res_man do
   it "creates a project with a name and labels" do
     mock = Minitest::Mock.new
     created_project = create_project_gapi("new-project-789", "My New Project", {"env" => "development"})
-    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1beta1::Project.new(projectId: "new-project-789", name: "My New Project", labels: {:env => :development})]
+    mock.expect :create_project, created_project, [Google::Apis::CloudresourcemanagerV1::Project.new(projectId: "new-project-789", name: "My New Project", labels: {:env => :development})]
 
     resource_manager.service.mocked_service = mock
     project = resource_manager.create_project "new-project-789",
@@ -244,7 +244,7 @@ describe Gcloud::ResourceManager::Manager, :mock_res_man do
 
   it "deletes a project" do
     mock = Minitest::Mock.new
-    empty_response = Google::Apis::CloudresourcemanagerV1beta1::Empty.new
+    empty_response = Google::Apis::CloudresourcemanagerV1::Empty.new
     mock.expect :delete_project, empty_response, ["existing-project-123"]
 
     resource_manager.service.mocked_service = mock
@@ -254,7 +254,7 @@ describe Gcloud::ResourceManager::Manager, :mock_res_man do
 
   it "undeletes a project" do
     mock = Minitest::Mock.new
-    empty_response = Google::Apis::CloudresourcemanagerV1beta1::Empty.new
+    empty_response = Google::Apis::CloudresourcemanagerV1::Empty.new
     mock.expect :undelete_project, empty_response, ["deleted-project-456"]
 
     resource_manager.service.mocked_service = mock
@@ -274,6 +274,6 @@ describe Gcloud::ResourceManager::Manager, :mock_res_man do
     projects = count.times.map { random_project_gapi }
     hash = { projects: projects }
     hash[:next_page_token] = token unless token.nil?
-    Google::Apis::CloudresourcemanagerV1beta1::ListProjectsResponse.new hash
+    Google::Apis::CloudresourcemanagerV1::ListProjectsResponse.new hash
   end
 end

--- a/test/gcloud/resource_manager/project_iam_test.rb
+++ b/test/gcloud/resource_manager/project_iam_test.rb
@@ -20,10 +20,10 @@ describe Gcloud::ResourceManager::Project, :iam, :mock_res_man do
   let(:project) { Gcloud::ResourceManager::Project.from_gapi project_gapi,
                                                              resource_manager.service }
   let(:old_policy_gapi) {
-    Google::Apis::CloudresourcemanagerV1beta1::Policy.new(
+    Google::Apis::CloudresourcemanagerV1::Policy.new(
       etag: "CAE=",
       bindings: [
-        Google::Apis::CloudresourcemanagerV1beta1::Binding.new(
+        Google::Apis::CloudresourcemanagerV1::Binding.new(
           role: "roles/viewer",
           members: [
             "user:viewer@example.com"
@@ -33,10 +33,10 @@ describe Gcloud::ResourceManager::Project, :iam, :mock_res_man do
     )
   }
   let(:new_policy_gapi) {
-    Google::Apis::CloudresourcemanagerV1beta1::Policy.new(
+    Google::Apis::CloudresourcemanagerV1::Policy.new(
       etag: "CAE=",
       bindings: [
-        Google::Apis::CloudresourcemanagerV1beta1::Binding.new(
+        Google::Apis::CloudresourcemanagerV1::Binding.new(
           role: "roles/viewer",
           members: [
             "user:viewer@example.com",
@@ -125,7 +125,7 @@ describe Gcloud::ResourceManager::Project, :iam, :mock_res_man do
 
   it "sets the policy" do
     mock = Minitest::Mock.new
-    update_policy_request = Google::Apis::CloudresourcemanagerV1beta1::SetIamPolicyRequest.new policy: new_policy_gapi
+    update_policy_request = Google::Apis::CloudresourcemanagerV1::SetIamPolicyRequest.new policy: new_policy_gapi
     mock.expect :set_project_iam_policy, new_policy_gapi, ["projects/example-project-123", update_policy_request]
 
     resource_manager.service.mocked_service = mock
@@ -149,7 +149,7 @@ describe Gcloud::ResourceManager::Project, :iam, :mock_res_man do
     mock = Minitest::Mock.new
     mock.expect :get_project_iam_policy, old_policy_gapi, ["projects/example-project-123"]
 
-    update_policy_request = Google::Apis::CloudresourcemanagerV1beta1::SetIamPolicyRequest.new policy: new_policy_gapi
+    update_policy_request = Google::Apis::CloudresourcemanagerV1::SetIamPolicyRequest.new policy: new_policy_gapi
     mock.expect :set_project_iam_policy, new_policy_gapi, ["projects/example-project-123", update_policy_request]
 
     resource_manager.service.mocked_service = mock
@@ -169,8 +169,8 @@ describe Gcloud::ResourceManager::Project, :iam, :mock_res_man do
 
   it "tests the permissions available" do
     mock = Minitest::Mock.new
-    update_policy_request  = Google::Apis::CloudresourcemanagerV1beta1::TestIamPermissionsRequest.new  permissions: ["resourcemanager.projects.get", "resourcemanager.projects.delete"]
-    update_policy_response = Google::Apis::CloudresourcemanagerV1beta1::TestIamPermissionsResponse.new permissions: ["resourcemanager.projects.get"]
+    update_policy_request  = Google::Apis::CloudresourcemanagerV1::TestIamPermissionsRequest.new  permissions: ["resourcemanager.projects.get", "resourcemanager.projects.delete"]
+    update_policy_response = Google::Apis::CloudresourcemanagerV1::TestIamPermissionsResponse.new permissions: ["resourcemanager.projects.get"]
     mock.expect :test_project_iam_permissions, update_policy_response, ["projects/example-project-123", update_policy_request]
 
     resource_manager.service.mocked_service = mock

--- a/test/gcloud/resource_manager/project_test.rb
+++ b/test/gcloud/resource_manager/project_test.rb
@@ -168,7 +168,7 @@ describe Gcloud::ResourceManager::Project, :mock_res_man do
 
   it "deletes itself" do
     mock = Minitest::Mock.new
-    empty_response      = Google::Apis::CloudresourcemanagerV1beta1::Empty.new
+    empty_response      = Google::Apis::CloudresourcemanagerV1::Empty.new
     deleted_project = random_project_gapi seed
     deleted_project.lifecycle_state = "DELETE_REQUESTED"
     # The delete request
@@ -191,7 +191,7 @@ describe Gcloud::ResourceManager::Project, :mock_res_man do
     project.gapi.lifecycle_state = "DELETE_REQUESTED"
 
     mock = Minitest::Mock.new
-    empty_response      = Google::Apis::CloudresourcemanagerV1beta1::Empty.new
+    empty_response      = Google::Apis::CloudresourcemanagerV1::Empty.new
     unspecified_project = random_project_gapi seed
     unspecified_project.lifecycle_state = "LIFECYCLE_STATE_UNSPECIFIED"
     # The delete request

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -695,7 +695,7 @@ class MockResourceManager < Minitest::Spec
     seed ||= rand(9999)
     name ||= "Example Project #{seed}"
     labels = { "env" => "production" } if labels.nil?
-    Google::Apis::CloudresourcemanagerV1beta1::Project.new(
+    Google::Apis::CloudresourcemanagerV1::Project.new(
       project_number: "123456789#{seed}",
       project_id:     "example-project-#{seed}",
       name:           name,


### PR DESCRIPTION
We don't have acceptance tests because this service requires user credentials. I've manually tested this and it works as expected. Much easier to do since the Google API Client upgrade.