### PR TITLE
Change Datastore QueryResult#next? to use NOT_FINISHED

### DIFF
--- a/acceptance/datastore/datastore_test.rb
+++ b/acceptance/datastore/datastore_test.rb
@@ -469,6 +469,16 @@ describe "Datastore", :datastore do
       entities[2]["name"].must_equal arya["name"]
     end
 
+    it "should paginate with all" do
+      query = Gcloud::Datastore::Query.new.
+        kind("Character").ancestor(book).
+        order("appearances")
+      entities = dataset.run(query).all.to_a
+      entities.count.must_equal 8
+      entities[0]["name"].must_equal rickard["name"]
+      entities[5]["name"].must_equal sansa["name"]
+    end
+
     it "should resume from a start cursor" do
       query = Gcloud::Datastore::Query.new.
         kind("Character").ancestor(book).

--- a/lib/gcloud/datastore/dataset/query_results.rb
+++ b/lib/gcloud/datastore/dataset/query_results.rb
@@ -133,7 +133,7 @@ module Gcloud
         #   end
         #
         def next?
-          !no_more?
+          not_finished?
         end
 
         ##

--- a/test/gcloud/datastore/query_results/all_test.rb
+++ b/test/gcloud/datastore/query_results/all_test.rb
@@ -38,7 +38,7 @@ describe Gcloud::Datastore::Dataset, :all do
     Google::Datastore::V1beta3::RunQueryResponse.new(
       batch: Google::Datastore::V1beta3::QueryResultBatch.new(
         entity_results: run_query_res_entities,
-        more_results: :MORE_RESULTS_AFTER_CURSOR,
+        more_results: :NOT_FINISHED,
         end_cursor: "second-page-cursor".force_encoding("ASCII-8BIT")
       )
     )
@@ -101,10 +101,10 @@ describe Gcloud::Datastore::Dataset, :all do
     end
     first_entities.cursor.must_equal     Gcloud::Datastore::Cursor.from_grpc("second-page-cursor")
     first_entities.end_cursor.must_equal Gcloud::Datastore::Cursor.from_grpc("second-page-cursor")
-    first_entities.more_results.must_equal :MORE_RESULTS_AFTER_CURSOR
-    refute first_entities.not_finished?
+    first_entities.more_results.must_equal :NOT_FINISHED
+    assert first_entities.not_finished?
     refute first_entities.more_after_limit?
-    assert first_entities.more_after_cursor?
+    refute first_entities.more_after_cursor?
     refute first_entities.no_more?
 
     assert first_entities.next?
@@ -136,7 +136,6 @@ describe Gcloud::Datastore::Dataset, :all do
 
     refute next_entities.next?
   end
-
 
   it "run will fulfill a query and return an object that can paginate with all" do
     entities = dataset.run dataset.query("Task")

--- a/test/gcloud/datastore/query_results/all_with_more_test.rb
+++ b/test/gcloud/datastore/query_results/all_with_more_test.rb
@@ -38,7 +38,7 @@ describe Gcloud::Datastore::Dataset, :all_with_more do
     Google::Datastore::V1beta3::RunQueryResponse.new(
       batch: Google::Datastore::V1beta3::QueryResultBatch.new(
         entity_results: run_query_res_entities,
-        more_results: :MORE_RESULTS_AFTER_CURSOR,
+        more_results: :NOT_FINISHED,
         end_cursor: "second-page-cursor".force_encoding("ASCII-8BIT")
       )
     )
@@ -64,7 +64,7 @@ describe Gcloud::Datastore::Dataset, :all_with_more do
     Google::Datastore::V1beta3::RunQueryResponse.new(
       batch: Google::Datastore::V1beta3::QueryResultBatch.new(
         entity_results: run_query_res_entities,
-        more_results: :MORE_RESULTS_AFTER_CURSOR,
+        more_results: :NOT_FINISHED,
         end_cursor: "third-page-cursor".force_encoding("ASCII-8BIT")
       )
     )


### PR DESCRIPTION
Change what check is made to paginate. Requested by the Datastore team.

[closes #793]