### PR TITLE
Add Gapic-generated clients for Logging API.

### DIFF
--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - "acceptance/**/*"
     - "google-cloud-logging.gemspec"
     - "lib/google/logging/**/*"
+    - "lib/google/cloud/logging/v2/**/*"
     - "Rakefile"
     - "test/**/*"
 

--- a/google-cloud-logging/.yardopts
+++ b/google-cloud-logging/.yardopts
@@ -1,6 +1,7 @@
 --no-private
 --title=Google Cloud Logging
 --exclude lib/google/logging
+--exclude lib/google/cloud/logging/v2
 --markup markdown
 
 ./lib/**/*.rb

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "grpc", "~> 1.0"
   gem.add_dependency "google-protobuf", "~> 3.0"
   gem.add_dependency "googleapis-common-protos", "~> 1.2"
+  gem.add_dependency "google-gax", "~> 0.4.4"
 
   gem.add_development_dependency "minitest", "~> 5.9"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-logging/lib/google/cloud/logging/v2.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'google/cloud/logging/v2/config_service_v2_api'
-require 'google/cloud/logging/v2/logging_service_v2_api'
-require 'google/cloud/logging/v2/metrics_service_v2_api'
+require "google/cloud/logging/v2/config_service_v2_api"
+require "google/cloud/logging/v2/logging_service_v2_api"
+require "google/cloud/logging/v2/metrics_service_v2_api"

--- a/google-cloud-logging/lib/google/cloud/logging/v2.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2.rb
@@ -1,0 +1,17 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'google/cloud/logging/v2/config_service_v2_api'
+require 'google/cloud/logging/v2/logging_service_v2_api'
+require 'google/cloud/logging/v2/metrics_service_v2_api'

--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_api.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_api.rb
@@ -1,0 +1,331 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# EDITING INSTRUCTIONS
+# This file was generated from the file
+# https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_config.proto,
+# and updates to that file get reflected here through a refresh process.
+# For the short term, the refresh process will only be runnable by Google
+# engineers.
+#
+# The only allowed edits are to method and file documentation. A 3-way
+# merge preserves those additions if the generated source changes.
+
+require "json"
+require "pathname"
+
+require "google/gax"
+require "google/logging/v2/logging_config_services_pb"
+
+module Google
+  module Cloud
+    module Logging
+      module V2
+        # Service for configuring sinks used to export log entries outside Stackdriver
+        # Logging.
+        #
+        # @!attribute [r] stub
+        #   @return [Google::Logging::V2::ConfigServiceV2::Stub]
+        class ConfigServiceV2Api
+          attr_reader :stub
+
+          # The default address of the service.
+          SERVICE_ADDRESS = "logging.googleapis.com".freeze
+
+          # The default port of the service.
+          DEFAULT_SERVICE_PORT = 443
+
+          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
+
+          DEFAULT_TIMEOUT = 30
+
+          PAGE_DESCRIPTORS = {
+            "list_sinks" => Google::Gax::PageDescriptor.new(
+              "page_token",
+              "next_page_token",
+              "sinks")
+          }.freeze
+
+          private_constant :PAGE_DESCRIPTORS
+
+          # The scopes needed to make gRPC calls to all of the methods defined in
+          # this service.
+          ALL_SCOPES = [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only",
+            "https://www.googleapis.com/auth/logging.admin",
+            "https://www.googleapis.com/auth/logging.read",
+            "https://www.googleapis.com/auth/logging.write"
+          ].freeze
+
+          PARENT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}"
+          )
+
+          private_constant :PARENT_PATH_TEMPLATE
+
+          SINK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}/sinks/{sink}"
+          )
+
+          private_constant :SINK_PATH_TEMPLATE
+
+          # Returns a fully-qualified parent resource name string.
+          # @param project [String]
+          # @return [String]
+          def self.parent_path project
+            PARENT_PATH_TEMPLATE.render(
+              :"project" => project
+            )
+          end
+
+          # Returns a fully-qualified sink resource name string.
+          # @param project [String]
+          # @param sink [String]
+          # @return [String]
+          def self.sink_path project, sink
+            SINK_PATH_TEMPLATE.render(
+              :"project" => project,
+              :"sink" => sink
+            )
+          end
+
+          # Parses the project from a parent resource.
+          # @param parent_name [String]
+          # @return [String]
+          def self.match_project_from_parent_name parent_name
+            PARENT_PATH_TEMPLATE.match(parent_name)["project"]
+          end
+
+          # Parses the project from a sink resource.
+          # @param sink_name [String]
+          # @return [String]
+          def self.match_project_from_sink_name sink_name
+            SINK_PATH_TEMPLATE.match(sink_name)["project"]
+          end
+
+          # Parses the sink from a sink resource.
+          # @param sink_name [String]
+          # @return [String]
+          def self.match_sink_from_sink_name sink_name
+            SINK_PATH_TEMPLATE.match(sink_name)["sink"]
+          end
+
+          # @param service_path [String]
+          #   The domain name of the API remote host.
+          # @param port [Integer]
+          #   The port on which to connect to the remote host.
+          # @param channel [Channel]
+          #   A Channel object through which to make calls.
+          # @param chan_creds [Grpc::ChannelCredentials]
+          #   A ChannelCredentials for the setting up the RPC client.
+          # @param client_config[Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          # @param app_name [String]
+          #   The codename of the calling service.
+          # @param app_version [String]
+          #   The version of the calling service.
+          def initialize \
+              service_path: SERVICE_ADDRESS,
+              port: DEFAULT_SERVICE_PORT,
+              channel: nil,
+              chan_creds: nil,
+              scopes: ALL_SCOPES,
+              client_config: {},
+              timeout: DEFAULT_TIMEOUT,
+              app_name: "gax",
+              app_version: Google::Gax::VERSION
+            google_api_client = "#{app_name}/#{app_version} " \
+              "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
+            headers = { :"x-goog-api-client" => google_api_client }
+            client_config_file = Pathname.new(__dir__).join(
+              "config_service_v2_client_config.json"
+            )
+            defaults = client_config_file.open do |f|
+              Google::Gax.construct_settings(
+                "google.logging.v2.ConfigServiceV2",
+                JSON.parse(f.read),
+                client_config,
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                page_descriptors: PAGE_DESCRIPTORS,
+                errors: Google::Gax::Grpc::API_ERRORS,
+                kwargs: headers
+              )
+            end
+            @stub = Google::Gax::Grpc.create_stub(
+              service_path,
+              port,
+              chan_creds: chan_creds,
+              channel: channel,
+              scopes: scopes,
+              &Google::Logging::V2::ConfigServiceV2::Stub.method(:new)
+            )
+
+            @list_sinks = Google::Gax.create_api_call(
+              @stub.method(:list_sinks),
+              defaults["list_sinks"]
+            )
+            @get_sink = Google::Gax.create_api_call(
+              @stub.method(:get_sink),
+              defaults["get_sink"]
+            )
+            @create_sink = Google::Gax.create_api_call(
+              @stub.method(:create_sink),
+              defaults["create_sink"]
+            )
+            @update_sink = Google::Gax.create_api_call(
+              @stub.method(:update_sink),
+              defaults["update_sink"]
+            )
+            @delete_sink = Google::Gax.create_api_call(
+              @stub.method(:delete_sink),
+              defaults["delete_sink"]
+            )
+          end
+
+          # Service calls
+
+          # Lists sinks.
+          #
+          # @param parent [String]
+          #   Required. The resource name containing the sinks.
+          #   Example: +"projects/my-logging-project"+.
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::PagedEnumerable<Google::Logging::V2::LogSink>]
+          #   An enumerable of Google::Logging::V2::LogSink instances.
+          #   See Google::Gax::PagedEnumerable documentation for other
+          #   operations such as per-page iteration or access to the response
+          #   object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def list_sinks \
+              parent,
+              page_size: nil,
+              options: nil
+            req = Google::Logging::V2::ListSinksRequest.new(
+              parent: parent
+            )
+            req.page_size = page_size unless page_size.nil?
+            @list_sinks.call(req, options)
+          end
+
+          # Gets a sink.
+          #
+          # @param sink_name [String]
+          #   The resource name of the sink to return.
+          #   Example: +"projects/my-project-id/sinks/my-sink-id"+.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Logging::V2::LogSink]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def get_sink \
+              sink_name,
+              options: nil
+            req = Google::Logging::V2::GetSinkRequest.new(
+              sink_name: sink_name
+            )
+            @get_sink.call(req, options)
+          end
+
+          # Creates a sink.
+          #
+          # @param parent [String]
+          #   The resource in which to create the sink.
+          #   Example: +"projects/my-project-id"+.
+          #
+          #   The new sink must be provided in the request.
+          # @param sink [Google::Logging::V2::LogSink]
+          #   The new sink, which must not have an identifier that already
+          #   exists.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Logging::V2::LogSink]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def create_sink \
+              parent,
+              sink,
+              options: nil
+            req = Google::Logging::V2::CreateSinkRequest.new(
+              parent: parent,
+              sink: sink
+            )
+            @create_sink.call(req, options)
+          end
+
+          # Creates or updates a sink.
+          #
+          # @param sink_name [String]
+          #   The resource name of the sink to update.
+          #   Example: +"projects/my-project-id/sinks/my-sink-id"+.
+          #
+          #   The updated sink must be provided in the request and have the
+          #   same name that is specified in +sinkName+.  If the sink does not
+          #   exist, it is created.
+          # @param sink [Google::Logging::V2::LogSink]
+          #   The updated sink, whose name must be the same as the sink
+          #   identifier in +sinkName+.  If +sinkName+ does not exist, then
+          #   this method creates a new sink.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Logging::V2::LogSink]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def update_sink \
+              sink_name,
+              sink,
+              options: nil
+            req = Google::Logging::V2::UpdateSinkRequest.new(
+              sink_name: sink_name,
+              sink: sink
+            )
+            @update_sink.call(req, options)
+          end
+
+          # Deletes a sink.
+          #
+          # @param sink_name [String]
+          #   The resource name of the sink to delete.
+          #   Example: +"projects/my-project-id/sinks/my-sink-id"+.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def delete_sink \
+              sink_name,
+              options: nil
+            req = Google::Logging::V2::DeleteSinkRequest.new(
+              sink_name: sink_name
+            )
+            @delete_sink.call(req, options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client_config.json
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client_config.json
@@ -1,0 +1,53 @@
+{
+  "interfaces": {
+    "google.logging.v2.ConfigServiceV2": {
+      "retry_codes": {
+        "retry_codes_def": {
+          "idempotent": [
+            "DEADLINE_EXCEEDED",
+            "UNAVAILABLE"
+          ],
+          "non_idempotent": []
+        }
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.2,
+          "max_retry_delay_millis": 1000,
+          "initial_rpc_timeout_millis": 2000,
+          "rpc_timeout_multiplier": 1.5,
+          "max_rpc_timeout_millis": 30000,
+          "total_timeout_millis": 45000
+        }
+      },
+      "methods": {
+        "ListSinks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "GetSink": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateSink": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateSink": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteSink": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_api.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_api.rb
@@ -1,0 +1,351 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# EDITING INSTRUCTIONS
+# This file was generated from the file
+# https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging.proto,
+# and updates to that file get reflected here through a refresh process.
+# For the short term, the refresh process will only be runnable by Google
+# engineers.
+#
+# The only allowed edits are to method and file documentation. A 3-way
+# merge preserves those additions if the generated source changes.
+
+require "json"
+require "pathname"
+
+require "google/gax"
+require "google/logging/v2/logging_services_pb"
+
+module Google
+  module Cloud
+    module Logging
+      module V2
+        # Service for ingesting and querying logs.
+        #
+        # @!attribute [r] stub
+        #   @return [Google::Logging::V2::LoggingServiceV2::Stub]
+        class LoggingServiceV2Api
+          attr_reader :stub
+
+          # The default address of the service.
+          SERVICE_ADDRESS = "logging.googleapis.com".freeze
+
+          # The default port of the service.
+          DEFAULT_SERVICE_PORT = 443
+
+          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
+
+          DEFAULT_TIMEOUT = 30
+
+          PAGE_DESCRIPTORS = {
+            "list_log_entries" => Google::Gax::PageDescriptor.new(
+              "page_token",
+              "next_page_token",
+              "entries"),
+            "list_monitored_resource_descriptors" => Google::Gax::PageDescriptor.new(
+              "page_token",
+              "next_page_token",
+              "resource_descriptors")
+          }.freeze
+
+          private_constant :PAGE_DESCRIPTORS
+
+          # The scopes needed to make gRPC calls to all of the methods defined in
+          # this service.
+          ALL_SCOPES = [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only",
+            "https://www.googleapis.com/auth/logging.admin",
+            "https://www.googleapis.com/auth/logging.read",
+            "https://www.googleapis.com/auth/logging.write"
+          ].freeze
+
+          PARENT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}"
+          )
+
+          private_constant :PARENT_PATH_TEMPLATE
+
+          LOG_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}/logs/{log}"
+          )
+
+          private_constant :LOG_PATH_TEMPLATE
+
+          # Returns a fully-qualified parent resource name string.
+          # @param project [String]
+          # @return [String]
+          def self.parent_path project
+            PARENT_PATH_TEMPLATE.render(
+              :"project" => project
+            )
+          end
+
+          # Returns a fully-qualified log resource name string.
+          # @param project [String]
+          # @param log [String]
+          # @return [String]
+          def self.log_path project, log
+            LOG_PATH_TEMPLATE.render(
+              :"project" => project,
+              :"log" => log
+            )
+          end
+
+          # Parses the project from a parent resource.
+          # @param parent_name [String]
+          # @return [String]
+          def self.match_project_from_parent_name parent_name
+            PARENT_PATH_TEMPLATE.match(parent_name)["project"]
+          end
+
+          # Parses the project from a log resource.
+          # @param log_name [String]
+          # @return [String]
+          def self.match_project_from_log_name log_name
+            LOG_PATH_TEMPLATE.match(log_name)["project"]
+          end
+
+          # Parses the log from a log resource.
+          # @param log_name [String]
+          # @return [String]
+          def self.match_log_from_log_name log_name
+            LOG_PATH_TEMPLATE.match(log_name)["log"]
+          end
+
+          # @param service_path [String]
+          #   The domain name of the API remote host.
+          # @param port [Integer]
+          #   The port on which to connect to the remote host.
+          # @param channel [Channel]
+          #   A Channel object through which to make calls.
+          # @param chan_creds [Grpc::ChannelCredentials]
+          #   A ChannelCredentials for the setting up the RPC client.
+          # @param client_config[Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          # @param app_name [String]
+          #   The codename of the calling service.
+          # @param app_version [String]
+          #   The version of the calling service.
+          def initialize \
+              service_path: SERVICE_ADDRESS,
+              port: DEFAULT_SERVICE_PORT,
+              channel: nil,
+              chan_creds: nil,
+              scopes: ALL_SCOPES,
+              client_config: {},
+              timeout: DEFAULT_TIMEOUT,
+              app_name: "gax",
+              app_version: Google::Gax::VERSION
+            google_api_client = "#{app_name}/#{app_version} " \
+              "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
+            headers = { :"x-goog-api-client" => google_api_client }
+            client_config_file = Pathname.new(__dir__).join(
+              "logging_service_v2_client_config.json"
+            )
+            defaults = client_config_file.open do |f|
+              Google::Gax.construct_settings(
+                "google.logging.v2.LoggingServiceV2",
+                JSON.parse(f.read),
+                client_config,
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                page_descriptors: PAGE_DESCRIPTORS,
+                errors: Google::Gax::Grpc::API_ERRORS,
+                kwargs: headers
+              )
+            end
+            @stub = Google::Gax::Grpc.create_stub(
+              service_path,
+              port,
+              chan_creds: chan_creds,
+              channel: channel,
+              scopes: scopes,
+              &Google::Logging::V2::LoggingServiceV2::Stub.method(:new)
+            )
+
+            @delete_log = Google::Gax.create_api_call(
+              @stub.method(:delete_log),
+              defaults["delete_log"]
+            )
+            @write_log_entries = Google::Gax.create_api_call(
+              @stub.method(:write_log_entries),
+              defaults["write_log_entries"]
+            )
+            @list_log_entries = Google::Gax.create_api_call(
+              @stub.method(:list_log_entries),
+              defaults["list_log_entries"]
+            )
+            @list_monitored_resource_descriptors = Google::Gax.create_api_call(
+              @stub.method(:list_monitored_resource_descriptors),
+              defaults["list_monitored_resource_descriptors"]
+            )
+          end
+
+          # Service calls
+
+          # Deletes a log and all its log entries.
+          # The log will reappear if it receives new entries.
+          #
+          # @param log_name [String]
+          #   Required. The resource name of the log to delete.  Example:
+          #   +"projects/my-project/logs/syslog"+.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def delete_log \
+              log_name,
+              options: nil
+            req = Google::Logging::V2::DeleteLogRequest.new(
+              log_name: log_name
+            )
+            @delete_log.call(req, options)
+          end
+
+          # Writes log entries to Stackdriver Logging.  All log entries are
+          # written by this method.
+          #
+          # @param log_name [String]
+          #   Optional. A default log resource name for those log entries in +entries+
+          #   that do not specify their own +logName+.  Example:
+          #   +"projects/my-project/logs/syslog"+.  See
+          #   LogEntry.
+          # @param resource [Google::Api::MonitoredResource]
+          #   Optional. A default monitored resource for those log entries in +entries+
+          #   that do not specify their own +resource+.
+          # @param labels [Hash{String => String}]
+          #   Optional. User-defined +key:value+ items that are added to
+          #   the +labels+ field of each log entry in +entries+, except when a log
+          #   entry specifies its own +key:value+ item with the same key.
+          #   Example: +{ "size": "large", "color":"red" }+
+          # @param entries [Array<Google::Logging::V2::LogEntry>]
+          #   Required. The log entries to write. The log entries must have values for
+          #   all required fields.
+          #
+          #   To improve throughput and to avoid exceeding the quota limit for calls
+          #   to +entries.write+, use this field to write multiple log entries at once
+          #   rather than  // calling this method for each log entry.
+          # @param partial_success [true, false]
+          #   Optional. Whether valid entries should be written even if some other
+          #   entries fail due to INVALID_ARGUMENT or PERMISSION_DENIED errors. If any
+          #   entry is not written, the response status will be the error associated
+          #   with one of the failed entries and include error details in the form of
+          #   WriteLogEntriesPartialErrors.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Logging::V2::WriteLogEntriesResponse]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def write_log_entries \
+              entries,
+              log_name: nil,
+              resource: nil,
+              labels: nil,
+              partial_success: nil,
+              options: nil
+            req = Google::Logging::V2::WriteLogEntriesRequest.new(
+              entries: entries
+            )
+            req.log_name = log_name unless log_name.nil?
+            req.resource = resource unless resource.nil?
+            req.labels = labels unless labels.nil?
+            req.partial_success = partial_success unless partial_success.nil?
+            @write_log_entries.call(req, options)
+          end
+
+          # Lists log entries.  Use this method to retrieve log entries from Cloud
+          # Logging.  For ways to export log entries, see
+          # {Exporting Logs}[https://cloud.google.com/logging/docs/export].
+          #
+          # @param project_ids [Array<String>]
+          #   Required. One or more project IDs or project numbers from which to retrieve
+          #   log entries.  Examples of a project ID: +"my-project-1A"+, +"1234567890"+.
+          # @param filter [String]
+          #   Optional. An {advanced logs filter}[https://cloud.google.com/logging/docs/view/advanced_filters].
+          #   The filter is compared against all log entries in the projects specified by
+          #   +projectIds+.  Only entries that match the filter are retrieved.  An empty
+          #   filter matches all log entries.
+          # @param order_by [String]
+          #   Optional. How the results should be sorted.  Presently, the only permitted
+          #   values are +"timestamp asc"+ (default) and +"timestamp desc"+. The first
+          #   option returns entries in order of increasing values of
+          #   +LogEntry.timestamp+ (oldest first), and the second option returns entries
+          #   in order of decreasing timestamps (newest first).  Entries with equal
+          #   timestamps are returned in order of +LogEntry.insertId+.
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::PagedEnumerable<Google::Logging::V2::LogEntry>]
+          #   An enumerable of Google::Logging::V2::LogEntry instances.
+          #   See Google::Gax::PagedEnumerable documentation for other
+          #   operations such as per-page iteration or access to the response
+          #   object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def list_log_entries \
+              project_ids,
+              filter: nil,
+              order_by: nil,
+              page_size: nil,
+              options: nil
+            req = Google::Logging::V2::ListLogEntriesRequest.new(
+              project_ids: project_ids
+            )
+            req.filter = filter unless filter.nil?
+            req.order_by = order_by unless order_by.nil?
+            req.page_size = page_size unless page_size.nil?
+            @list_log_entries.call(req, options)
+          end
+
+          # Lists the monitored resource descriptors used by Stackdriver Logging.
+          #
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::PagedEnumerable<Google::Api::MonitoredResourceDescriptor>]
+          #   An enumerable of Google::Api::MonitoredResourceDescriptor instances.
+          #   See Google::Gax::PagedEnumerable documentation for other
+          #   operations such as per-page iteration or access to the response
+          #   object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def list_monitored_resource_descriptors \
+              page_size: nil,
+              options: nil
+            req = Google::Logging::V2::ListMonitoredResourceDescriptorsRequest.new
+            req.page_size = page_size unless page_size.nil?
+            @list_monitored_resource_descriptors.call(req, options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client_config.json
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client_config.json
@@ -1,0 +1,57 @@
+{
+  "interfaces": {
+    "google.logging.v2.LoggingServiceV2": {
+      "retry_codes": {
+        "retry_codes_def": {
+          "idempotent": [
+            "DEADLINE_EXCEEDED",
+            "UNAVAILABLE"
+          ],
+          "non_idempotent": []
+        }
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.2,
+          "max_retry_delay_millis": 1000,
+          "initial_rpc_timeout_millis": 2000,
+          "rpc_timeout_multiplier": 1.5,
+          "max_rpc_timeout_millis": 30000,
+          "total_timeout_millis": 45000
+        },
+        "list": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.2,
+          "max_retry_delay_millis": 1000,
+          "initial_rpc_timeout_millis": 7000,
+          "rpc_timeout_multiplier": 1.5,
+          "max_rpc_timeout_millis": 30000,
+          "total_timeout_millis": 45000
+        }
+      },
+      "methods": {
+        "DeleteLog": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "WriteLogEntries": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "ListLogEntries": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "list"
+        },
+        "ListMonitoredResourceDescriptors": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_api.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_api.rb
@@ -1,0 +1,330 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# EDITING INSTRUCTIONS
+# This file was generated from the file
+# https://github.com/googleapis/googleapis/blob/master/google/logging/v2/logging_metrics.proto,
+# and updates to that file get reflected here through a refresh process.
+# For the short term, the refresh process will only be runnable by Google
+# engineers.
+#
+# The only allowed edits are to method and file documentation. A 3-way
+# merge preserves those additions if the generated source changes.
+
+require "json"
+require "pathname"
+
+require "google/gax"
+require "google/logging/v2/logging_metrics_services_pb"
+
+module Google
+  module Cloud
+    module Logging
+      module V2
+        # Service for configuring logs-based metrics.
+        #
+        # @!attribute [r] stub
+        #   @return [Google::Logging::V2::MetricsServiceV2::Stub]
+        class MetricsServiceV2Api
+          attr_reader :stub
+
+          # The default address of the service.
+          SERVICE_ADDRESS = "logging.googleapis.com".freeze
+
+          # The default port of the service.
+          DEFAULT_SERVICE_PORT = 443
+
+          CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
+
+          DEFAULT_TIMEOUT = 30
+
+          PAGE_DESCRIPTORS = {
+            "list_log_metrics" => Google::Gax::PageDescriptor.new(
+              "page_token",
+              "next_page_token",
+              "metrics")
+          }.freeze
+
+          private_constant :PAGE_DESCRIPTORS
+
+          # The scopes needed to make gRPC calls to all of the methods defined in
+          # this service.
+          ALL_SCOPES = [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only",
+            "https://www.googleapis.com/auth/logging.admin",
+            "https://www.googleapis.com/auth/logging.read",
+            "https://www.googleapis.com/auth/logging.write"
+          ].freeze
+
+          PARENT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}"
+          )
+
+          private_constant :PARENT_PATH_TEMPLATE
+
+          METRIC_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+            "projects/{project}/metrics/{metric}"
+          )
+
+          private_constant :METRIC_PATH_TEMPLATE
+
+          # Returns a fully-qualified parent resource name string.
+          # @param project [String]
+          # @return [String]
+          def self.parent_path project
+            PARENT_PATH_TEMPLATE.render(
+              :"project" => project
+            )
+          end
+
+          # Returns a fully-qualified metric resource name string.
+          # @param project [String]
+          # @param metric [String]
+          # @return [String]
+          def self.metric_path project, metric
+            METRIC_PATH_TEMPLATE.render(
+              :"project" => project,
+              :"metric" => metric
+            )
+          end
+
+          # Parses the project from a parent resource.
+          # @param parent_name [String]
+          # @return [String]
+          def self.match_project_from_parent_name parent_name
+            PARENT_PATH_TEMPLATE.match(parent_name)["project"]
+          end
+
+          # Parses the project from a metric resource.
+          # @param metric_name [String]
+          # @return [String]
+          def self.match_project_from_metric_name metric_name
+            METRIC_PATH_TEMPLATE.match(metric_name)["project"]
+          end
+
+          # Parses the metric from a metric resource.
+          # @param metric_name [String]
+          # @return [String]
+          def self.match_metric_from_metric_name metric_name
+            METRIC_PATH_TEMPLATE.match(metric_name)["metric"]
+          end
+
+          # @param service_path [String]
+          #   The domain name of the API remote host.
+          # @param port [Integer]
+          #   The port on which to connect to the remote host.
+          # @param channel [Channel]
+          #   A Channel object through which to make calls.
+          # @param chan_creds [Grpc::ChannelCredentials]
+          #   A ChannelCredentials for the setting up the RPC client.
+          # @param client_config[Hash]
+          #   A Hash for call options for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
+          # @param timeout [Numeric]
+          #   The default timeout, in seconds, for calls made through this client.
+          # @param app_name [String]
+          #   The codename of the calling service.
+          # @param app_version [String]
+          #   The version of the calling service.
+          def initialize \
+              service_path: SERVICE_ADDRESS,
+              port: DEFAULT_SERVICE_PORT,
+              channel: nil,
+              chan_creds: nil,
+              scopes: ALL_SCOPES,
+              client_config: {},
+              timeout: DEFAULT_TIMEOUT,
+              app_name: "gax",
+              app_version: Google::Gax::VERSION
+            google_api_client = "#{app_name}/#{app_version} " \
+              "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
+            headers = { :"x-goog-api-client" => google_api_client }
+            client_config_file = Pathname.new(__dir__).join(
+              "metrics_service_v2_client_config.json"
+            )
+            defaults = client_config_file.open do |f|
+              Google::Gax.construct_settings(
+                "google.logging.v2.MetricsServiceV2",
+                JSON.parse(f.read),
+                client_config,
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                page_descriptors: PAGE_DESCRIPTORS,
+                errors: Google::Gax::Grpc::API_ERRORS,
+                kwargs: headers
+              )
+            end
+            @stub = Google::Gax::Grpc.create_stub(
+              service_path,
+              port,
+              chan_creds: chan_creds,
+              channel: channel,
+              scopes: scopes,
+              &Google::Logging::V2::MetricsServiceV2::Stub.method(:new)
+            )
+
+            @list_log_metrics = Google::Gax.create_api_call(
+              @stub.method(:list_log_metrics),
+              defaults["list_log_metrics"]
+            )
+            @get_log_metric = Google::Gax.create_api_call(
+              @stub.method(:get_log_metric),
+              defaults["get_log_metric"]
+            )
+            @create_log_metric = Google::Gax.create_api_call(
+              @stub.method(:create_log_metric),
+              defaults["create_log_metric"]
+            )
+            @update_log_metric = Google::Gax.create_api_call(
+              @stub.method(:update_log_metric),
+              defaults["update_log_metric"]
+            )
+            @delete_log_metric = Google::Gax.create_api_call(
+              @stub.method(:delete_log_metric),
+              defaults["delete_log_metric"]
+            )
+          end
+
+          # Service calls
+
+          # Lists logs-based metrics.
+          #
+          # @param parent [String]
+          #   Required. The resource name containing the metrics.
+          #   Example: +"projects/my-project-id"+.
+          # @param page_size [Integer]
+          #   The maximum number of resources contained in the underlying API
+          #   response. If page streaming is performed per-resource, this
+          #   parameter does not affect the return value. If page streaming is
+          #   performed per-page, this determines the maximum number of
+          #   resources in a page.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Gax::PagedEnumerable<Google::Logging::V2::LogMetric>]
+          #   An enumerable of Google::Logging::V2::LogMetric instances.
+          #   See Google::Gax::PagedEnumerable documentation for other
+          #   operations such as per-page iteration or access to the response
+          #   object.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def list_log_metrics \
+              parent,
+              page_size: nil,
+              options: nil
+            req = Google::Logging::V2::ListLogMetricsRequest.new(
+              parent: parent
+            )
+            req.page_size = page_size unless page_size.nil?
+            @list_log_metrics.call(req, options)
+          end
+
+          # Gets a logs-based metric.
+          #
+          # @param metric_name [String]
+          #   The resource name of the desired metric.
+          #   Example: +"projects/my-project-id/metrics/my-metric-id"+.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Logging::V2::LogMetric]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def get_log_metric \
+              metric_name,
+              options: nil
+            req = Google::Logging::V2::GetLogMetricRequest.new(
+              metric_name: metric_name
+            )
+            @get_log_metric.call(req, options)
+          end
+
+          # Creates a logs-based metric.
+          #
+          # @param parent [String]
+          #   The resource name of the project in which to create the metric.
+          #   Example: +"projects/my-project-id"+.
+          #
+          #   The new metric must be provided in the request.
+          # @param metric [Google::Logging::V2::LogMetric]
+          #   The new logs-based metric, which must not have an identifier that
+          #   already exists.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Logging::V2::LogMetric]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def create_log_metric \
+              parent,
+              metric,
+              options: nil
+            req = Google::Logging::V2::CreateLogMetricRequest.new(
+              parent: parent,
+              metric: metric
+            )
+            @create_log_metric.call(req, options)
+          end
+
+          # Creates or updates a logs-based metric.
+          #
+          # @param metric_name [String]
+          #   The resource name of the metric to update.
+          #   Example: +"projects/my-project-id/metrics/my-metric-id"+.
+          #
+          #   The updated metric must be provided in the request and have the
+          #   same identifier that is specified in +metricName+.
+          #   If the metric does not exist, it is created.
+          # @param metric [Google::Logging::V2::LogMetric]
+          #   The updated metric, whose name must be the same as the
+          #   metric identifier in +metricName+. If +metricName+ does not
+          #   exist, then a new metric is created.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [Google::Logging::V2::LogMetric]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def update_log_metric \
+              metric_name,
+              metric,
+              options: nil
+            req = Google::Logging::V2::UpdateLogMetricRequest.new(
+              metric_name: metric_name,
+              metric: metric
+            )
+            @update_log_metric.call(req, options)
+          end
+
+          # Deletes a logs-based metric.
+          #
+          # @param metric_name [String]
+          #   The resource name of the metric to delete.
+          #   Example: +"projects/my-project-id/metrics/my-metric-id"+.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def delete_log_metric \
+              metric_name,
+              options: nil
+            req = Google::Logging::V2::DeleteLogMetricRequest.new(
+              metric_name: metric_name
+            )
+            @delete_log_metric.call(req, options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client_config.json
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client_config.json
@@ -1,0 +1,53 @@
+{
+  "interfaces": {
+    "google.logging.v2.MetricsServiceV2": {
+      "retry_codes": {
+        "retry_codes_def": {
+          "idempotent": [
+            "DEADLINE_EXCEEDED",
+            "UNAVAILABLE"
+          ],
+          "non_idempotent": []
+        }
+      },
+      "retry_params": {
+        "default": {
+          "initial_retry_delay_millis": 100,
+          "retry_delay_multiplier": 1.2,
+          "max_retry_delay_millis": 1000,
+          "initial_rpc_timeout_millis": 2000,
+          "rpc_timeout_multiplier": 1.5,
+          "max_rpc_timeout_millis": 30000,
+          "total_timeout_millis": 45000
+        }
+      },
+      "methods": {
+        "ListLogMetrics": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "GetLogMetric": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "CreateLogMetric": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "UpdateLogMetric": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "DeleteLogMetric": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- v2.rb is hand-written. This should be auto-generated, but
  not yet.
- manually modified .rubocop.yml, .yardopts, and gemspec.