### PR TITLE
Fix Pub/Sub bug in pull timeout

### DIFF
--- a/lib/gcloud/pubsub/subscription.rb
+++ b/lib/gcloud/pubsub/subscription.rb
@@ -234,7 +234,7 @@ module Gcloud
         end
         acknowledge messages if autoack
         messages
-      rescue Hurley::Timeout
+      rescue Gcloud::DeadlineExceededError
         []
       end
 

--- a/test/gcloud/pubsub/subscription/pull_wait_test.rb
+++ b/test/gcloud/pubsub/subscription/pull_wait_test.rb
@@ -64,10 +64,10 @@ describe Gcloud::Pubsub::Subscription, :pull, :wait, :mock_pubsub do
     rec_messages.first.message.data.must_equal rec_message_msg
   end
 
-  it "will not error when a request times out with Hurley::Timeout" do
+  it "will not error when a request times out with Gcloud::DeadlineExceededError" do
     stub = Object.new
     def stub.pull *args
-      raise Hurley::Timeout
+      raise Gcloud::DeadlineExceededError
     end
     subscription.service.mocked_subscriber = stub
 


### PR DESCRIPTION
When pull times out, it should continue. Now that Pub/Sub is on gRPC the
timeout error is no longer a Faraday or Hurley error. Fix the rescue statement
to recover from the error class that will be raised in a gRPC timeout.

[fixes #811]