### PR TITLE
Add jsondoc support for multiple packages

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -48,15 +48,15 @@ The **Project ID** and **Credentials JSON** can be placed in environment variabl
 
 Here are the environment variables that Datastore checks for project ID:
 
-1. DATASTORE_PROJECT
-2. GCLOUD_PROJECT
+1. `DATASTORE_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
 
 Here are the environment variables that Datastore checks for credentials:
 
-1. DATASTORE_KEYFILE - Path to JSON file
-2. GCLOUD_KEYFILE - Path to JSON file
-3. DATASTORE_KEYFILE_JSON - JSON contents
-4. GCLOUD_KEYFILE_JSON - JSON contents
+1. `DATASTORE_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `DATASTORE_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
 
 ### Cloud SDK
 

--- a/Rakefile
+++ b/Rakefile
@@ -181,12 +181,56 @@ task :jsondoc, :bundleupdate do |t, args|
 end
 
 namespace :jsondoc do
-  desc "Copies all jsondoc to google-cloud umbrella package."
-  task :copy, :jsondoc do
+  # @param tag [String] A valid tag, e.g. "v0.10.0", or "master".
+  desc "Clones gh-pages branch to a temp dir"
+  task :init, :tag do |t, args|
+    tag = args[:tag]
+    fail "Missing required parameter 'tag'."if tag.nil?
+    gh_pages = Pathname.new(Dir.home) + "tmp/#{tag}-gh-pages"
+
+    header "Cloning gh-pages branch to #{gh_pages}"
+
+    FileUtils.remove_dir gh_pages if Dir.exists? gh_pages
+    FileUtils.mkdir_p gh_pages
+
+    # checkout the gh-pages branch
+    git_repo = "git@github.com:GoogleCloudPlatform/gcloud-ruby.git"
+    if ENV["GH_OAUTH_TOKEN"]
+      git_repo = "https://#{ENV["GH_OAUTH_TOKEN"]}@github.com/#{ENV["GH_OWNER"]}/#{ENV["GH_PROJECT_NAME"]}"
+    end
+    puts "git clone --quiet --branch=gh-pages --single-branch #{git_repo} #{gh_pages} > /dev/null"
+    puts `git clone --quiet --branch=gh-pages --single-branch #{git_repo} #{gh_pages} > /dev/null`
+  end
+
+  desc "Copies jsondoc to gh-pages repo in temp dir."
+  task :copy, [:tag] => [:jsondoc, :init] do |t, args|
+    tag = args[:tag]
+    fail "Missing required parameter 'tag'."if tag.nil?
+    gh_pages = Pathname.new(Dir.home) + "tmp/#{tag}-gh-pages"
+
+    header "Copying all jsondoc for branch/tag '#{tag}' to '#{gh_pages}'"
+    gems.each do |gem|
+      unless Dir.exist? gh_pages + "json/#{gem}"
+        mkdir_p gh_pages + "json/#{gem}", verbose: true
+      end
+      cp_r "#{gem}/jsondoc", gh_pages + "json/#{gem}/#{tag}", verbose: true
+    end
+    cp "docs/manifest.json", gh_pages, verbose: true
+    cp "docs/json/home.html", gh_pages + "json", verbose: true
+  end
+
+  desc "Assembles google-cloud umbrella package jsondoc, from gems' jsondoc to gh-pages repo in temp dir."
+  task :umbrella, [:tag] => [:copy] do |t, args|
+    tag = args[:tag]
+    fail "Missing required parameter 'tag'."if tag.nil?
+    gh_pages = Pathname.new(Dir.home) + "tmp/#{tag}-gh-pages"
+
     require "json"
     excluded = ["gcloud", "google-cloud"]
     all_types = []
     google_cloud_json = JSON.parse File.read("google-cloud/jsondoc/google/cloud.json")
+
+    # Load existing google/cloud.json methods.
     all_google_cloud_methods = [google_cloud_json["methods"]]
 
     header "Copying all jsondoc to google-cloud umbrella package"
@@ -194,39 +238,103 @@ namespace :jsondoc do
       next if excluded.include? gem
       gem_shortname = gem[/\Agoogle-cloud-(.+)/, 1]
       gem_shortname = gem_shortname.gsub "_", "" # "resource_manager" -> "resourcemanager"
-      gem_jsondoc_path = "#{gem}/jsondoc/google/cloud/#{gem_shortname}"
       unless gem == "google-cloud-core" # There is no `core` subdir
-        cp_r "#{gem}/jsondoc/google/cloud/#{gem_shortname}", "google-cloud/jsondoc/google/cloud/", verbose: true
+        cp_r "#{gem}/jsondoc/google/cloud/#{gem_shortname}", gh_pages + "json/google-cloud/master/google/cloud/", verbose: true
       end
-      cp Dir["#{gem}/jsondoc/google/cloud/*.json"], "google-cloud/jsondoc/google/cloud/", verbose: true
+      cp Dir["#{gem}/jsondoc/google/cloud/*.json"], gh_pages + "json/google-cloud/master/google/cloud/", verbose: true
       all_types << JSON.parse(File.read("#{gem}/jsondoc/types.json"))
       all_google_cloud_methods << JSON.parse(File.read("#{gem}/jsondoc/google/cloud.json"))["methods"]
     end
 
-    header "Merging each gem types.json into google-cloud/jsondoc/types.json"
-    File.open("google-cloud/jsondoc/types.json", "w") do |f|
+    header "Merging each gem types.json into #{gh_pages}/json/google-cloud/jsondoc/types.json"
+    File.open(gh_pages + "json/google-cloud/master/types.json", "w") do |f|
       f.write(all_types.flatten.to_json)
     end
-    header "Merging methods from each google/cloud.json into google-cloud/jsondoc/google/cloud.json"
+
+    header "Merging methods from each google/cloud.json into #{gh_pages}/json/google-cloud/jsondoc/google/cloud.json"
     all_google_cloud_methods.each {|x| x.each {|y| puts y["id"]}}
     google_cloud_json["methods"] = all_google_cloud_methods.flatten
-    File.open("google-cloud/jsondoc/google/cloud.json", "w") do |f|
+    File.open(gh_pages + "json/google-cloud/master/google/cloud.json", "w") do |f|
       f.write(google_cloud_json.to_json)
     end
   end
 
-  desc "Copies jsondoc to development gh-pages"
-  task :dev do
-    # target_dir = "../gcloud-common/site/src" # for development
-    target_dir = "../gcloud-ruby-gh-pages"
-    gems.each do |gem|
-      unless Dir.exist? "#{target_dir}/json/#{gem}"
-        mkdir "#{target_dir}/json/#{gem}", verbose: true
+  desc "Publishes assembled jsondoc to gh-pages"
+  task :publish, [:tag] => [:umbrella] do |t, args|
+    tag = args[:tag]
+    fail "Missing required parameter 'tag'."if tag.nil?
+    gh_pages = Pathname.new(Dir.home) + "tmp/#{tag}-gh-pages"
+
+    git_ref = tag == "master" ? `git rev-parse --short HEAD`.chomp : tag
+    # Change to gh-pages
+    puts "cd #{gh_pages}"
+    Dir.chdir gh_pages do
+      # commit changes
+      puts `git add -A .`
+      if ENV["GH_OAUTH_TOKEN"]
+        puts `git config --global user.email "travis@travis-ci.org"`
+        puts `git config --global user.name "travis-ci"`
+        puts `git commit -m "Update documentation for #{git_ref}"`
+        puts `git push #{git_repo} gh-pages:gh-pages`
+      else
+        puts `git commit -m "Update documentation for #{git_ref}"`
+        puts `git push origin gh-pages`
       end
-      cp_r "#{gem}/jsondoc", "#{target_dir}/json/#{gem}/master", verbose: true
     end
-    cp "docs/manifest.json", target_dir, verbose: true
-    cp "docs/json/home.html", "#{target_dir}/json", verbose: true
+  end
+
+  desc "Publishes the jsondoc for master branch to the gh-pages branch"
+  task :master do
+    unless ENV["GH_OAUTH_TOKEN"]
+      # only check this if we are not running on travis
+      branch = `git symbolic-ref --short HEAD`.chomp
+      if "master" != branch
+        puts "You are on the #{branch} branch. You must be on the master branch to run this rake task."
+        exit
+      end
+
+      unless `git status --porcelain`.chomp.empty?
+        puts "The master branch is not clean. Unable to update gh-pages."
+        exit
+      end
+    end
+    Rake::Task["jsondoc:publish"].invoke("master")
+  end
+
+  desc "Publishes the jsondoc for the tag to the gh-pages branch"
+  task :tag, :tag do |t, args|
+    tag = args[:tag]
+    fail "Missing required parameter 'tag'."if tag.nil?
+    # Verify the tag exists
+    tag_check = `git show-ref --tags | grep #{tag}`.chomp
+    if tag_check.empty?
+      fail "Cannot find the tag '#{tag}'."
+    end
+
+    git_repo = "git@github.com:GoogleCloudPlatform/gcloud-ruby.git"
+    if ENV["GH_OAUTH_TOKEN"]
+      git_repo = "https://#{ENV["GH_OAUTH_TOKEN"]}@github.com/#{ENV["GH_OWNER"]}/#{ENV["GH_PROJECT_NAME"]}"
+    end
+
+    tag_repo  =  Pathname.new(Dir.home) + "tmp/#{tag}-repo"
+    FileUtils.remove_dir tag_repo if Dir.exists? tag_repo
+    FileUtils.mkdir_p tag_repo
+
+    header "Cloning tag #{tag} to #{tag_repo}"
+
+    # checkout the tag repo
+    puts "git clone --quiet --branch=#{tag} --single-branch #{git_repo} #{tag_repo} > /dev/null"
+    puts `git clone --quiet --branch=#{tag} --single-branch #{git_repo} #{tag_repo} > /dev/null`
+    # build the docs in the tag repo
+    Dir.chdir tag_repo do
+      Bundler.with_clean_env do
+        # create the docs
+        puts "bundle install --path .bundle"
+        puts `bundle install --path .bundle`
+        puts "bundle exec rake jsondoc:publish[\"#{tag}\"]"
+        puts `bundle exec rake jsondoc:publish["#{tag}"]`
+      end
+    end
   end
 end
 

--- a/docs/json/home.html
+++ b/docs/json/home.html
@@ -1,0 +1,107 @@
+<section class="hero-banner">
+  <div class="container clearfix">
+    <div class="quote-box">
+      <h1>gcloud</h1>
+      <p>Google Cloud Client Library for Ruby
+      - an idiomatic, intuitive, and natural way for Ruby developers to
+      integrate with Google Cloud Platform services, like Cloud Datastore
+      and Cloud Storage.</p>
+    </div>
+
+    <div class="quote-box--supplementary">
+      <h2>One-line install</h2>
+      <pre>$ gem install gcloud</pre>
+      <h4 class="latest-release subtle" ng-if="home.latestRelease">
+        Latest Release <a ng-href="{{home.latestRelease.link}}" class="latest-release--link white">{{home.latestRelease.name}}</a>
+        {{home.latestRelease.date|date}}
+      </h4>
+    </div>
+  </div><!-- end of .container -->
+</section><!-- end of .hero-banner -->
+
+<section class="block featuring">
+  <div class="container">
+    <ul class="featuring-links">
+      <li>
+        <a href="#/docs/google-cloud/{{home.latestRelease.name}}" title="gcloud-ruby docs" class="btn btn-docs">
+          <img src="src/images/icon-lang-ruby-gray.svg" alt="Ruby icon" />
+          Read the Docs
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/GoogleCloudPlatform/gcloud-ruby" title="gcloud-ruby on GitHub" class="ext-link">
+          <img src="src/images/icon-link-github.svg" alt="GitHub icon" />
+          GitHub
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/GoogleCloudPlatform/gcloud-ruby/issues" title="gcloud-ruby issues on Github" class="ext-link">
+          <img src="src/images/icon-link-issues.svg" alt="GitHub icon" />
+          Issues
+        </a>
+      </li>
+      <li>
+        <a href="http://stackoverflow.com/questions/tagged/gcloud-ruby" title="gcloud-ruby on StackOverflow" class="ext-link">
+          <img src="src/images/icon-link-stackoverflow.svg" alt="StackOverflow icon" />
+          StackOverflow
+        </a>
+      </li>
+      <li>
+        <a href="http://rubygems.org/gems/gcloud" title="RubyGems" class="ext-link">
+          <img src="src/images/icon-link-rubygems.svg" alt="RubyGems icon" />
+          RubyGems
+        </a>
+      </li>
+    </ul>
+  </div><!-- end of .container -->
+</section><!-- end of .featuring -->
+
+<section class="block about">
+  <div class="container clearfix">
+    <div class="quote-box">
+      <h3 class="block-title">What is it?</h3>
+
+      <p><code>gcloud</code> is a client library for accessing Google
+      Cloud Platform services that significantly reduces the boilerplate
+      code you have to write. The library provides high-level API
+      abstractions so they're easier to understand. It embraces
+      Ruby idioms, works well with the standard library, and
+      integrates better with your codebase.
+      All this means you spend more time creating code that matters
+      to you.</p>
+
+      <p><code>gcloud</code> is configured to access Google Cloud Platform
+      services and authenticate (OAuth 2.0) automatically on your behalf.
+      With a one-line install and a private key, you are up and ready
+      to go. Better yet, if you are running on a Google Compute Engine
+      instance, the one-line install is enough!</p>
+
+    </div>
+
+    <div class="quote-box--supplementary">
+      <h4>Retrieve an entity from Cloud Datastore</h4>
+      <div hljs hljs-language="ruby">
+require "gcloud/datastore"
+
+datastore = Gcloud.datastore "my-project",
+                             "key.json"
+
+product = datastore.find "Product", 123</div>
+
+    </div>
+  </div><!-- end of .container -->
+</section><!-- end of .featuring -->
+
+ <section class="block">
+    <div class="container clearfix">
+    <h3 class="block-title">FAQ</h3>
+
+      <h4>What is the relationship between the gcloud package and the gcloud command-line tool?</h4>
+
+      <p>Both the gcloud command-line tool and gcloud package are a part of the Google Cloud SDK: a collection of tools and libraries that enable you to easily create and manage resources on the Google Cloud Platform. The gcloud command-line tool can be used to manage both your development workflow and your Google Cloud Platform resources while the gcloud package is the Google Cloud Client Library for Ruby.</p>
+
+      <h4>What is the relationship between gcloud and the Google APIs Ruby Client?</h4>
+
+      <p>The <a href="https://github.com/google/google-api-ruby-client">Google APIs Ruby Client</a> is a client library for using the broad set of Google APIs. gcloud is built specifically for the Google Cloud Platform and is the recommended way to integrate Google Cloud APIs into your Ruby applications. If your application requires both Google Cloud Platform and other Google APIs, the 2 libraries may be used by your application.</p>
+    </div>
+</section> <!-- end of FAQ -->

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -13,6 +13,24 @@
   },
   "modules": [
     {
+      "id": "gcloud",
+      "name": "gcloud",
+      "defaultService": "gcloud",
+      "versions": [
+        "v0.12.1",
+        "master",
+        "v0.12.0",
+        "v0.11.0",
+        "v0.10.0",
+        "v0.9.0",
+        "v0.8.2",
+        "v0.8.0",
+        "v0.7.2",
+        "v0.7.1",
+        "v0.7.0"
+      ]
+    },
+    {
       "id": "google-cloud",
       "name": "google-cloud",
       "defaultService": "google/cloud",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -88,8 +88,8 @@
       ]
     },
     {
-      "id": "google-cloud-resourcemanager",
-      "name": "google-cloud-resourcemanager",
+      "id": "google-cloud-resource_manager",
+      "name": "google-cloud-resource_manager",
       "defaultService": "google/cloud/resourcemanager",
       "versions": [
         "master"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,115 @@
+{
+  "lang": "ruby",
+  "friendlyLang": "Ruby",
+  "moduleName": "gcloud-ruby",
+  "markdown": "ruby",
+  "titleDelimiter": "::",
+  "defaultModule": "google-cloud",
+  "content": "json",
+  "home": "home.html",
+  "package": {
+    "title": "RubyGems",
+    "href": "http://rubygems.org/gems/gcloud"
+  },
+  "modules": [
+    {
+      "id": "google-cloud",
+      "name": "google-cloud",
+      "defaultService": "google/cloud",
+      "versions": [
+        "v0.12.2",
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-bigquery",
+      "name": "google-cloud-bigquery",
+      "defaultService": "google/cloud/bigquery",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-core",
+      "name": "google-cloud-core",
+      "defaultService": "google/cloud/error",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-datastore",
+      "name": "google-cloud-datastore",
+      "defaultService": "google/cloud/datastore",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-dns",
+      "name": "google-cloud-dns",
+      "defaultService": "google/cloud/dns",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-logging",
+      "name": "google-cloud-logging",
+      "defaultService": "google/cloud/logging",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-pubsub",
+      "name": "google-cloud-pubsub",
+      "defaultService": "google/cloud/pubsub",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-resourcemanager",
+      "name": "google-cloud-resourcemanager",
+      "defaultService": "google/cloud/resourcemanager",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-storage",
+      "name": "google-cloud-storage",
+      "defaultService": "google/cloud/storage",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-translate",
+      "name": "google-cloud-translate",
+      "defaultService": "google/cloud/translate",
+      "versions": [
+        "master"
+      ]
+    },
+    {
+      "id": "google-cloud-vision",
+      "name": "google-cloud-vision",
+      "defaultService": "google/cloud/vision",
+      "versions": [
+        "master"
+      ]
+    }
+  ],
+  "methodTypeSymbols": [
+    {
+      "type": "class",
+      "symbol": "::"
+    },
+    {
+      "type": "instance",
+      "symbol": "#"
+    }
+  ]
+}

--- a/gcloud/Rakefile
+++ b/gcloud/Rakefile
@@ -63,6 +63,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/gcloud/docs/authentication.md
+++ b/gcloud/docs/authentication.md
@@ -1,0 +1,37 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/gcloud/docs/toc.json
+++ b/gcloud/docs/toc.json
@@ -1,0 +1,55 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "BigQuery",
+      "type": "google/cloud/bigquery",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/bigquery/project"
+        },
+        {
+          "title": "Dataset",
+          "type": "google/cloud/bigquery/dataset"
+        },
+        {
+          "title": "Job",
+          "type": "google/cloud/bigquery/job"
+        },
+        {
+          "title": "Table",
+          "type": "google/cloud/bigquery/table"
+        }
+      ]
+    }
+  ]
+}

--- a/gcloud/lib/gcloud.rb
+++ b/gcloud/lib/gcloud.rb
@@ -15,4 +15,12 @@
 
 require "google/cloud"
 
+##
+# # Gcloud
+#
+# This module exists to facilitate the transition of legacy code using the
+# `Gcloud` namespace to the current `Google::Cloud` namespace.
+#
+module Gcloud
+end
 Gcloud = Google::Cloud

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -110,6 +110,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-bigquery/docs/authentication.md
+++ b/google-cloud-bigquery/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. BIGQUERY_PROJECT
+2. GOOGLE_CLOUD_PROJECT
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `BIGQUERY_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `BIGQUERY_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-bigquery/docs/toc.json
+++ b/google-cloud-bigquery/docs/toc.json
@@ -1,0 +1,55 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "BigQuery",
+      "type": "google/cloud/bigquery",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/bigquery/project"
+        },
+        {
+          "title": "Dataset",
+          "type": "google/cloud/bigquery/dataset"
+        },
+        {
+          "title": "Job",
+          "type": "google/cloud/bigquery/job"
+        },
+        {
+          "title": "Table",
+          "type": "google/cloud/bigquery/table"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-core/Rakefile
+++ b/google-cloud-core/Rakefile
@@ -62,6 +62,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-core/docs/authentication.md
+++ b/google-cloud-core/docs/authentication.md
@@ -1,0 +1,37 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-core/docs/toc.json
+++ b/google-cloud-core/docs/toc.json
@@ -1,0 +1,37 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Google Cloud Core",
+      "type": "google/cloud/errors"
+    }
+  ]
+}

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -90,6 +90,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-datastore/docs/authentication.md
+++ b/google-cloud-datastore/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `DATASTORE_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `DATASTORE_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `DATASTORE_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-datastore/docs/toc.json
+++ b/google-cloud-datastore/docs/toc.json
@@ -1,0 +1,55 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Datastore",
+      "type": "google/cloud/datastore",
+      "nav": [
+        {
+          "title": "Dataset",
+          "type": "google/cloud/datastore/dataset"
+        },
+        {
+          "title": "Query",
+          "type": "google/cloud/datastore/query"
+        },
+        {
+          "title": "Entity",
+          "type": "google/cloud/datastore/entity"
+        },
+        {
+          "title": "Key",
+          "type": "google/cloud/datastore/key"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-dns/Rakefile
+++ b/google-cloud-dns/Rakefile
@@ -109,6 +109,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-dns/docs/authentication.md
+++ b/google-cloud-dns/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `DNS_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `DNS_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `DNS_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-dns/docs/toc.json
+++ b/google-cloud-dns/docs/toc.json
@@ -1,0 +1,51 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "DNS",
+      "type": "google/cloud/dns",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/dns/project"
+        },
+        {
+          "title": "Zone",
+          "type": "google/cloud/dns/zone"
+        },
+        {
+          "title": "Record",
+          "type": "google/cloud/dns/record"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-language/Rakefile
+++ b/google-cloud-language/Rakefile
@@ -75,6 +75,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-language/docs/authentication.md
+++ b/google-cloud-language/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `LANGUAGE_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `LANGUAGE_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `LANGUAGE_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-language/docs/toc.json
+++ b/google-cloud-language/docs/toc.json
@@ -1,0 +1,37 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Natural Language",
+      "type": "google/cloud/language"
+    }
+  ]
+}

--- a/google-cloud-logging/Rakefile
+++ b/google-cloud-logging/Rakefile
@@ -108,6 +108,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-logging/docs/authentication.md
+++ b/google-cloud-logging/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `LOGGING_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `LOGGING_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `LOGGING_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-logging/docs/toc.json
+++ b/google-cloud-logging/docs/toc.json
@@ -1,0 +1,51 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Logging",
+      "type": "google/cloud/logging",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/logging/project"
+        },
+        {
+          "title": "Entry",
+          "type": "google/cloud/logging/entry"
+        },
+        {
+          "title": "Resource",
+          "type": "google/cloud/logging/resource"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -104,6 +104,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-pubsub/docs/authentication.md
+++ b/google-cloud-pubsub/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `PUBSUB_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `PUBSUB_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `PUBSUB_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-pubsub/docs/toc.json
+++ b/google-cloud-pubsub/docs/toc.json
@@ -1,0 +1,51 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "PubSub",
+      "type": "google/cloud/pubsub",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/pubsub/project"
+        },
+        {
+          "title": "Topic",
+          "type": "google/cloud/pubsub/topic"
+        },
+        {
+          "title": "Subscription",
+          "type": "google/cloud/pubsub/subscription"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-resource_manager/Rakefile
+++ b/google-cloud-resource_manager/Rakefile
@@ -62,6 +62,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-resource_manager/docs/authentication.md
+++ b/google-cloud-resource_manager/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `RESOURCE_MANAGER_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `RESOURCE_MANAGER_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `RESOURCE_MANAGER_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-resource_manager/docs/toc.json
+++ b/google-cloud-resource_manager/docs/toc.json
@@ -1,0 +1,47 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Resource Manager",
+      "type": "google/cloud/resourcemanager",
+      "nav": [
+        {
+          "title": "Manager",
+          "type": "google/cloud/resourcemanager/manager"
+        },
+        {
+          "title": "Project",
+          "type": "google/cloud/resourcemanager/project"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-speech/Rakefile
+++ b/google-cloud-speech/Rakefile
@@ -75,6 +75,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-speech/docs/authentication.md
+++ b/google-cloud-speech/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `SPEECH_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `SPEECH_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `SPEECH_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-speech/docs/toc.json
+++ b/google-cloud-speech/docs/toc.json
@@ -1,0 +1,37 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Speech",
+      "type": "google/cloud/speech"
+    }
+  ]
+}

--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -103,6 +103,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-storage/docs/authentication.md
+++ b/google-cloud-storage/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `STORAGE_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `STORAGE_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `STORAGE_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-storage/docs/toc.json
+++ b/google-cloud-storage/docs/toc.json
@@ -1,0 +1,51 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Storage",
+      "type": "google/cloud/storage",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/storage/project"
+        },
+        {
+          "title": "Bucket",
+          "type": "google/cloud/storage/bucket"
+        },
+        {
+          "title": "File",
+          "type": "google/cloud/storage/file"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-translate/Rakefile
+++ b/google-cloud-translate/Rakefile
@@ -85,6 +85,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-translate/docs/authentication.md
+++ b/google-cloud-translate/docs/authentication.md
@@ -1,0 +1,9 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### The API access key
+
+Unlike other Cloud Platform services, which authenticate using a project ID and OAuth 2.0 credentials, Google Translate API requires a public API access key. (This may change in future releases of Google Translate API.)
+
+Follow the general instructions at [Identifying your application to Google](https://cloud.google.com/translate/v2/using_rest#auth), and the specific instructions for [Server keys](https://cloud.google.com/translate/v2/using_rest#creating-server-api-keys).

--- a/google-cloud-translate/docs/toc.json
+++ b/google-cloud-translate/docs/toc.json
@@ -1,0 +1,51 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Translate",
+      "type": "google/cloud/translate",
+      "nav": [
+        {
+          "title": "Api",
+          "type": "google/cloud/translate/api"
+        },
+        {
+          "title": "Translation",
+          "type": "google/cloud/translate/translation"
+        },
+        {
+          "title": "Detection",
+          "type": "google/cloud/translate/detection"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud-vision/Rakefile
+++ b/google-cloud-vision/Rakefile
@@ -88,6 +88,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud-vision/docs/authentication.md
+++ b/google-cloud-vision/docs/authentication.md
@@ -1,0 +1,40 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `VISION_PROJECT`
+2. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `VISION_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+3. `VISION_KEYFILE_JSON` - JSON contents
+4. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud-vision/docs/toc.json
+++ b/google-cloud-vision/docs/toc.json
@@ -1,0 +1,51 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Vision",
+      "type": "google/cloud/vision",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/vision/project"
+        },
+        {
+          "title": "Image",
+          "type": "google/cloud/vision/image"
+        },
+        {
+          "title": "Annotation",
+          "type": "google/cloud/vision/annotation"
+        }
+      ]
+    }
+  ]
+}

--- a/google-cloud/Rakefile
+++ b/google-cloud/Rakefile
@@ -63,6 +63,7 @@ task :jsondoc => :yard do
   registry = YARD::Registry.load! ".yardoc"
   generator = Gcloud::Jsondoc::Generator.new registry
   generator.write_to "jsondoc"
+  cp ["docs/authentication.md", "docs/toc.json"], "jsondoc", verbose: true
 end
 
 task :default => :test

--- a/google-cloud/docs/authentication.md
+++ b/google-cloud/docs/authentication.md
@@ -1,0 +1,37 @@
+## With `gcloud-ruby`
+
+With `gcloud-ruby` it's incredibly easy to get authenticated and start using Google's APIs. You can set your credentials on a global basis as well as on a per-API basis.
+
+### Project and Credential Lookup
+
+Gcloud aims to make authentication as simple as possible, and provides several mechanisms to configure your system without providing **Project ID** and **Service Account Credentials** directly in code.
+
+**Project ID** is discovered in the following order:
+
+1. Specify project ID in code
+2. Discover project ID in environment variables
+3. Discover GCE project ID
+
+**Credentials** are discovered in the following order:
+
+1. Specify credentials in code
+2. Discover credentials path in environment variables
+3. Discover credentials JSON in environment variables
+4. Discover credentials file in the Cloud SDK's path
+5. Discover GCE credentials
+
+### Environment Variables
+
+The **Project ID** and **Credentials JSON** can be placed in environment variables instead of declaring them directly in code. Each service has its own environment variable, allowing for different service accounts to be used for different services. The path to the **Credentials JSON** file can be stored in the environment variable, or the **Credentials JSON** itself can be stored for environments such as Docker containers where writing files is difficult or not encouraged.
+
+Here are the environment variables (in the order they are checked) for project ID:
+
+1. `GOOGLE_CLOUD_PROJECT`
+
+Here are the environment variables (in the order they are checked) for credentials:
+
+1. `GOOGLE_CLOUD_KEYFILE` - Path to JSON file
+2. `GOOGLE_CLOUD_KEYFILE_JSON` - JSON contents
+
+
+

--- a/google-cloud/docs/toc.json
+++ b/google-cloud/docs/toc.json
@@ -1,0 +1,203 @@
+{
+  "guides": [
+    {
+      "title": "Authentication",
+      "id": "authentication",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/authentication/readme.md",
+      "contents": [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/authentication/readme.md",
+        "authentication.md"
+      ]
+    },
+    {
+      "title": "FAQ",
+      "id": "faq",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/faq/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/faq/readme.md"
+    },
+    {
+      "title": "Troubleshooting",
+      "id": "troubleshooting",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/troubleshooting/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/troubleshooting/readme.md"
+    },
+    {
+      "title": "Contributing",
+      "id": "contributing",
+      "edit": "https://github.com/GoogleCloudPlatform/gcloud-common/edit/master/contributing/readme.md",
+      "contents": "https://raw.githubusercontent.com/GoogleCloudPlatform/gcloud-common/master/contributing/readme.md"
+    }
+  ],
+  "services": [
+    {
+      "title": "Google Cloud",
+      "type": "google/cloud"
+    },
+    {
+      "title": "BigQuery",
+      "type": "google/cloud/bigquery",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/bigquery/project"
+        },
+        {
+          "title": "Dataset",
+          "type": "google/cloud/bigquery/dataset"
+        },
+        {
+          "title": "Job",
+          "type": "google/cloud/bigquery/job"
+        },
+        {
+          "title": "Table",
+          "type": "google/cloud/bigquery/table"
+        }
+      ]
+    },
+    {
+      "title": "Datastore",
+      "type": "google/cloud/datastore",
+      "nav": [
+        {
+          "title": "Dataset",
+          "type": "google/cloud/datastore/dataset"
+        },
+        {
+          "title": "Query",
+          "type": "google/cloud/datastore/query"
+        },
+        {
+          "title": "Entity",
+          "type": "google/cloud/datastore/entity"
+        },
+        {
+          "title": "Key",
+          "type": "google/cloud/datastore/key"
+        }
+      ]
+    },
+    {
+      "title": "DNS",
+      "type": "google/cloud/dns",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/dns/project"
+        },
+        {
+          "title": "Zone",
+          "type": "google/cloud/dns/zone"
+        },
+        {
+          "title": "Record",
+          "type": "google/cloud/dns/record"
+        }
+      ]
+    },
+    {
+      "title": "Logging",
+      "type": "google/cloud/logging",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/logging/project"
+        },
+        {
+          "title": "Entry",
+          "type": "google/cloud/logging/entry"
+        },
+        {
+          "title": "Resource",
+          "type": "google/cloud/logging/resource"
+        }
+      ]
+    },
+    {
+      "title": "PubSub",
+      "type": "google/cloud/pubsub",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/pubsub/project"
+        },
+        {
+          "title": "Topic",
+          "type": "google/cloud/pubsub/topic"
+        },
+        {
+          "title": "Subscription",
+          "type": "google/cloud/pubsub/subscription"
+        }
+      ]
+    },
+    {
+      "title": "Resource Manager",
+      "type": "google/cloud/resourcemanager",
+      "nav": [
+        {
+          "title": "Manager",
+          "type": "google/cloud/resourcemanager/manager"
+        },
+        {
+          "title": "Project",
+          "type": "google/cloud/resourcemanager/project"
+        }
+      ]
+    },
+    {
+      "title": "Storage",
+      "type": "google/cloud/storage",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/storage/project"
+        },
+        {
+          "title": "Bucket",
+          "type": "google/cloud/storage/bucket"
+        },
+        {
+          "title": "File",
+          "type": "google/cloud/storage/file"
+        }
+      ]
+    },
+    {
+      "title": "Translate",
+      "type": "google/cloud/translate",
+      "nav": [
+        {
+          "title": "Api",
+          "type": "google/cloud/translate/api"
+        },
+        {
+          "title": "Translation",
+          "type": "google/cloud/translate/translation"
+        },
+        {
+          "title": "Detection",
+          "type": "google/cloud/translate/detection"
+        }
+      ]
+    },
+    {
+      "title": "Vision",
+      "type": "google/cloud/vision",
+      "nav": [
+        {
+          "title": "Project",
+          "type": "google/cloud/vision/project"
+        },
+        {
+          "title": "Image",
+          "type": "google/cloud/vision/image"
+        },
+        {
+          "title": "Annotation",
+          "type": "google/cloud/vision/annotation"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds `docs` directories containing assets such as `manifest.json` `toc.json` to the root project and to each sub-project, and updates the `jsondoc` rake task to copy these assets. 

It also adds a rake task that copies JSON content from the sub-projects to the `google-cloud` umbrella project, for compatibility with the site app (see GoogleCloudPlatform/gcloud-common/pull/157.)

[refs #830]

[Demo](https://quartzmo.github.io/gcloud-ruby/#/docs/google-cloud/v0.12.2/google/cloud)