### PR TITLE
Update Logging service name in docs

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -99,7 +99,7 @@ end
 
 # Logging
 
-[Google Cloud Logging](https://cloud.google.com/logging/) collects and stores logs from applications and services on the Google Cloud Platform, giving you fine-grained, programmatic control over your projects' logs. With this API you can do the following:
+[Stackdriver Logging](https://cloud.google.com/logging/) collects and stores logs from applications and services on the Google Cloud Platform, giving you fine-grained, programmatic control over your projects' logs. With this API you can do the following:
 
 * Read and filter log entries
 * Export your log entries to Cloud Storage,

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ end
 ### Logging
 
 - [gcloud-ruby Logging API documentation](http://googlecloudplatform.github.io/gcloud-ruby/docs/master/Gcloud/Logging.html)
-- [Google Cloud Logging Documentation](https://cloud.google.com/logging/docs/)
+- [Stackdriver Logging Documentation](https://cloud.google.com/logging/docs/)
 
 #### Preview
 

--- a/lib/gcloud.rb
+++ b/lib/gcloud.rb
@@ -347,7 +347,7 @@ module Gcloud
   # rubocop:enable Metrics/LineLength
 
   ##
-  # Creates a new object for connecting to the Logging service.
+  # Creates a new object for connecting to the Stackdriver Logging service.
   # Each call creates a new connection.
   #
   # For more information on connecting to Google Cloud see the [Authentication

--- a/lib/gcloud/logging.rb
+++ b/lib/gcloud/logging.rb
@@ -18,14 +18,14 @@ require "gcloud/logging/project"
 
 module Gcloud
   ##
-  # Creates a new object for connecting to the Logging service.
+  # Creates a new object for connecting to the Stackdriver Logging service.
   # Each call creates a new connection.
   #
   # For more information on connecting to Google Cloud see the [Authentication
   # Guide](https://googlecloudplatform.github.io/gcloud-ruby/#/docs/guides/authentication).
   #
-  # @param [String] project Project identifier for the Logging service you are
-  #   connecting to.
+  # @param [String] project Project identifier for the Stackdriver Logging
+  #   service.
   # @param [String, Hash] keyfile Keyfile downloaded from Google Cloud. If file
   #   path the file must be readable.
   # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling the
@@ -67,12 +67,12 @@ module Gcloud
   end
 
   ##
-  # # Google Cloud Logging
+  # # Stackdriver Logging
   #
-  # The Google Cloud Logging service collects and stores logs from applications
+  # The Stackdriver Logging service collects and stores logs from applications
   # and services on the Google Cloud Platform, giving you fine-grained,
-  # programmatic control over your projects' logs. You can use the Cloud Logging
-  # API to:
+  # programmatic control over your projects' logs. You can use the Stackdriver
+  # Logging API to:
   #
   # * [Read and filter log entries](#listing-log-entries)
   # * [Export your log entries](#exporting-log-entries) to Cloud Storage,
@@ -81,21 +81,21 @@ module Gcloud
   #   Monitoring
   # * [Write log entries](#writing-log-entries)
   #
-  # For general information about Cloud Logging, read [What is Google Cloud
-  # Logging?](https://cloud.google.com/logging/docs/).
+  # For general information about Stackdriver Logging, read [Stackdriver Logging
+  # Documentation](https://cloud.google.com/logging/docs/).
   #
   # The goal of gcloud-ruby is to provide an API that is comfortable to
   # Rubyists. Authentication is handled by {Gcloud#logging}. You can provide the
-  # project and credential information to connect to the Cloud Logging service,
-  # or if you are running on Google Compute Engine this configuration is taken
-  # care of for you. You can read more about the options for connecting in the
-  # [Authentication
+  # project and credential information to connect to the Stackdriver Logging
+  # service, or if you are running on Google Compute Engine this configuration
+  # is taken care of for you. You can read more about the options for connecting
+  # in the [Authentication
   # Guide](https://googlecloudplatform.github.io/gcloud-ruby/#/docs/guides/authentication).
   #
   # ## Listing log entries
   #
-  # Cloud Logging gathers log entries from many services, including Google App
-  # Engine and Google Compute Engine. (See the [List of Log
+  # Stackdriver Logging gathers log entries from many services, including Google
+  # App Engine and Google Compute Engine. (See the [List of Log
   # Types](https://cloud.google.com/logging/docs/view/logs_index).) In addition,
   # you can write your own log entries to the service.
   #
@@ -119,7 +119,8 @@ module Gcloud
   # Platform services, by third-party services, or by your applications. For
   # example, the log `compute.googleapis.com/activity_log` is produced by Google
   # Compute Engine. Logs are simply referenced by name in gcloud-ruby. There is
-  # no `Log` type in gcloud-ruby or `Log` resource in the Cloud Logging API.
+  # no `Log` type in gcloud-ruby or `Log` resource in the Stackdriver Logging
+  # API.
   #
   # ```ruby
   # require "gcloud"
@@ -147,9 +148,9 @@ module Gcloud
   #
   # ## Exporting log entries
   #
-  # Cloud Logging lets you export log entries to destinations including Google
-  # Cloud Storage buckets (for long term log storage), Google BigQuery datasets
-  # (for log analysis), and Google Pub/Sub (for streaming to other
+  # Stackdriver Logging lets you export log entries to destinations including
+  # Google Cloud Storage buckets (for long term log storage), Google BigQuery
+  # datasets (for log analysis), and Google Pub/Sub (for streaming to other
   # applications).
   #
   # ### Creating sinks
@@ -176,15 +177,16 @@ module Gcloud
   #
   # bucket = storage.create_bucket "my-logs-bucket"
   #
-  # # Grant owner permission to Cloud Logging service
+  # # Grant owner permission to Stackdriver Logging service
   # email = "cloud-logs@google.com"
   # bucket.acl.add_owner "group-#{email}"
   #
   # sink = logging.create_sink "my-sink", "storage.googleapis.com/#{bucket.id}"
   # ```
   #
-  # When you create a sink, only new log entries are exported. Cloud Logging
-  # does not send previously-ingested log entries to the sink's destination.
+  # When you create a sink, only new log entries are exported. Stackdriver
+  # Logging does not send previously-ingested log entries to the sink's
+  # destination.
   #
   # ### Listing sinks
   #
@@ -243,7 +245,7 @@ module Gcloud
   # ## Writing log entries
   #
   # An {Gcloud::Logging::Entry} is composed of metadata and a payload. The
-  # payload is traditionally a message string, but in Cloud Logging it can
+  # payload is traditionally a message string, but in Stackdriver Logging it can
   # also be a JSON or protocol buffer object. A single log can have entries with
   # different payload types. In addition to the payload, your argument(s) to
   # {Gcloud::Logging::Project#write_entries} must also contain a log name and a

--- a/lib/gcloud/logging/entry.rb
+++ b/lib/gcloud/logging/entry.rb
@@ -27,11 +27,11 @@ module Gcloud
     # An individual entry in a log.
     #
     # Each log entry is composed of metadata and a payload. The metadata
-    # includes standard information used by Cloud Logging, such as when the
-    # entry was created and where it came from. The payload is the event record.
-    # Traditionally this is a message string, but in Cloud Logging it can also
-    # be a JSON or protocol buffer object. A single log can have entries with
-    # different payload types.
+    # includes standard information used by Stackdriver Logging, such as when
+    # the entry was created and where it came from. The payload is the event
+    # record. Traditionally this is a message string, but in Stackdriver Logging
+    # it can also be a JSON or protocol buffer object. A single log can have
+    # entries with different payload types.
     #
     # A log is a named collection of entries. Logs can be produced by Google
     # Cloud Platform services, by third-party services, or by your applications.
@@ -92,7 +92,7 @@ module Gcloud
 
       ##
       # The time the event described by the log entry occurred. If omitted,
-      # Cloud Logging will use the time the log entry is written.
+      # Stackdriver Logging will use the time the log entry is written.
       # @return [Time]
       attr_accessor :timestamp
 
@@ -329,8 +329,8 @@ module Gcloud
       ##
       # A unique ID for the log entry. If you provide this field, the logging
       # service considers other log entries in the same log with the same ID as
-      # duplicates which can be removed. If omitted, Cloud Logging will generate
-      # a unique ID for this log entry.
+      # duplicates which can be removed. If omitted, Stackdriver Logging will
+      # generate a unique ID for this log entry.
       # @return [String]
       attr_accessor :insert_id
 

--- a/lib/gcloud/logging/logger.rb
+++ b/lib/gcloud/logging/logger.rb
@@ -266,7 +266,7 @@ module Gcloud
       protected
 
       ##
-      # @private Write a log entry to Google Cloud Logging service.
+      # @private Write a log entry to the Stackdriver Logging service.
       def write_entry severity, message
         entry = logging.entry.tap do |e|
           e.severity = gcloud_severity(severity)

--- a/lib/gcloud/logging/project.rb
+++ b/lib/gcloud/logging/project.rb
@@ -30,7 +30,7 @@ module Gcloud
     #
     # Projects are top-level containers in Google Cloud Platform. They store
     # information about billing and authorized users, and they control access to
-    # Google Cloud Logging resources. Each project has a friendly name and a
+    # Stackdriver Logging resources. Each project has a friendly name and a
     # unique ID. Projects can be created only in the [Google Developers
     # Console](https://console.developers.google.com). See {Gcloud#logging}.
     #
@@ -152,24 +152,24 @@ module Gcloud
 
       ##
       # Creates an new Entry instance that may be populated and written to the
-      # Cloud Logging service. The {Entry#resource} attribute is pre-populated
-      # with a new {Gcloud::Logging::Resource} instance. Equivalent to calling
-      # `Gcloud::Logging::Entry.new`.
+      # Stackdriver Logging service. The {Entry#resource} attribute is
+      # pre-populated with a new {Gcloud::Logging::Resource} instance.
+      # Equivalent to calling `Gcloud::Logging::Entry.new`.
       #
       # @param [String] log_name The resource name of the log to which this log
       #   entry belongs. See also {Entry#log_name=}.
       # @param [Resource] resource The monitored resource associated with this
       #   log entry. See also {Entry#resource}.
       # @param [Time] timestamp The time the event described by the log entry
-      #   occurred. If omitted, Cloud Logging will use the time the log entry is
-      #   written. See also {Entry#timestamp}.
+      #   occurred. If omitted, Stackdriver Logging will use the time the log
+      #   entry is written. See also {Entry#timestamp}.
       # @param [Symbol] severity The severity level of the log entry. The
       #   default value is `DEFAULT`. See also {Entry#severity}.
       # @param [String] insert_id A unique ID for the log entry. If you provide
       #   this field, the logging service considers other log entries in the
       #   same log with the same ID as duplicates which can be removed. If
-      #   omitted, Cloud Logging will generate a unique ID for this log entry.
-      #   See also {Entry#insert_id}.
+      #   omitted, Stackdriver Logging will generate a unique ID for this log
+      #   entry. See also {Entry#insert_id}.
       # @param [Hash{Symbol,String => String}] labels A hash of user-defined
       #   `key:value` pairs that provide additional information about the log
       #   entry. See also {Entry#labels=}.
@@ -204,7 +204,7 @@ module Gcloud
       alias_method :new_entry, :entry
 
       ##
-      # Writes log entries to the Cloud Logging service.
+      # Writes log entries to the Stackdriver Logging service.
       #
       # If you write a collection of log entries, you can provide the log name,
       # resource, and/or labels hash to be used for all of the entries, and omit
@@ -325,7 +325,7 @@ module Gcloud
 
       ##
       # Retrieves the list of monitored resource descriptors that are used by
-      # Google Cloud Logging.
+      # Stackdriver Logging.
       #
       # @see https://cloud.google.com/logging/docs/api/introduction_v2#monitored_resources
       #   Monitored Resources
@@ -429,8 +429,8 @@ module Gcloud
 
       ##
       # Creates a new project sink. When you create a sink, only new log entries
-      # that match the sink's filter are exported. Cloud Logging does not send
-      # previously-ingested log entries to the sink's destination.
+      # that match the sink's filter are exported. Stackdriver Logging does not
+      # send previously-ingested log entries to the sink's destination.
       #
       # Before creating the sink, ensure that you have granted
       # `cloud-logs@google.com` permission to write logs to the destination. See
@@ -458,12 +458,12 @@ module Gcloud
       #  that defines the log entries to be exported. The filter must be
       #  consistent with the log entry format designed by the `version`
       #  parameter, regardless of the format of the log entry that was
-      #  originally written to Cloud Logging.
+      #  originally written to Stackdriver Logging.
       # @param [Symbol] version The log entry version used when exporting log
       #   entries from this sink. This version does not have to correspond to
-      #   the version of the log entry when it was written to Cloud Logging.
-      #   Accepted values are `:unspecified`, `:v2`, and `:v1`. Version 2 is
-      #   currently the preferred format. An unspecified version format
+      #   the version of the log entry when it was written to Stackdriver
+      #   Logging. Accepted values are `:unspecified`, `:v2`, and `:v1`. Version
+      #   2 is currently the preferred format. An unspecified version format
       #   currently defaults to V2 in the service. The default value is
       #   `:unspecified`.
       #
@@ -478,7 +478,7 @@ module Gcloud
       #
       #   bucket = storage.create_bucket "my-logs-bucket"
       #
-      #   # Grant owner permission to Cloud Logging service
+      #   # Grant owner permission to Stackdriver Logging service
       #   email = "cloud-logs@google.com"
       #   bucket.acl.add_owner "group-#{email}"
       #

--- a/lib/gcloud/logging/resource_descriptor.rb
+++ b/lib/gcloud/logging/resource_descriptor.rb
@@ -20,8 +20,8 @@ module Gcloud
     ##
     # # ResourceDescriptor
     #
-    # Describes a type of monitored resource supported by Cloud Logging. Each
-    # ResourceDescriptor has a type name, such as `cloudsql_database`,
+    # Describes a type of monitored resource supported by Stackdriver Logging.
+    # Each ResourceDescriptor has a type name, such as `cloudsql_database`,
     # `gae_app`, or `gce_instance`. It also specifies a set of labels that must
     # all be given values in a {Resource} instance to represent an actual
     # instance of the type.

--- a/lib/gcloud/logging/sink.rb
+++ b/lib/gcloud/logging/sink.rb
@@ -20,8 +20,8 @@ module Gcloud
     ##
     # # Sink
     #
-    # Used to export log entries outside Cloud Logging. When you create a sink,
-    # new log entries are exported. Cloud Logging does not send
+    # Used to export log entries outside Stackdriver Logging. When you create a
+    # sink, new log entries are exported. Stackdriver Logging does not send
     # previously-ingested log entries to the sink's destination.
     #
     # Before creating the sink, ensure that you have granted
@@ -48,7 +48,7 @@ module Gcloud
     #
     #   bucket = storage.create_bucket "my-logs-bucket"
     #
-    #   # Grant owner permission to Cloud Logging service
+    #   # Grant owner permission to Stackdriver Logging service
     #   email = "cloud-logs@google.com"
     #   bucket.acl.add_owner "group-#{email}"
     #
@@ -99,7 +99,7 @@ module Gcloud
       # that defines the log entries to be exported. The filter must be
       # consistent with the log entry format designed by the `version`
       # parameter, regardless of the format of the log entry that was originally
-      # written to Cloud Logging.
+      # written to Stackdriver Logging.
       def filter
         @grpc.filter
       end
@@ -110,7 +110,7 @@ module Gcloud
       # that defines the log entries to be exported. The filter must be
       # consistent with the log entry format designed by the `version`
       # parameter, regardless of the format of the log entry that was originally
-      # written to Cloud Logging.
+      # written to Stackdriver Logging.
       def filter= filter
         @grpc.filter = filter
       end
@@ -118,7 +118,7 @@ module Gcloud
       ##
       # The log entry version used when exporting log entries from this sink.
       # This version does not have to correspond to the version of the log entry
-      # when it was written to Cloud Logging.
+      # when it was written to Stackdriver Logging.
       def version
         @grpc.output_version_format
       end
@@ -126,7 +126,7 @@ module Gcloud
       ##
       # Updates the log entry version used when exporting log entries from this
       # sink. This version does not have to correspond to the version of the log
-      # entry when it was written to Cloud Logging. Accepted values are
+      # entry when it was written to Stackdriver Logging. Accepted values are
       # `:VERSION_FORMAT_UNSPECIFIED`, `:V2`, and `:V1`.
       def version= version
         @grpc.output_version_format = self.class.resolve_version(version)


### PR DESCRIPTION
The official docs now use "Stackdriver Logging" in all API descriptions. For example:

> If omitted, Stackdriver Logging will use the time the log entry is received.

This PR updates all gcloud-ruby doc usages of Cloud Logging docs to match.

[closes #750]